### PR TITLE
feat(agentless): add agentless build to agent build workflow

### DIFF
--- a/.github/workflows/build_agent_container.yaml
+++ b/.github/workflows/build_agent_container.yaml
@@ -33,7 +33,7 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
+      # Uses the `docker/login-action` action to log in to the Container registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
       - name: Log in to the Container registry
         uses: docker/login-action@v3
         with:
@@ -83,7 +83,7 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
+      # Uses the `docker/login-action` action to log in to the Container registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
       - name: Log in to the Container registry
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/build_agent_container.yaml
+++ b/.github/workflows/build_agent_container.yaml
@@ -5,7 +5,6 @@ on:
   push:
     branches: 
       - main
-      - docker_ci
     paths:
       - agent/**
       - .github/workflows/build_agent_container.yaml
@@ -18,10 +17,11 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
+  DOCKER_CMD: docker
 
 # There is a single job in this workflow. It's configured to run on the latest available version of Ubuntu.
 jobs:
-  build-and-push-image:
+  build-and-push-agent:
     runs-on: ubuntu-latest
     # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
     permissions:
@@ -72,3 +72,52 @@ jobs:
           subject-digest: ${{ steps.build.outputs.digest }}
           push-to-registry: true
       
+  build-and-publish-agentless:
+    runs-on: ubuntu-latest
+    # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      
+      # Setup for multi-platform
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build the agent container image
+        id: build
+        run: |
+          source ./containers/agentless/versions.sh
+          cd agent
+          export TAGS=()
+          for version in $TEST_VERSIONS; do
+            TAGS+="-t ${{ env.REGISTRY }}/${{env.IMAGE_NAME}}/agentless:$version "
+          done
+
+          docker buildx build --push --platform linux/amd64,linux/arm64 $TAGS --metadata-file=metadata.json -f ../containers/agentless/Dockerfile ../containers/agentless
+
+          cat metadata.json
+          echo "digest=$(cat metadata.json | jq -r .\"containerimage.digest\")" >> $GITHUB_OUTPUT
+          cat $GITHUB_OUTPUT
+      
+      # This step generates an artifact attestation for the image, which is an unforgeable statement about where and how it was built. It increases supply chain security for people who consume the image. For more information, see [AUTOTITLE](/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds). 
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{env.IMAGE_NAME}}/agentless
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -17,12 +17,12 @@
                 "LOG_LEVEL": "info",
                 "REAPPLY_ON_REBOOT": "false",
                 // "AGENT_IMAGE": "nvcr.io/nvidian/swgpu-baseos/skyhook-agent:25.01.02-233800-38d9732d", 
-                "AGENT_IMAGE": "nvcr.io/nvidian/swgpu-baseos/agentless-test:6.2.0", // this is the mock image, if you need to test for real, use the real image.
+                "AGENT_IMAGE": "ghcr.io/nvidia/skyhook/agentless:6.2.0", // this is the mock image, if you need to test for real, use the real image.
                 // "COPY_DIR_ROOT": "/var/lib/google/skyhook"
             },
             "args": [],
             "showLog": true
-        },   
+        },
         {
             "name": "Test Current File",
             "type": "go",
@@ -32,6 +32,6 @@
             "env": {},
             "args": [],
             "showLog": true
-        }   
+        }
     ]
 }

--- a/k8s-tests/chainsaw/skyhook/config-skyhook/assert-update-no-interrupt.yaml
+++ b/k8s-tests/chainsaw/skyhook/config-skyhook/assert-update-no-interrupt.yaml
@@ -11,21 +11,21 @@ metadata:
         "baxter|3.2.1": {
             "name": "baxter",
             "version": "3.2.1",
-            "image": "nvcr.io/nvidian/swgpu-baseos/agentless-test",
+            "image": "ghcr.io/nvidia/skyhook/agentless",
             "stage": "config",
             "state": "complete"
         },
         "dexter|1.2.3": {
             "name": "dexter",
             "version": "1.2.3",
-            "image": "nvcr.io/nvidian/swgpu-baseos/agentless-test",
+            "image": "ghcr.io/nvidia/skyhook/agentless",
             "stage": "config",
             "state": "complete"
         },
         "spencer|3.2.3": {
             "name": "spencer",
             "version": "3.2.3",
-            "image": "nvcr.io/nvidian/swgpu-baseos/agentless-test",
+            "image": "ghcr.io/nvidia/skyhook/agentless",
             "stage": "post-interrupt",
             "state": "complete"
         }
@@ -53,19 +53,19 @@ status:
           state: complete
           version: '1.2.3'
           stage: config
-          image: nvcr.io/nvidian/swgpu-baseos/agentless-test
+          image: ghcr.io/nvidia/skyhook/agentless
         baxter|3.2.1:
           name: baxter
           state: complete
           version: '3.2.1'
           stage: config
-          image: nvcr.io/nvidian/swgpu-baseos/agentless-test
+          image: ghcr.io/nvidia/skyhook/agentless
         spencer|3.2.3:
           name: spencer
           state: complete
           version: '3.2.3'
           stage: post-interrupt
-          image: nvcr.io/nvidian/swgpu-baseos/agentless-test
+          image: ghcr.io/nvidia/skyhook/agentless
   nodeStatus:
    # grab values should be one and is complete
     (values(@)):

--- a/k8s-tests/chainsaw/skyhook/config-skyhook/assert-update-while-running.yaml
+++ b/k8s-tests/chainsaw/skyhook/config-skyhook/assert-update-while-running.yaml
@@ -11,21 +11,21 @@ metadata:
         "baxter|3.2.1": {
             "name": "baxter",
             "version": "3.2.1",
-            "image": "nvcr.io/nvidian/swgpu-baseos/agentless-test",
+            "image": "ghcr.io/nvidia/skyhook/agentless",
             "stage": "post-interrupt",
             "state": "complete"
         },
         "dexter|1.2.3": {
             "name": "dexter",
             "version": "1.2.3",
-            "image": "nvcr.io/nvidian/swgpu-baseos/agentless-test",
+            "image": "ghcr.io/nvidia/skyhook/agentless",
             "stage": "post-interrupt",
             "state": "complete"
         },
         "spencer|3.2.3": {
             "name": "spencer",
             "version": "3.2.3",
-            "image": "nvcr.io/nvidian/swgpu-baseos/agentless-test",
+            "image": "ghcr.io/nvidia/skyhook/agentless",
             "stage": "post-interrupt",
             "state": "complete"
         }
@@ -53,19 +53,19 @@ status:
           state: complete
           version: '1.2.3'
           stage: post-interrupt
-          image: nvcr.io/nvidian/swgpu-baseos/agentless-test
+          image: ghcr.io/nvidia/skyhook/agentless
         baxter|3.2.1:
           name: baxter
           state: complete
           version: '3.2.1'
           stage: post-interrupt
-          image: nvcr.io/nvidian/swgpu-baseos/agentless-test
+          image: ghcr.io/nvidia/skyhook/agentless
         spencer|3.2.3:
           name: spencer
           state: complete
           version: '3.2.3'
           stage: post-interrupt
-          image: nvcr.io/nvidian/swgpu-baseos/agentless-test
+          image: ghcr.io/nvidia/skyhook/agentless
   nodeStatus:
    # grab values should be one and is complete
     (values(@)):

--- a/k8s-tests/chainsaw/skyhook/config-skyhook/assert-update.yaml
+++ b/k8s-tests/chainsaw/skyhook/config-skyhook/assert-update.yaml
@@ -11,21 +11,21 @@ metadata:
         "baxter|3.2.1": {
             "name": "baxter",
             "version": "3.2.1",
-            "image": "nvcr.io/nvidian/swgpu-baseos/agentless-test",
+            "image": "ghcr.io/nvidia/skyhook/agentless",
             "stage": "post-interrupt",
             "state": "complete"
         },
         "dexter|1.2.3": {
             "name": "dexter",
             "version": "1.2.3",
-            "image": "nvcr.io/nvidian/swgpu-baseos/agentless-test",
+            "image": "ghcr.io/nvidia/skyhook/agentless",
             "stage": "post-interrupt",
             "state": "complete"
         },
         "spencer|3.2.3": {
             "name": "spencer",
             "version": "3.2.3",
-            "image": "nvcr.io/nvidian/swgpu-baseos/agentless-test",
+            "image": "ghcr.io/nvidia/skyhook/agentless",
             "stage": "post-interrupt",
             "state": "complete"
         }
@@ -53,19 +53,19 @@ status:
           state: complete
           version: '1.2.3'
           stage: post-interrupt
-          image: nvcr.io/nvidian/swgpu-baseos/agentless-test
+          image: ghcr.io/nvidia/skyhook/agentless
         baxter|3.2.1:
           name: baxter
           state: complete
           version: '3.2.1'
           stage: post-interrupt
-          image: nvcr.io/nvidian/swgpu-baseos/agentless-test
+          image: ghcr.io/nvidia/skyhook/agentless
         spencer|3.2.3:
           name: spencer
           state: complete
           version: '3.2.3'
           stage: post-interrupt
-          image: nvcr.io/nvidian/swgpu-baseos/agentless-test
+          image: ghcr.io/nvidia/skyhook/agentless
   nodeStatus:
    # grab values should be one and is complete
     (values(@)):

--- a/k8s-tests/chainsaw/skyhook/config-skyhook/assert.yaml
+++ b/k8s-tests/chainsaw/skyhook/config-skyhook/assert.yaml
@@ -10,21 +10,21 @@ metadata:
         "baxter|3.2.1": {
             "name": "baxter",
             "version": "3.2.1",
-            "image": "nvcr.io/nvidian/swgpu-baseos/agentless-test",
+            "image": "ghcr.io/nvidia/skyhook/agentless",
             "stage": "apply",
             "state": "in_progress"
         },
         "dexter|1.2.3": {
             "name": "dexter",
             "version": "1.2.3",
-            "image": "nvcr.io/nvidian/swgpu-baseos/agentless-test",
+            "image": "ghcr.io/nvidia/skyhook/agentless",
             "stage": "apply",
             "state": "in_progress"
         },
         "spencer|3.2.3": {
             "name": "spencer",
             "version": "3.2.3",
-            "image": "nvcr.io/nvidian/swgpu-baseos/agentless-test",
+            "image": "ghcr.io/nvidia/skyhook/agentless",
             "stage": "apply",
             "state": "in_progress"
         }
@@ -51,19 +51,19 @@ status:
           state: in_progress
           version: '1.2.3'
           stage: apply
-          image: nvcr.io/nvidian/swgpu-baseos/agentless-test
+          image: ghcr.io/nvidia/skyhook/agentless
         baxter|3.2.1:
           name: baxter
           state: in_progress
           version: '3.2.1'
           stage: apply
-          image: nvcr.io/nvidian/swgpu-baseos/agentless-test
+          image: ghcr.io/nvidia/skyhook/agentless
         spencer|3.2.3:
           name: spencer
           state: in_progress
           version: '3.2.3'
           stage: apply
-          image: nvcr.io/nvidian/swgpu-baseos/agentless-test
+          image: ghcr.io/nvidia/skyhook/agentless
   nodeStatus:
    # grab values should be one and is complete
     (values(@)):

--- a/k8s-tests/chainsaw/skyhook/config-skyhook/skyhook.yaml
+++ b/k8s-tests/chainsaw/skyhook/config-skyhook/skyhook.yaml
@@ -14,13 +14,13 @@ spec:
   packages:
     spencer:
       version: "3.2.3"
-      image: nvcr.io/nvidian/swgpu-baseos/agentless-test
+      image: ghcr.io/nvidia/skyhook/agentless
       interrupt: 
         type: service
         services: [cron]
     dexter:
       version: "1.2.3"
-      image: nvcr.io/nvidian/swgpu-baseos/agentless-test
+      image: ghcr.io/nvidia/skyhook/agentless
       interrupt:
         type: reboot
       configInterrupts:
@@ -40,7 +40,7 @@ spec:
           how.nice.to.look=fairlyNice
     baxter:
       version: "3.2.1"
-      image: nvcr.io/nvidian/swgpu-baseos/agentless-test
+      image: ghcr.io/nvidia/skyhook/agentless
       configInterrupts:
         game.properties:
           type: service

--- a/k8s-tests/chainsaw/skyhook/config-skyhook/update-no-interrupt.yaml
+++ b/k8s-tests/chainsaw/skyhook/config-skyhook/update-no-interrupt.yaml
@@ -14,13 +14,13 @@ spec:
   packages:
     spencer:
       version: "3.2.3"
-      image: nvcr.io/nvidian/swgpu-baseos/agentless-test
+      image: ghcr.io/nvidia/skyhook/agentless
       interrupt: 
         type: service
         services: [cron]
     dexter:
       version: "1.2.3"
-      image: nvcr.io/nvidian/swgpu-baseos/agentless-test
+      image: ghcr.io/nvidia/skyhook/agentless
       interrupt:
         type: reboot
       configInterrupts:
@@ -34,7 +34,7 @@ spec:
           changed
     baxter:
       version: "3.2.1"
-      image: nvcr.io/nvidian/swgpu-baseos/agentless-test
+      image: ghcr.io/nvidia/skyhook/agentless
       configInterrupts:
         game.properties:
           type: service

--- a/k8s-tests/chainsaw/skyhook/config-skyhook/update-while-running.yaml
+++ b/k8s-tests/chainsaw/skyhook/config-skyhook/update-while-running.yaml
@@ -14,13 +14,13 @@ spec:
   packages:
     spencer:
       version: "3.2.3"
-      image: nvcr.io/nvidian/swgpu-baseos/agentless-test
+      image: ghcr.io/nvidia/skyhook/agentless
       interrupt: 
         type: service
         services: [cron]
     dexter:
       version: "1.2.3"
-      image: nvcr.io/nvidian/swgpu-baseos/agentless-test
+      image: ghcr.io/nvidia/skyhook/agentless
       interrupt:
         type: reboot
       configInterrupts:
@@ -40,7 +40,7 @@ spec:
           how.nice.to.look=fairlyNice
     baxter:
       version: "3.2.1"
-      image: nvcr.io/nvidian/swgpu-baseos/agentless-test
+      image: ghcr.io/nvidia/skyhook/agentless
       configInterrupts:
         game.properties:
           type: service

--- a/k8s-tests/chainsaw/skyhook/config-skyhook/update.yaml
+++ b/k8s-tests/chainsaw/skyhook/config-skyhook/update.yaml
@@ -14,13 +14,13 @@ spec:
   packages:
     spencer:
       version: "3.2.3"
-      image: nvcr.io/nvidian/swgpu-baseos/agentless-test
+      image: ghcr.io/nvidia/skyhook/agentless
       interrupt: 
         type: service
         services: [cron]
     dexter:
       version: "1.2.3"
-      image: nvcr.io/nvidian/swgpu-baseos/agentless-test
+      image: ghcr.io/nvidia/skyhook/agentless
       interrupt:
         type: reboot
       configInterrupts:
@@ -37,7 +37,7 @@ spec:
           how.nice.to.look=fairlyNice
     baxter:
       version: "3.2.1"
-      image: nvcr.io/nvidian/swgpu-baseos/agentless-test
+      image: ghcr.io/nvidia/skyhook/agentless
       configInterrupts:
         game.properties:
           type: service

--- a/k8s-tests/chainsaw/skyhook/failure-skyhook/node-assert.yaml
+++ b/k8s-tests/chainsaw/skyhook/failure-skyhook/node-assert.yaml
@@ -10,14 +10,14 @@ metadata:
         "dexter|1.2.3": {
             "name": "dexter",
             "version": "1.2.3",
-            "image": "nvcr.io/nvidian/swgpu-baseos/agentless-test",
+            "image": "ghcr.io/nvidia/skyhook/agentless",
             "stage": "config",
             "state": "complete"
         },
         "failure|1.2.3": {
             "name": "failure",
             "version": "1.2.3",
-            "image": "nvcr.io/nvidian/swgpu-baseos/agentless-test",
+            "image": "ghcr.io/nvidia/skyhook/agentless",
             "stage": "apply",
             "state": "erroring",
             (!restarts || restarts == `1`): true

--- a/k8s-tests/chainsaw/skyhook/failure-skyhook/skyhook.yaml
+++ b/k8s-tests/chainsaw/skyhook/failure-skyhook/skyhook.yaml
@@ -14,7 +14,7 @@ spec:
   packages:
     failure:
       version: "1.2.3"
-      image: nvcr.io/nvidian/swgpu-baseos/agentless-test
+      image: ghcr.io/nvidia/skyhook/agentless
       env: 
         - name: EXIT_CODE
           value: "2"
@@ -22,7 +22,7 @@ spec:
         dexter: "1.2.3"
     dexter:
       version: "1.2.3"
-      image: nvcr.io/nvidian/swgpu-baseos/agentless-test
+      image: ghcr.io/nvidia/skyhook/agentless
       env: 
         - name: SLEEP_LEN
           value: "1" ## making faster

--- a/k8s-tests/chainsaw/skyhook/interrupt-grouping/assert.yaml
+++ b/k8s-tests/chainsaw/skyhook/interrupt-grouping/assert.yaml
@@ -8,7 +8,7 @@ metadata:
     skyhook.nvidia.com/package: dax-1.2.3
   annotations:
     skyhook.nvidia.com/package: >-
-      {"name":"dax","version":"1.2.3","skyhook":"interrupt-grouping","stage":"apply","image":"nvcr.io/nvidian/swgpu-baseos/agentless-test"}
+      {"name":"dax","version":"1.2.3","skyhook":"interrupt-grouping","stage":"apply","image":"ghcr.io/nvidia/skyhook/agentless"}
   ownerReferences:
     - apiVersion: skyhook.nvidia.com/v1alpha1
       kind: Skyhook
@@ -16,15 +16,15 @@ metadata:
 spec:
   initContainers:
     - name: dax-init
-      image: nvcr.io/nvidian/swgpu-baseos/agentless-test:1.2.3
+      image: ghcr.io/nvidia/skyhook/agentless:1.2.3
     - name: dax-apply
-      image: nvcr.io/nvidian/swgpu-baseos/agentless-test:6.2.0
+      image: ghcr.io/nvidia/skyhook/agentless:6.2.0
       args:
         ([0]): apply
         ([1]): /root
         (length(@)): 3
     - name: dax-applycheck
-      image: nvcr.io/nvidian/swgpu-baseos/agentless-test:6.2.0
+      image: ghcr.io/nvidia/skyhook/agentless:6.2.0
       args:
         ([0]): apply-check
         ([1]): /root
@@ -42,7 +42,7 @@ metadata:
     skyhook.nvidia.com/package: dax-1.2.3
   annotations:
     skyhook.nvidia.com/package: >-
-      {"name":"dax","version":"1.2.3","skyhook":"interrupt-grouping","stage":"config","image":"nvcr.io/nvidian/swgpu-baseos/agentless-test"}
+      {"name":"dax","version":"1.2.3","skyhook":"interrupt-grouping","stage":"config","image":"ghcr.io/nvidia/skyhook/agentless"}
   ownerReferences:
     - apiVersion: skyhook.nvidia.com/v1alpha1
       kind: Skyhook
@@ -78,7 +78,7 @@ metadata:
         "version": "1.2.3",
         "skyhook": "interrupt-grouping",
         "stage": "interrupt",
-        "image": "nvcr.io/nvidian/swgpu-baseos/agentless-test"
+        "image": "ghcr.io/nvidia/skyhook/agentless"
       }
   ownerReferences:
     - apiVersion: skyhook.nvidia.com/v1alpha1
@@ -113,7 +113,7 @@ metadata:
     skyhook.nvidia.com/package: dax-1.2.3
   annotations:
     skyhook.nvidia.com/package: >-
-      {"name":"dax","version":"1.2.3","skyhook":"interrupt-grouping","stage":"post-interrupt","image":"nvcr.io/nvidian/swgpu-baseos/agentless-test"}
+      {"name":"dax","version":"1.2.3","skyhook":"interrupt-grouping","stage":"post-interrupt","image":"ghcr.io/nvidia/skyhook/agentless"}
   ownerReferences:
     - apiVersion: skyhook.nvidia.com/v1alpha1
       kind: Skyhook
@@ -143,7 +143,7 @@ metadata:
   annotations:
     (length("skyhook.nvidia.com/version_interrupt-grouping") >= `6`): true
     skyhook.nvidia.com/nodeState_interrupt-grouping: >-
-      {"dax|1.2.3":{"name":"dax","version":"1.2.3","image":"nvcr.io/nvidian/swgpu-baseos/agentless-test","stage":"post-interrupt","state":"complete"},"zeb|2.1.4":{"name":"zeb","version":"2.1.4","image":"nvcr.io/nvidian/swgpu-baseos/agentless-test","stage":"post-interrupt","state":"complete"}}
+      {"dax|1.2.3":{"name":"dax","version":"1.2.3","image":"ghcr.io/nvidia/skyhook/agentless","stage":"post-interrupt","state":"complete"},"zeb|2.1.4":{"name":"zeb","version":"2.1.4","image":"ghcr.io/nvidia/skyhook/agentless","stage":"post-interrupt","state":"complete"}}
     skyhook.nvidia.com/status_interrupt-grouping: complete
   (!taints || length(taints)==`0` || (taints && !not_null(taints))): true ## taints should be empty or not exist
 status:
@@ -172,13 +172,13 @@ status:
           stage: post-interrupt
           state: complete
           version: 1.2.3
-          image: nvcr.io/nvidian/swgpu-baseos/agentless-test
+          image: ghcr.io/nvidia/skyhook/agentless
         zeb|2.1.4:
           name: zeb
           stage: post-interrupt
           state: complete
           version: 2.1.4
-          image: nvcr.io/nvidian/swgpu-baseos/agentless-test
+          image: ghcr.io/nvidia/skyhook/agentless
   nodeStatus:
    # grab values should be one and is complete
     (values(@)):

--- a/k8s-tests/chainsaw/skyhook/interrupt-grouping/skyhook.yaml
+++ b/k8s-tests/chainsaw/skyhook/interrupt-grouping/skyhook.yaml
@@ -17,7 +17,7 @@ spec:
     spenser:
     zeb:
       version: "2.1.4"
-      image: nvcr.io/nvidian/swgpu-baseos/agentless-test
+      image: ghcr.io/nvidia/skyhook/agentless
       env: 
         - name: SLEEP_LEN
           value: "2"
@@ -26,7 +26,7 @@ spec:
         services: [cron]
     dax:
       version: "1.2.3"
-      image: nvcr.io/nvidian/swgpu-baseos/agentless-test
+      image: ghcr.io/nvidia/skyhook/agentless
       env: 
         - name: SLEEP_LEN
           value: "2"

--- a/k8s-tests/chainsaw/skyhook/interrupt/assert.yaml
+++ b/k8s-tests/chainsaw/skyhook/interrupt/assert.yaml
@@ -14,7 +14,7 @@ metadata:
         "version": "1.2.3",
         "skyhook": "interrupt",
         "stage": "uninstall",
-        "image": "nvcr.io/nvidian/swgpu-baseos/agentless-test"
+        "image": "ghcr.io/nvidia/skyhook/agentless"
       }
   ownerReferences:
     - apiVersion: skyhook.nvidia.com/v1alpha1
@@ -49,7 +49,7 @@ metadata:
         "version": "1.3.2",
         "skyhook": "interrupt",
         "stage": "apply",
-        "image": "nvcr.io/nvidian/swgpu-baseos/agentless-test"
+        "image": "ghcr.io/nvidia/skyhook/agentless"
       }
   ownerReferences:
     - apiVersion: skyhook.nvidia.com/v1alpha1
@@ -58,15 +58,15 @@ metadata:
 spec:
   initContainers:
     - name: jason-init
-      image: nvcr.io/nvidian/swgpu-baseos/agentless-test:1.3.2
+      image: ghcr.io/nvidia/skyhook/agentless:1.3.2
     - name: jason-apply
-      image: nvcr.io/nvidian/swgpu-baseos/agentless-test:3.2.3
+      image: ghcr.io/nvidia/skyhook/agentless:3.2.3
       args:
         ([0]): apply
         ([1]): /root
         (length(@)): 3
     - name: jason-applycheck
-      image: nvcr.io/nvidian/swgpu-baseos/agentless-test:3.2.3
+      image: ghcr.io/nvidia/skyhook/agentless:3.2.3
       args:
         ([0]): apply-check
         ([1]): /root
@@ -112,7 +112,7 @@ metadata:
           "version": "1.2.3",
           "skyhook": "interrupt",
           "stage": "interrupt",
-          "image": "nvcr.io/nvidian/swgpu-baseos/agentless-test"
+          "image": "ghcr.io/nvidia/skyhook/agentless"
       }
   ownerReferences:
     - apiVersion: skyhook.nvidia.com/v1alpha1
@@ -143,35 +143,35 @@ metadata:
         "baxter|3.3": {
             "name": "baxter",
             "version": "3.3",
-            "image": "nvcr.io/nvidian/swgpu-baseos/agentless-test",
+            "image": "ghcr.io/nvidia/skyhook/agentless",
             "stage": "post-interrupt",
             "state": "complete"
         },
         "dexter|1.2.3": {
             "name": "dexter",
             "version": "1.2.3",
-            "image": "nvcr.io/nvidian/swgpu-baseos/agentless-test",
+            "image": "ghcr.io/nvidia/skyhook/agentless",
             "stage": "post-interrupt",
             "state": "complete"
         },
         "foobar|1.2": {
             "name": "foobar",
             "version": "1.2",
-            "image": "nvcr.io/nvidian/swgpu-baseos/agentless-test",
+            "image": "ghcr.io/nvidia/skyhook/agentless",
             "stage": "config",
             "state": "complete"
         },
         "jason|1.3.2": {
             "name": "jason",
             "version": "1.3.2",
-            "image": "nvcr.io/nvidian/swgpu-baseos/agentless-test",
+            "image": "ghcr.io/nvidia/skyhook/agentless",
             "stage": "config",
             "state": "complete"
         },
         "spencer|3.2.3": {
             "name": "spencer",
             "version": "3.2.3",
-            "image": "nvcr.io/nvidian/swgpu-baseos/agentless-test",
+            "image": "ghcr.io/nvidia/skyhook/agentless",
             "stage": "config",
             "state": "complete"
         }
@@ -200,25 +200,25 @@ status:
           stage: post-interrupt
           state: complete
           version: "3.3"
-          image: nvcr.io/nvidian/swgpu-baseos/agentless-test
+          image: ghcr.io/nvidia/skyhook/agentless
         dexter|1.2.3:
           name: dexter
           stage: post-interrupt
           state: complete
           version: 1.2.3
-          image: nvcr.io/nvidian/swgpu-baseos/agentless-test
+          image: ghcr.io/nvidia/skyhook/agentless
         foobar|1.2:
           name: foobar
           stage: config
           state: complete
           version: "1.2"
-          image: nvcr.io/nvidian/swgpu-baseos/agentless-test
+          image: ghcr.io/nvidia/skyhook/agentless
         spencer|3.2.3:
           name: spencer
           stage: config
           state: complete
           version: 3.2.3
-          image: nvcr.io/nvidian/swgpu-baseos/agentless-test
+          image: ghcr.io/nvidia/skyhook/agentless
   nodeStatus:
    # grab values should be one and is complete
     (values(@)):

--- a/k8s-tests/chainsaw/skyhook/interrupt/pod.yaml
+++ b/k8s-tests/chainsaw/skyhook/interrupt/pod.yaml
@@ -41,7 +41,7 @@ metadata:
       skyhook.nvidia.com/package: invalid-1.2.3
       skyhook.nvidia.com/name: interrupt
   annotations:
-    skyhook.nvidia.com/package: '{"name":"invalid","version":"1.2.3","stage":"apply","skyhook":"interrupt","image":"nvcr.io/nvidian/swgpu-baseos/agentless-test"}'
+    skyhook.nvidia.com/package: '{"name":"invalid","version":"1.2.3","stage":"apply","skyhook":"interrupt","image":"ghcr.io/nvidia/skyhook/agentless"}'
 spec:
   terminationGracePeriodSeconds: 5
   restartPolicy: OnFailure

--- a/k8s-tests/chainsaw/skyhook/interrupt/skyhook.yaml
+++ b/k8s-tests/chainsaw/skyhook/interrupt/skyhook.yaml
@@ -18,14 +18,14 @@ spec:
   packages:
     jason:
       version: "1.3.2"
-      image: nvcr.io/nvidian/swgpu-baseos/agentless-test
-      agentImageOverride: nvcr.io/nvidian/swgpu-baseos/agentless-test:3.2.3
+      image: ghcr.io/nvidia/skyhook/agentless
+      agentImageOverride: ghcr.io/nvidia/skyhook/agentless:3.2.3
       env: 
         - name: SLEEP_LEN
           value: "8" ## making slow
     spencer:
       version: "3.2.3"
-      image: nvcr.io/nvidian/swgpu-baseos/agentless-test
+      image: ghcr.io/nvidia/skyhook/agentless
       env: 
         - name: SLEEP_LEN
           value: "3" ## making faster
@@ -33,13 +33,13 @@ spec:
         dexter: "1.2.3"
     foobar:
       version: "1.2"
-      image: nvcr.io/nvidian/swgpu-baseos/agentless-test
+      image: ghcr.io/nvidia/skyhook/agentless
       dependsOn:
         dexter: "1.2.3"
         baxter: "3.3"
     baxter: 
       version: "3.3"
-      image: nvcr.io/nvidian/swgpu-baseos/agentless-test
+      image: ghcr.io/nvidia/skyhook/agentless
       env: 
         - name: SLEEP_LEN
           value: "3" ## making faster
@@ -50,7 +50,7 @@ spec:
         spencer: "3.2.3"
     dexter:
       version: "1.2.3"
-      image: nvcr.io/nvidian/swgpu-baseos/agentless-test
+      image: ghcr.io/nvidia/skyhook/agentless
       interrupt: 
         type: service
         services: [cron]

--- a/k8s-tests/chainsaw/skyhook/runtime-required/skyhook.yaml
+++ b/k8s-tests/chainsaw/skyhook/runtime-required/skyhook.yaml
@@ -13,5 +13,5 @@ spec:
   packages:
     spencer:
       version: "3.2.3"
-      image: nvcr.io/nvidian/swgpu-baseos/agentless-test
+      image: ghcr.io/nvidia/skyhook/agentless
 

--- a/k8s-tests/chainsaw/skyhook/simple-skyhook/assert.yaml
+++ b/k8s-tests/chainsaw/skyhook/simple-skyhook/assert.yaml
@@ -5,7 +5,7 @@ metadata:
     skyhook.nvidia.com/test-node: skyhooke2e
     skyhook.nvidia.com/status_simple-skyhook: complete
   annotations:
-    skyhook.nvidia.com/nodeState_simple-skyhook: '{"dexter|1.2.3":{"name":"dexter","version":"1.2.3","image":"nvcr.io/nvidian/swgpu-baseos/agentless-test","stage":"config","state":"complete"},"foobar|1.2":{"name":"foobar","version":"1.2","image":"nvcr.io/nvidian/swgpu-baseos/agentless-test","stage":"config","state":"complete"},"spencer|3.2.3":{"name":"spencer","version":"3.2.3","image":"nvcr.io/nvidian/swgpu-baseos/agentless-test","stage":"config","state":"complete"}}'
+    skyhook.nvidia.com/nodeState_simple-skyhook: '{"dexter|1.2.3":{"name":"dexter","version":"1.2.3","image":"ghcr.io/nvidia/skyhook/agentless","stage":"config","state":"complete"},"foobar|1.2":{"name":"foobar","version":"1.2","image":"ghcr.io/nvidia/skyhook/agentless","stage":"config","state":"complete"},"spencer|3.2.3":{"name":"spencer","version":"3.2.3","image":"ghcr.io/nvidia/skyhook/agentless","stage":"config","state":"complete"}}'
     skyhook.nvidia.com/status_simple-skyhook: complete
 status:
   (conditions[?type == 'skyhook.nvidia.com/simple-skyhook/NotReady']):
@@ -28,19 +28,19 @@ status:
           name: dexter
           state: complete
           version: '1.2.3'
-          image: nvcr.io/nvidian/swgpu-baseos/agentless-test
+          image: ghcr.io/nvidia/skyhook/agentless
           stage: config
         foobar|1.2:
           name: foobar
           state: complete
           version: '1.2'
-          image: nvcr.io/nvidian/swgpu-baseos/agentless-test
+          image: ghcr.io/nvidia/skyhook/agentless
           stage: config
         spencer|3.2.3:
           name: spencer
           state: complete
           version: '3.2.3'
-          image: nvcr.io/nvidian/swgpu-baseos/agentless-test
+          image: ghcr.io/nvidia/skyhook/agentless
           stage: config
   nodeStatus:
    # grab values should be one and is complete

--- a/k8s-tests/chainsaw/skyhook/simple-skyhook/skyhook.yaml
+++ b/k8s-tests/chainsaw/skyhook/simple-skyhook/skyhook.yaml
@@ -17,12 +17,12 @@ spec:
   packages:
     spencer:
       version: "3.2.3"
-      image: nvcr.io/nvidian/swgpu-baseos/agentless-test
+      image: ghcr.io/nvidia/skyhook/agentless
       dependsOn:
         dexter: "1.2.3"
     foobar:
       version: "1.2"
-      image: nvcr.io/nvidian/swgpu-baseos/agentless-test
+      image: ghcr.io/nvidia/skyhook/agentless
       dependsOn:
         dexter: "1.2.3"
       env: 
@@ -30,7 +30,7 @@ spec:
           value: "3" ## making faster so the test works for asserting node condition
     dexter:
       version: "1.2.3"
-      image: nvcr.io/nvidian/swgpu-baseos/agentless-test:bogus ## testing that the image tag is replaced with the version by giving bad image tag
+      image: ghcr.io/nvidia/skyhook/agentless:bogus ## testing that the image tag is replaced with the version by giving bad image tag
       configMap:
         game.properties: |
           enemies=aliens

--- a/k8s-tests/chainsaw/skyhook/simple-update-skyhook/assert-update.yaml
+++ b/k8s-tests/chainsaw/skyhook/simple-update-skyhook/assert-update.yaml
@@ -36,35 +36,35 @@ metadata:
         "baxter|2.3.1-test": {
             "name": "baxter",
             "version": "2.3.1-test",
-            "image": "nvcr.io/nvidian/swgpu-baseos/agentless-test",
+            "image": "ghcr.io/nvidia/skyhook/agentless",
             "stage": "config",
             "state": "complete"
         },
         "dexter|1.2.3": {
             "name": "dexter",
             "version": "1.2.3",
-            "image": "nvcr.io/nvidian/swgpu-baseos/agentless-test",
+            "image": "ghcr.io/nvidia/skyhook/agentless",
             "stage": "config",
             "state": "complete"
         },
         "foobar|1.2": {
             "name": "foobar",
             "version": "1.2",
-            "image": "nvcr.io/nvidian/swgpu-baseos/agentless-test",
+            "image": "ghcr.io/nvidia/skyhook/agentless",
             "stage": "config",
             "state": "complete"
         },
         "jackie-chan|2024.7.7-test": {
             "name": "jackie-chan",
             "version": "2024.7.7-test",
-            "image": "nvcr.io/nvidian/swgpu-baseos/agentless-test",
+            "image": "ghcr.io/nvidia/skyhook/agentless",
             "stage": "config",
             "state": "complete"
         },
         "spencer|3.2.3": {
             "name": "spencer",
             "version": "3.2.3",
-            "image": "nvcr.io/nvidian/swgpu-baseos/agentless-test",
+            "image": "ghcr.io/nvidia/skyhook/agentless",
             "stage": "config",
             "state": "complete"
         }
@@ -92,31 +92,31 @@ status:
           stage: config
           state: complete
           version: 2.3.1-test
-          image: nvcr.io/nvidian/swgpu-baseos/agentless-test
+          image: ghcr.io/nvidia/skyhook/agentless
         dexter|1.2.3:
           name: dexter
           stage: config
           state: complete
           version: 1.2.3
-          image: nvcr.io/nvidian/swgpu-baseos/agentless-test
+          image: ghcr.io/nvidia/skyhook/agentless
         foobar|1.2:
           name: foobar
           stage: config
           state: complete
           version: '1.2'
-          image: nvcr.io/nvidian/swgpu-baseos/agentless-test
+          image: ghcr.io/nvidia/skyhook/agentless
         jackie-chan|2024.7.7-test:
           name: jackie-chan
           stage: config
           state: complete
           version: '2024.7.7-test'
-          image: nvcr.io/nvidian/swgpu-baseos/agentless-test
+          image: ghcr.io/nvidia/skyhook/agentless
         spencer|3.2.3:
           name: spencer
           stage: config
           state: complete
           version: 3.2.3
-          image: nvcr.io/nvidian/swgpu-baseos/agentless-test
+          image: ghcr.io/nvidia/skyhook/agentless
   nodeStatus:
    # grab values should be one and is complete
     (values(@)):

--- a/k8s-tests/chainsaw/skyhook/simple-update-skyhook/assert.yaml
+++ b/k8s-tests/chainsaw/skyhook/simple-update-skyhook/assert.yaml
@@ -11,21 +11,21 @@ metadata:
         "dexter|1.2.3": {
             "name": "dexter",
             "version": "1.2.3",
-            "image": "nvcr.io/nvidian/swgpu-baseos/agentless-test",
+            "image": "ghcr.io/nvidia/skyhook/agentless",
             "stage": "config",
             "state": "complete"
         },
         "foobar|1.2": {
             "name": "foobar",
             "version": "1.2",
-            "image": "nvcr.io/nvidian/swgpu-baseos/agentless-test",
+            "image": "ghcr.io/nvidia/skyhook/agentless",
             "stage": "config",
             "state": "complete"
         },
         "spencer|3.2.3": {
             "name": "spencer",
             "version": "3.2.3",
-            "image": "nvcr.io/nvidian/swgpu-baseos/agentless-test",
+            "image": "ghcr.io/nvidia/skyhook/agentless",
             "stage": "config",
             "state": "complete"
         }
@@ -56,19 +56,19 @@ status:
           name: dexter
           state: complete
           version: '1.2.3'
-          image: nvcr.io/nvidian/swgpu-baseos/agentless-test
+          image: ghcr.io/nvidia/skyhook/agentless
           stage: config
         foobar|1.2:
           name: foobar
           state: complete
           version: '1.2'
-          image: nvcr.io/nvidian/swgpu-baseos/agentless-test
+          image: ghcr.io/nvidia/skyhook/agentless
           stage: config
         spencer|3.2.3:
           name: spencer
           state: complete
           version: '3.2.3'
-          image: nvcr.io/nvidian/swgpu-baseos/agentless-test
+          image: ghcr.io/nvidia/skyhook/agentless
           stage: config
   nodeStatus:
    # grab values should be one and is complete

--- a/k8s-tests/chainsaw/skyhook/simple-update-skyhook/skyhook.yaml
+++ b/k8s-tests/chainsaw/skyhook/simple-update-skyhook/skyhook.yaml
@@ -14,12 +14,12 @@ spec:
   packages:
     spencer:
       version: "3.2.3"
-      image: nvcr.io/nvidian/swgpu-baseos/agentless-test
+      image: ghcr.io/nvidia/skyhook/agentless
       dependsOn:
         dexter: "1.2.3"
     foobar:
       version: "1.2"
-      image: nvcr.io/nvidian/swgpu-baseos/agentless-test
+      image: ghcr.io/nvidia/skyhook/agentless
       env: 
         - name: SLEEP_LEN
           value: "3" ## making faster so the test works for asserting node condition
@@ -27,7 +27,7 @@ spec:
         dexter: "1.2.3"
     dexter:
       version: "1.2.3"
-      image: nvcr.io/nvidian/swgpu-baseos/agentless-test:bogus ## testing that the image tag is cut off
+      image: ghcr.io/nvidia/skyhook/agentless:bogus ## testing that the image tag is cut off
       configMap:
         game.properties: |
           enemies=aliens

--- a/k8s-tests/chainsaw/skyhook/simple-update-skyhook/update.yaml
+++ b/k8s-tests/chainsaw/skyhook/simple-update-skyhook/update.yaml
@@ -14,7 +14,7 @@ spec:
   packages:
     baxter:
       version: 2.3.1-test
-      image: nvcr.io/nvidian/swgpu-baseos/agentless-test
+      image: ghcr.io/nvidia/skyhook/agentless
       configMap:
         game.properties: |
           enemies=aliens
@@ -28,7 +28,7 @@ spec:
           how.nice.to.look=fairlyNice
     jackie-chan: ## TODO: need to handle bad naming, because this are pod names, so can have issues depending on the chars
       version: "2024.7.7-test"
-      image: nvcr.io/nvidian/swgpu-baseos/agentless-test
+      image: ghcr.io/nvidia/skyhook/agentless
       env: 
         - name: SLEEP_LEN
           value: "3" ## making faster so the test works for asserting node condition

--- a/k8s-tests/chainsaw/skyhook/taint-scheduling/assert-update.yaml
+++ b/k8s-tests/chainsaw/skyhook/taint-scheduling/assert-update.yaml
@@ -10,7 +10,7 @@ metadata:
         "spencer|3.2.3": {
             "name": "spencer",
             "version": "3.2.3",
-            "image": "nvcr.io/nvidian/swgpu-baseos/agentless-test",
+            "image": "ghcr.io/nvidia/skyhook/agentless",
             "stage": "config",
             "state": "complete"
         }

--- a/k8s-tests/chainsaw/skyhook/taint-scheduling/skyhook.yaml
+++ b/k8s-tests/chainsaw/skyhook/taint-scheduling/skyhook.yaml
@@ -12,5 +12,5 @@ spec:
   packages:
     spencer:
       version: "3.2.3"
-      image: nvcr.io/nvidian/swgpu-baseos/agentless-test
+      image: ghcr.io/nvidia/skyhook/agentless
 

--- a/k8s-tests/chainsaw/skyhook/taint-scheduling/update-skyhook.yaml
+++ b/k8s-tests/chainsaw/skyhook/taint-scheduling/update-skyhook.yaml
@@ -15,5 +15,5 @@ spec:
   packages:
     spencer:
       version: "3.2.3"
-      image: nvcr.io/nvidian/swgpu-baseos/agentless-test
+      image: ghcr.io/nvidia/skyhook/agentless
 

--- a/k8s-tests/chainsaw/skyhook/uninstall-upgrade-skyhook/assert-update-no-packages.yaml
+++ b/k8s-tests/chainsaw/skyhook/uninstall-upgrade-skyhook/assert-update-no-packages.yaml
@@ -14,7 +14,7 @@ metadata:
         "version": "1.2.5",
         "skyhook": "uninstall-upgrade-skyhook",
         "stage": "uninstall",
-        "image": "nvcr.io/nvidian/swgpu-baseos/agentless-test"
+        "image": "ghcr.io/nvidia/skyhook/agentless"
       }
   ownerReferences:
     - apiVersion: skyhook.nvidia.com/v1alpha1
@@ -49,7 +49,7 @@ metadata:
         "version": "2.0.1",
         "skyhook": "uninstall-upgrade-skyhook",
         "stage": "uninstall",
-        "image": "nvcr.io/nvidian/swgpu-baseos/agentless-test"
+        "image": "ghcr.io/nvidia/skyhook/agentless"
       }
   ownerReferences:
     - apiVersion: skyhook.nvidia.com/v1alpha1

--- a/k8s-tests/chainsaw/skyhook/uninstall-upgrade-skyhook/assert-update.yaml
+++ b/k8s-tests/chainsaw/skyhook/uninstall-upgrade-skyhook/assert-update.yaml
@@ -14,7 +14,7 @@ metadata:
         "version": "6.2.0",
         "skyhook": "uninstall-upgrade-skyhook",
         "stage": "uninstall",
-        "image": "nvcr.io/nvidian/swgpu-baseos/agentless-test"
+        "image": "ghcr.io/nvidia/skyhook/agentless"
       }
   ownerReferences:
     - apiVersion: skyhook.nvidia.com/v1alpha1
@@ -63,7 +63,7 @@ metadata:
         "version": "1.2.6",
         "skyhook": "uninstall-upgrade-skyhook",
         "stage": "uninstall",
-        "image": "nvcr.io/nvidian/swgpu-baseos/agentless-test"
+        "image": "ghcr.io/nvidia/skyhook/agentless"
       }
   ownerReferences:
     - apiVersion: skyhook.nvidia.com/v1alpha1
@@ -98,7 +98,7 @@ metadata:
         "version": "2.0.1",
         "skyhook": "uninstall-upgrade-skyhook",
         "stage": "upgrade",
-        "image": "nvcr.io/nvidian/swgpu-baseos/agentless-test"
+        "image": "ghcr.io/nvidia/skyhook/agentless"
       }
   ownerReferences:
     - apiVersion: skyhook.nvidia.com/v1alpha1
@@ -130,14 +130,14 @@ metadata:
         "dogs|1.2.5": {
             "name": "dogs",
             "version": "1.2.5",
-            "image": "nvcr.io/nvidian/swgpu-baseos/agentless-test",
+            "image": "ghcr.io/nvidia/skyhook/agentless",
             "stage": "post-interrupt",
             "state": "complete"
         },
         "nullptr|2.0.1": {
             "name": "nullptr",
             "version": "2.0.1",
-            "image": "nvcr.io/nvidian/swgpu-baseos/agentless-test",
+            "image": "ghcr.io/nvidia/skyhook/agentless",
             "stage": "post-interrupt",
             "state": "complete"
         }
@@ -168,13 +168,13 @@ status:
           state: complete
           version: '1.2.5'
           stage: post-interrupt
-          image: nvcr.io/nvidian/swgpu-baseos/agentless-test
+          image: ghcr.io/nvidia/skyhook/agentless
         nullptr|2.0.1:
           name: nullptr
           state: complete
           version: '2.0.1'
           stage: post-interrupt
-          image: nvcr.io/nvidian/swgpu-baseos/agentless-test
+          image: ghcr.io/nvidia/skyhook/agentless
   nodeStatus:
    # grab values should be one and is complete
     (values(@)):

--- a/k8s-tests/chainsaw/skyhook/uninstall-upgrade-skyhook/assert.yaml
+++ b/k8s-tests/chainsaw/skyhook/uninstall-upgrade-skyhook/assert.yaml
@@ -10,21 +10,21 @@ metadata:
         "cats|6.2.0": {
             "name": "cats",
             "version": "6.2.0",
-            "image": "nvcr.io/nvidian/swgpu-baseos/agentless-test",
+            "image": "ghcr.io/nvidia/skyhook/agentless",
             "stage": "config",
             "state": "complete"
         },
         "dogs|1.2.6": {
             "name": "dogs",
             "version": "1.2.6",
-            "image": "nvcr.io/nvidian/swgpu-baseos/agentless-test",
+            "image": "ghcr.io/nvidia/skyhook/agentless",
             "stage": "post-interrupt",
             "state": "complete"
         },
         "nullptr|2.0.0": {
             "name": "nullptr",
             "version": "2.0.0",
-            "image": "nvcr.io/nvidian/swgpu-baseos/agentless-test",
+            "image": "ghcr.io/nvidia/skyhook/agentless",
             "stage": "post-interrupt",
             "state": "complete"
         }
@@ -55,19 +55,19 @@ status:
           state: complete
           version: '1.2.6'
           stage: post-interrupt
-          image: nvcr.io/nvidian/swgpu-baseos/agentless-test
+          image: ghcr.io/nvidia/skyhook/agentless
         nullptr|2.0.0:
           name: nullptr
           state: complete
           version: '2.0.0'
           stage: post-interrupt
-          image: nvcr.io/nvidian/swgpu-baseos/agentless-test
+          image: ghcr.io/nvidia/skyhook/agentless
         cats|6.2.0:
           name: cats
           state: complete
           version: '6.2.0'
           stage: config
-          image: nvcr.io/nvidian/swgpu-baseos/agentless-test
+          image: ghcr.io/nvidia/skyhook/agentless
   nodeStatus:
    # grab values should be one and is complete
     (values(@)):

--- a/k8s-tests/chainsaw/skyhook/uninstall-upgrade-skyhook/skyhook.yaml
+++ b/k8s-tests/chainsaw/skyhook/uninstall-upgrade-skyhook/skyhook.yaml
@@ -14,7 +14,7 @@ spec:
   packages:
     dogs:
       version: "1.2.6"
-      image: nvcr.io/nvidian/swgpu-baseos/agentless-test
+      image: ghcr.io/nvidia/skyhook/agentless
       interrupt:
         type: reboot
       configMap:  
@@ -30,7 +30,7 @@ spec:
           how.nice.to.look=fairlyNice
     nullptr:
       version: "2.0.0"
-      image: nvcr.io/nvidian/swgpu-baseos/agentless-test
+      image: ghcr.io/nvidia/skyhook/agentless
       interrupt:
         type: service
         services: [cron, containerd]
@@ -47,4 +47,4 @@ spec:
           how.nice.to.look=fairlyNice
     cats:
       version: "6.2.0"
-      image: nvcr.io/nvidian/swgpu-baseos/agentless-test
+      image: ghcr.io/nvidia/skyhook/agentless

--- a/k8s-tests/chainsaw/skyhook/uninstall-upgrade-skyhook/update.yaml
+++ b/k8s-tests/chainsaw/skyhook/uninstall-upgrade-skyhook/update.yaml
@@ -14,7 +14,7 @@ spec:
   packages:
     dogs: 
       version: "1.2.5" ## downgrade
-      image: nvcr.io/nvidian/swgpu-baseos/agentless-test
+      image: ghcr.io/nvidia/skyhook/agentless
       interrupt:
         type: reboot
       configMap:  
@@ -24,7 +24,7 @@ spec:
           changed
     nullptr:
       version: "2.0.1" ## upgrade
-      image: nvcr.io/nvidian/swgpu-baseos/agentless-test
+      image: ghcr.io/nvidia/skyhook/agentless
       interrupt:
         type: service
         services: [cron, containerd]

--- a/k8s-tests/chainsaw/skyhook/validate-packages/assert-update.yaml
+++ b/k8s-tests/chainsaw/skyhook/validate-packages/assert-update.yaml
@@ -10,21 +10,21 @@ metadata:
         "invalid-env|5.4.3": {
             "name": "invalid-env",
             "version": "5.4.3",
-            "image": "nvcr.io/nvidian/swgpu-baseos/agentless-test",
+            "image": "ghcr.io/nvidia/skyhook/agentless",
             "stage": "config",
             "state": "complete"
         },
         "invalid-image|3.2.3": {
             "name": "invalid-image",
             "version": "3.2.3",
-            "image": "nvcr.io/nvidian/swgpu-baseos/agentless-test",
+            "image": "ghcr.io/nvidia/skyhook/agentless",
             "stage": "config",
             "state": "complete"
         },
         "invalid-resources|1.2.3": {
             "name": "invalid-resources",
             "version": "1.2.3",
-            "image": "nvcr.io/nvidian/swgpu-baseos/agentless-test",
+            "image": "ghcr.io/nvidia/skyhook/agentless",
             "stage": "config",
             "state": "complete"
         }
@@ -51,19 +51,19 @@ status:
         name: invalid-image
         state: complete
         version: '3.2.3'
-        image: nvcr.io/nvidian/swgpu-baseos/agentless-test
+        image: ghcr.io/nvidia/skyhook/agentless
         stage: config
       invalid-resources|1.2.3:
         name: invalid-resources
         state: complete
         version: '1.2.3'
-        image: nvcr.io/nvidian/swgpu-baseos/agentless-test
+        image: ghcr.io/nvidia/skyhook/agentless
         stage: config
       invalid-env|5.4.3:
         name: invalid-env
         state: complete
         version: '5.4.3'
-        image: nvcr.io/nvidian/swgpu-baseos/agentless-test
+        image: ghcr.io/nvidia/skyhook/agentless
         stage: config
   nodeStatus:
    # grab values should be one and is complete

--- a/k8s-tests/chainsaw/skyhook/validate-packages/assert.yaml
+++ b/k8s-tests/chainsaw/skyhook/validate-packages/assert.yaml
@@ -10,21 +10,21 @@ metadata:
         "invalid-env|5.4.3": {
             "name": "invalid-env",
             "version": "5.4.3",
-            "image": "nvcr.io/nvidian/swgpu-baseos/agentless-test",
+            "image": "ghcr.io/nvidia/skyhook/agentless",
             "stage": "apply",
             "state": "in_progress"
         },
         "invalid-image|3.2.3-bogus": {
             "name": "invalid-image",
             "version": "3.2.3-bogus",
-            "image": "nvcr.io/nvidian/swgpu-baseos/agentless-test",
+            "image": "ghcr.io/nvidia/skyhook/agentless",
             "stage": "apply",
             "state": "in_progress"
         },
         "invalid-resources|1.2.3": {
             "name": "invalid-resources",
             "version": "1.2.3",
-            "image": "nvcr.io/nvidian/swgpu-baseos/agentless-test",
+            "image": "ghcr.io/nvidia/skyhook/agentless",
             "stage": "apply",
             "state": "in_progress"
         }
@@ -50,19 +50,19 @@ status:
         name: invalid-env
         state: in_progress
         version: '5.4.3'
-        image: nvcr.io/nvidian/swgpu-baseos/agentless-test
+        image: ghcr.io/nvidia/skyhook/agentless
         stage: apply
       invalid-image|3.2.3-bogus:
         name: invalid-image
         state: in_progress
         version: '3.2.3-bogus'
-        image: nvcr.io/nvidian/swgpu-baseos/agentless-test
+        image: ghcr.io/nvidia/skyhook/agentless
         stage: apply
       invalid-resources|1.2.3:
         name: invalid-resources
         state: in_progress
         version: '1.2.3'
-        image: nvcr.io/nvidian/swgpu-baseos/agentless-test
+        image: ghcr.io/nvidia/skyhook/agentless
         stage: apply
   nodeStatus:
     # grab values should be one and is erroring

--- a/k8s-tests/chainsaw/skyhook/validate-packages/skyhook.yaml
+++ b/k8s-tests/chainsaw/skyhook/validate-packages/skyhook.yaml
@@ -14,10 +14,10 @@ spec:
   packages:
     invalid-image:
       version: "3.2.3-bogus"
-      image: nvcr.io/nvidian/swgpu-baseos/agentless-test
+      image: ghcr.io/nvidia/skyhook/agentless
     invalid-resources:
       version: "1.2.3"
-      image: nvcr.io/nvidian/swgpu-baseos/agentless-test
+      image: ghcr.io/nvidia/skyhook/agentless
       resources:
         cpuRequest: 10000m
         cpuLimit: 10000m
@@ -25,7 +25,7 @@ spec:
         memoryLimit: 10000Mi
     invalid-env:
       version: "5.4.3"
-      image: nvcr.io/nvidian/swgpu-baseos/agentless-test
+      image: ghcr.io/nvidia/skyhook/agentless
       env:
         - name: SLEEP_LEN
           value: "1000"

--- a/k8s-tests/chainsaw/skyhook/validate-packages/update.yaml
+++ b/k8s-tests/chainsaw/skyhook/validate-packages/update.yaml
@@ -14,10 +14,10 @@ spec:
   packages:
     invalid-image:
       version: "3.2.3"
-      image: nvcr.io/nvidian/swgpu-baseos/agentless-test
+      image: ghcr.io/nvidia/skyhook/agentless
     invalid-resources:
       version: "1.2.3"
-      image: nvcr.io/nvidian/swgpu-baseos/agentless-test
+      image: ghcr.io/nvidia/skyhook/agentless
       resources:
         cpuRequest: 50m
         cpuLimit: 250m
@@ -25,7 +25,7 @@ spec:
         memoryLimit: 256Mi
     invalid-env:
       version: "5.4.3"
-      image: nvcr.io/nvidian/swgpu-baseos/agentless-test
+      image: ghcr.io/nvidia/skyhook/agentless
       env: 
         - name: SLEEP_LEN
           value: "3"

--- a/operator/config/samples/interrupt_group.yaml
+++ b/operator/config/samples/interrupt_group.yaml
@@ -16,13 +16,13 @@ spec:
     spenser:
     zeb:
       version: "2.1.4"
-      image: nvcr.io/nvidian/swgpu-baseos/agentless-test:latest
+      image: ghcr.io/nvidia/skyhook/agentless:latest
       interrupt: 
         type: service
         services: [cron]
     dax:
       version: "1.2.3"
-      image: nvcr.io/nvidian/swgpu-baseos/agentless-test:latest
+      image: ghcr.io/nvidia/skyhook/agentless:latest
       interrupt: 
         type: service
         services: [containerd, foobar]

--- a/operator/config/samples/skyhook_v1alpha1_skyhook.yaml
+++ b/operator/config/samples/skyhook_v1alpha1_skyhook.yaml
@@ -29,10 +29,10 @@ spec:
           echo $0
       interrupt: 
         type: reboot
-      image: nvcr.io/nvidian/swgpu-baseos/agentless-test:latest
+      image: ghcr.io/nvidia/skyhook/agentless:latest
     ssh:
       version: "3.0"
-      image: nvcr.io/nvidian/swgpu-baseos/agentless-test:latest
+      image: ghcr.io/nvidia/skyhook/agentless:latest
     phoenix:
       version: "2.1.4"
       env:
@@ -41,10 +41,10 @@ spec:
       interrupt: 
         type: service
         services: [cron]
-      image: nvcr.io/nvidian/swgpu-baseos/agentless-test:latest
+      image: ghcr.io/nvidia/skyhook/agentless:latest
     dax:
       version: "1.2.3"
-      image: nvcr.io/nvidian/swgpu-baseos/agentless-test:latest
+      image: ghcr.io/nvidia/skyhook/agentless:latest
       dependsOn: 
         spenser: "3.1.1"
         ssh: "3.0"


### PR DESCRIPTION
The agenless image is used in end to end testing, `k8s-tests/chainsaw`, and is a basically bare image that sleeps for a configurable period of time then exits. Adds agentless image build to enable end to end tests, change test pointers to that image.