### PR TITLE
fix(agent): chdir to / and make env var setting more robust for host machine

### DIFF
--- a/agent/skyhook-agent/src/skyhook_agent/chroot_exec.py
+++ b/agent/skyhook-agent/src/skyhook_agent/chroot_exec.py
@@ -40,6 +40,7 @@ def chroot_exec(config: dict, chroot_dir: str):
     no_chmod = config["no_chmod"]
     skyhook_env = config["env"]
 
+    # Capture container environment before chroot
     container_env = dict(os.environ)
    
     if chroot_dir != "local":
@@ -49,8 +50,8 @@ def chroot_exec(config: dict, chroot_dir: str):
             # chmod +x the step
             os.chmod(cmds[0], os.stat(cmds[0]).st_mode | stat.S_IXGRP | stat.S_IXUSR | stat.S_IXOTH)
         # Re-import os to get the chroot environment
-        import os
-        process_env = _get_process_env(container_env, skyhook_env, os.environ)
+        import os as chroot_os
+        process_env = _get_process_env(container_env, skyhook_env, chroot_os.environ)
         subprocess.run(cmds, check=True, env=process_env)
     except:
         raise

--- a/agent/skyhook-agent/src/skyhook_agent/chroot_exec.py
+++ b/agent/skyhook-agent/src/skyhook_agent/chroot_exec.py
@@ -23,16 +23,35 @@ import subprocess
 import shutil
 
 
+def _get_process_env(container_env: dict, skyhook_env: dict, chroot_env: dict):
+    # Set this first with the container environment.
+    # We need to do this because the skyhook package could set any env var they want so that needs
+    # to get replicated down. BUT we are in distroless so we then need to overwrite with the chroot environment
+    # so things like path/user resolution work.
+    process_env = dict(container_env)
+    # Overwrite the container environment with the chroot environment
+    process_env.update(chroot_env)
+    # Inject the skyhook environment variables
+    process_env.update(skyhook_env)
+    return process_env
+
 def chroot_exec(config: dict, chroot_dir: str):
     cmds = config["cmd"]
     no_chmod = config["no_chmod"]
+    skyhook_env = config["env"]
+
+    container_env = dict(os.environ)
+   
     if chroot_dir != "local":
         os.chroot(chroot_dir)
     try:
         if not no_chmod:
             # chmod +x the step
             os.chmod(cmds[0], os.stat(cmds[0]).st_mode | stat.S_IXGRP | stat.S_IXUSR | stat.S_IXOTH)
-        subprocess.run(cmds, check=True)
+        # Re-import os to get the chroot environment
+        import os
+        process_env = _get_process_env(container_env, skyhook_env, os.environ)
+        subprocess.run(cmds, check=True, env=process_env)
     except:
         raise
 

--- a/agent/skyhook-agent/src/skyhook_agent/chroot_exec.py
+++ b/agent/skyhook-agent/src/skyhook_agent/chroot_exec.py
@@ -45,6 +45,7 @@ def chroot_exec(config: dict, chroot_dir: str):
    
     if chroot_dir != "local":
         os.chroot(chroot_dir)
+        os.chdir("/")
     try:
         if not no_chmod:
             # chmod +x the step

--- a/agent/skyhook-agent/tests/test_chroot_exec.py
+++ b/agent/skyhook-agent/tests/test_chroot_exec.py
@@ -1,0 +1,141 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from skyhook_agent.chroot_exec import _get_process_env
+
+
+class TestChrootExec(unittest.TestCase):
+    
+    def test_get_process_env_basic_functionality(self):
+        """Test _get_process_env with non-overlapping keys"""
+        container_env = {"CONTAINER_VAR": "container_value"}
+        chroot_env = {"CHROOT_VAR": "chroot_value"}
+        skyhook_env = {"SKYHOOK_VAR": "skyhook_value"}
+        
+        result = _get_process_env(container_env, skyhook_env, chroot_env)
+        
+        expected = {
+            "CONTAINER_VAR": "container_value",
+            "CHROOT_VAR": "chroot_value",
+            "SKYHOOK_VAR": "skyhook_value"
+        }
+        self.assertEqual(result, expected)
+    
+    def test_get_process_env_chroot_overrides_container(self):
+        """Test that chroot_env overrides container_env for same keys"""
+        container_env = {"SAME_VAR": "container_value", "CONTAINER_VAR": "container_value"}
+        chroot_env = {"SAME_VAR": "chroot_value", "CHROOT_VAR": "chroot_value"}
+        skyhook_env = {"SKYHOOK_VAR": "skyhook_value"}
+        
+        result = _get_process_env(container_env, skyhook_env, chroot_env)
+        
+        expected = {
+            "SAME_VAR": "chroot_value",  # chroot overrides container
+            "CONTAINER_VAR": "container_value",
+            "CHROOT_VAR": "chroot_value",
+            "SKYHOOK_VAR": "skyhook_value"
+        }
+        self.assertEqual(result, expected)
+    
+    def test_get_process_env_skyhook_overrides_all(self):
+        """Test that skyhook_env has highest priority and overrides both chroot and container"""
+        container_env = {"SAME_VAR": "container_value", "CONTAINER_VAR": "container_value"}
+        chroot_env = {"SAME_VAR": "chroot_value", "CHROOT_VAR": "chroot_value"}
+        skyhook_env = {"SAME_VAR": "skyhook_value", "SKYHOOK_VAR": "skyhook_value"}
+        
+        result = _get_process_env(container_env, skyhook_env, chroot_env)
+        
+        expected = {
+            "SAME_VAR": "skyhook_value",  # skyhook overrides both chroot and container
+            "CONTAINER_VAR": "container_value",
+            "CHROOT_VAR": "chroot_value",
+            "SKYHOOK_VAR": "skyhook_value"
+        }
+        self.assertEqual(result, expected)
+    
+    def test_get_process_env_with_empty_dicts(self):
+        """Test _get_process_env with empty dictionaries"""
+        result = _get_process_env({}, {}, {})
+        self.assertEqual(result, {})
+        
+        # Test with only one dict having values
+        container_env = {"VAR": "value"}
+        result = _get_process_env(container_env, {}, {})
+        self.assertEqual(result, {"VAR": "value"})
+        
+        chroot_env = {"VAR": "value"}
+        result = _get_process_env({}, {}, chroot_env)
+        self.assertEqual(result, {"VAR": "value"})
+        
+        skyhook_env = {"VAR": "value"}
+        result = _get_process_env({}, skyhook_env, {})
+        self.assertEqual(result, {"VAR": "value"})
+    
+    def test_get_process_env_precedence_order(self):
+        """Test complete precedence order: skyhook > chroot > container"""
+        container_env = {
+            "PATH": "/container/path",
+            "HOME": "/container/home",
+            "USER": "container_user",
+            "ONLY_CONTAINER": "container_only"
+        }
+        chroot_env = {
+            "PATH": "/chroot/path",
+            "HOME": "/chroot/home",
+            "ONLY_CHROOT": "chroot_only"
+        }
+        skyhook_env = {
+            "PATH": "/skyhook/path",
+            "ONLY_SKYHOOK": "skyhook_only"
+        }
+        
+        result = _get_process_env(container_env, skyhook_env, chroot_env)
+        
+        expected = {
+            "PATH": "/skyhook/path",      # skyhook wins
+            "HOME": "/chroot/home",       # chroot wins over container
+            "USER": "container_user",     # only in container
+            "ONLY_CONTAINER": "container_only",
+            "ONLY_CHROOT": "chroot_only",
+            "ONLY_SKYHOOK": "skyhook_only"
+        }
+        self.assertEqual(result, expected)
+    
+    def test_get_process_env_does_not_modify_input_dicts(self):
+        """Test that input dictionaries are not modified"""
+        container_env = {"VAR": "container"}
+        chroot_env = {"VAR": "chroot"}
+        skyhook_env = {"VAR": "skyhook"}
+        
+        # Keep original references
+        original_container = container_env.copy()
+        original_chroot = chroot_env.copy()
+        original_skyhook = skyhook_env.copy()
+        
+        result = _get_process_env(container_env, skyhook_env, chroot_env)
+        
+        # Verify input dicts weren't modified
+        self.assertEqual(container_env, original_container)
+        self.assertEqual(chroot_env, original_chroot)
+        self.assertEqual(skyhook_env, original_skyhook)
+        
+        # Verify result is correct
+        self.assertEqual(result, {"VAR": "skyhook"})
+
+
+if __name__ == '__main__':
+    unittest.main() 

--- a/agent/skyhook-agent/tests/test_controller.py
+++ b/agent/skyhook-agent/tests/test_controller.py
@@ -244,9 +244,9 @@ class TestHelpers(unittest.TestCase):
                     ["copy_dir/skyhook_dir/foo", "a", "foo"],
                     log_file,
                     f"{log_file}.err",
-                    env=dict(**os.environ, **{"STEP_ROOT": "copy_dir/skyhook_dir", "FOO": "foo", "SKYHOOK_DIR": "copy_dir"}),
                     write_cmds=False,
-                    no_chmod=False
+                    no_chmod=False,
+                    env={"STEP_ROOT": "copy_dir/skyhook_dir", "SKYHOOK_DIR": "copy_dir"}
                 )
             ]
         )
@@ -690,9 +690,9 @@ class TestUseCases(unittest.TestCase):
                         controller.get_log_file(
                             f"{controller.get_host_path_for_steps(copy_dir)}/foo", f"/foo", config_data, root_dir
                         ),
-                        env=dict(**os.environ, 
-                                **{"PREVIOUS_VERSION": "0.0.9", "CURRENT_VERSION": "1.0.0"}, 
-                                **{"STEP_ROOT": f"{root_dir}/{copy_dir}/skyhook_dir", "SKYHOOK_DIR": copy_dir})
+                        env=dict(
+                            **{"PREVIOUS_VERSION": "0.0.9", "CURRENT_VERSION": "1.0.0"}, 
+                            **{"STEP_ROOT": f"{root_dir}/{copy_dir}/skyhook_dir", "SKYHOOK_DIR": copy_dir})
                     )
                 ])
 
@@ -729,9 +729,9 @@ class TestUseCases(unittest.TestCase):
                     controller.get_log_file(
                         f"{controller.get_host_path_for_steps(copy_dir)}/foo", f"/foo", config_data, root_dir
                     ),
-                    env=dict(**os.environ, 
-                            **{"PREVIOUS_VERSION": "2024.07.28", "CURRENT_VERSION": "1.0.0"}, 
-                            **{"STEP_ROOT": f"{root_dir}/{copy_dir}/skyhook_dir", "SKYHOOK_DIR": copy_dir})
+                    env=dict(
+                        **{"PREVIOUS_VERSION": "2024.07.28", "CURRENT_VERSION": "1.0.0"}, 
+                        **{"STEP_ROOT": f"{root_dir}/{copy_dir}/skyhook_dir", "SKYHOOK_DIR": copy_dir})
                 )
             ])
 


### PR DESCRIPTION
The main change is the addition of `os.chdir("/")` the environment stuff is also better as well.

Redo how environment variables are handled and move it all the to chroot_exec script. Precedence order is now skyhook specific > chroot env > container env

This way we should capture anything the user sets and use the proper env vars for chroot