### PR TITLE
fix(gitlab-ci): add missing chart-json to publishing mr needs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -61,6 +61,9 @@ include:
       - job: create-agent-json
         optional: true
         artifacts: true
+      - job: create-chart-json
+        optional: true
+        artifacts: true
 
 ## setup vault creds
 bootstrap:


### PR DESCRIPTION
add the create-chart-json job to dependencies of create-publishing-mr to ensure config file is passed properly