### PR TITLE
feat(operator): added comprehensive status and state metrics

### DIFF
--- a/docs/metrics/README.md
+++ b/docs/metrics/README.md
@@ -1,19 +1,31 @@
 # Metrics
-The current metrics supplied by the Operator are intended to be sufficient to determine the state of application of a Skyhook Custom Resource within a cluster. These metrics are defined at [internal/controller/metrics.go](operator/internal/controller/metrics.go). There are three primary flavors:
- * `skyhook_node_*` : Which give the count of nodes in given state for a SCR. Tags are:
+The current metrics supplied by the Operator are intended to be sufficient to determine the state of application of a Skyhook Custom Resource within a cluster. These metrics are defined at [internal/controller/metrics.go](../../operator/internal/controller/metrics.go). 
+
+## Skyhook Status Metrics
+ * `skyhook_status` : Binary metric indicating the status of the Skyhook Custom Resource (1 if in that status, 0 otherwise). Tags:
     * `skyhook_name` : The name of the Skyhook Custom Resource
- * `skyhook_[complete|disabled|pause]_count` : A 1 or 0 for if a given SCR is in this state
- * `skyhook_package_*` : Can be used to track the progress of packages through a deployment. Tags:
-    * `skyhook_name` : The of the SCR the package belongs to
+    * `status` : One of complete, disabled, paused
+
+## Node Metrics
+ * `skyhook_node_status_count` : Number of nodes in the cluster by status for the Skyhook Custom Resource. Tags:
+    * `skyhook_name` : The name of the Skyhook Custom Resource
+    * `status` : One of complete, in_progress, erroring, blocked, waiting
+ * `skyhook_node_target_count` : Total number of nodes targeted by this Skyhook Custom Resource. Tags:
+    * `skyhook_name` : The name of the Skyhook Custom Resource
+
+## Package Metrics
+ * `skyhook_package_state_count` : Number of nodes in the cluster by state for this package. Tags:
+    * `skyhook_name` : The name of the SCR the package belongs to
     * `package_name` : The name of the package
     * `package_version`: The version of the package
- * `skyhook_package_stage_count` : Allows the tracking of a package's lifecyle. Tags:
-    * `skyhook_name` : The of the SCR the package belongs to
+    * `state` : One of complete, in_progress, skipped, erroring, unknown
+ * `skyhook_package_stage_count` : Number of nodes in the cluster by stage for this package. Tags:
+    * `skyhook_name` : The name of the SCR the package belongs to
     * `package_name` : The name of the package
     * `package_version`: The version of the package
-    * `stage` : One of apply, conifg, interrupt, post_interrupt, uninstall
-* `skyhook_package_restart-count`: Sum of restarts across all nodes for this package
-    * `skyhook_name` : The of the SCR the package belongs to
+    * `stage` : One of apply, config, interrupt, post_interrupt, uninstall, upgrade
+ * `skyhook_package_restarts_count`: Number of restarts for this package on this node. Tags:
+    * `skyhook_name` : The name of the SCR the package belongs to
     * `package_name` : The name of the package
     * `package_version`: The version of the package
 

--- a/k8s-tests/chainsaw/skyhook/delete-skyhook/chainsaw-test.yaml
+++ b/k8s-tests/chainsaw/skyhook/delete-skyhook/chainsaw-test.yaml
@@ -36,10 +36,10 @@ spec:
     - script:
         content: |
           ../metrics_test.py skyhook_node_target_count 1 -t skyhook_name=delete-skyhook
-          ../metrics_test.py skyhook_node_complete_count 1 -t skyhook_name=delete-skyhook
-          ../metrics_test.py skyhook_package_complete_count 1 -t package_name=dexter -t skyhook_name=delete-skyhook
-          ../metrics_test.py skyhook_package_complete_count 1 -t package_name=spencer -t skyhook_name=delete-skyhook
-          ../metrics_test.py skyhook_package_complete_count 1 -t package_name=foobar -t skyhook_name=delete-skyhook
+          ../metrics_test.py skyhook_node_status_count 1 -t skyhook_name=delete-skyhook -t status=complete
+          ../metrics_test.py skyhook_package_state_count 1 -t package_name=dexter -t skyhook_name=delete-skyhook -t state=complete
+          ../metrics_test.py skyhook_package_state_count 1 -t package_name=spencer -t skyhook_name=delete-skyhook -t state=complete
+          ../metrics_test.py skyhook_package_state_count 1 -t package_name=foobar -t skyhook_name=delete-skyhook -t state=complete
           ../metrics_test.py skyhook_package_stage_count 1 -t package_name=dexter -t skyhook_name=delete-skyhook -t stage=config
           ../metrics_test.py skyhook_package_stage_count 1 -t package_name=spencer -t skyhook_name=delete-skyhook -t stage=config
           ../metrics_test.py skyhook_package_stage_count 1 -t package_name=foobar -t skyhook_name=delete-skyhook -t stage=config
@@ -48,10 +48,10 @@ spec:
     - script:
         content: |
           ../metrics_test.py skyhook_node_target_count 1 -t skyhook_name=delete-skyhook --not-found
-          ../metrics_test.py skyhook_node_complete_count 1 -t skyhook_name=delete-skyhook --not-found
-          ../metrics_test.py skyhook_package_complete_count 1 -t package_name=dexter -t skyhook_name=delete-skyhook --not-found
-          ../metrics_test.py skyhook_package_complete_count 1 -t package_name=spencer -t skyhook_name=delete-skyhook --not-found
-          ../metrics_test.py skyhook_package_complete_count 1 -t package_name=foobar -t skyhook_name=delete-skyhook --not-found
+          ../metrics_test.py skyhook_node_status_count 1 -t skyhook_name=delete-skyhook -t status=complete --not-found
+          ../metrics_test.py skyhook_package_state_count 1 -t package_name=dexter -t skyhook_name=delete-skyhook -t state=complete --not-found
+          ../metrics_test.py skyhook_package_state_count 1 -t package_name=spencer -t skyhook_name=delete-skyhook -t state=complete --not-found
+          ../metrics_test.py skyhook_package_state_count 1 -t package_name=foobar -t skyhook_name=delete-skyhook -t state=complete --not-found
           ../metrics_test.py skyhook_package_stage_count 1 -t package_name=dexter -t skyhook_name=delete-skyhook -t stage=config --not-found
           ../metrics_test.py skyhook_package_stage_count 1 -t package_name=spencer -t skyhook_name=delete-skyhook -t stage=config --not-found
           ../metrics_test.py skyhook_package_stage_count 1 -t package_name=foobar -t skyhook_name=delete-skyhook -t stage=config --not-found

--- a/k8s-tests/chainsaw/skyhook/failure-skyhook/chainsaw-test.yaml
+++ b/k8s-tests/chainsaw/skyhook/failure-skyhook/chainsaw-test.yaml
@@ -46,9 +46,9 @@ spec:
         file: node-assert.yaml
     - script:
         content: |
-          ../metrics_test.py skyhook_package_restarts_count 0 -t package_name=failure -t skyhook_name=failure-skyhook --not-found
-          ../metrics_test.py skyhook_node_error_count 1 -t skyhook_name=failure-skyhook
-          ../metrics_test.py skyhook_node_complete_count 0 -t skyhook_name=failure-skyhook
-          ../metrics_test.py skyhook_package_error_count 1 -t package_name=failure -t skyhook_name=failure-skyhook
-          ../metrics_test.py skyhook_package_complete_count 0 -t package_name=failure -t skyhook_name=failure-skyhook
-          ../metrics_test.py skyhook_package_complete_count 1 -t package_name=dexter -t skyhook_name=failure-skyhook
+          ../metrics_test.py skyhook_node_target_count 1 -t skyhook_name=failure-skyhook
+          ../metrics_test.py skyhook_node_status_count 1 -t skyhook_name=failure-skyhook -t status=erroring
+          ../metrics_test.py skyhook_package_state_count 1 -t package_name=dexter -t skyhook_name=failure-skyhook -t state=complete
+          ../metrics_test.py skyhook_package_state_count 1 -t package_name=failure -t skyhook_name=failure-skyhook -t state=erroring
+          ../metrics_test.py skyhook_package_stage_count 1 -t package_name=dexter -t skyhook_name=failure-skyhook -t stage=config
+          ../metrics_test.py skyhook_package_stage_count 1 -t package_name=failure -t skyhook_name=failure-skyhook -t stage=apply

--- a/k8s-tests/chainsaw/skyhook/metrics_test.txt
+++ b/k8s-tests/chainsaw/skyhook/metrics_test.txt
@@ -16,21 +16,23 @@ skyhook_node_in_progress_count{skyhook_name="simple-skyhook"} 1
 # HELP skyhook_node_target_count Number of nodes in the cluster that the Skyhook Custom Resource is targeting
 # TYPE skyhook_node_target_count gauge
 skyhook_node_target_count{skyhook_name="simple-skyhook"} 1
-# HELP skyhook_package_complete_count Number of nodes in the cluster that have applied this package
-# TYPE skyhook_package_complete_count gauge
-skyhook_package_complete_count{package_name="dexter",package_version="1.2.3",skyhook_name="simple-skyhook"} 1
-skyhook_package_complete_count{package_name="foobar",package_version="1.2",skyhook_name="simple-skyhook"} 0
-skyhook_package_complete_count{package_name="spencer",package_version="3.2.3",skyhook_name="simple-skyhook"} 0
-# HELP skyhook_package_error_count Number of nodes in the cluster that have failed to apply this package
-# TYPE skyhook_package_error_count gauge
-skyhook_package_error_count{package_name="dexter",package_version="1.2.3",skyhook_name="simple-skyhook"} 0
-skyhook_package_error_count{package_name="foobar",package_version="1.2",skyhook_name="simple-skyhook"} 0
-skyhook_package_error_count{package_name="spencer",package_version="3.2.3",skyhook_name="simple-skyhook"} 0
-# HELP skyhook_package_in_progress_count Number of nodes in the cluster that are in progress for this package
-# TYPE skyhook_package_in_progress_count gauge
-skyhook_package_in_progress_count{package_name="dexter",package_version="1.2.3",skyhook_name="simple-skyhook"} 0
-skyhook_package_in_progress_count{package_name="foobar",package_version="1.2",skyhook_name="simple-skyhook"} 1
-skyhook_package_in_progress_count{package_name="spencer",package_version="3.2.3",skyhook_name="simple-skyhook"} 1
+# HELP skyhook_package_state_count Number of nodes in the cluster by state for this package
+# TYPE skyhook_package_state_count gauge
+skyhook_package_state_count{package_name="dexter",package_version="1.2.3",skyhook_name="simple-skyhook",state="complete"} 1
+skyhook_package_state_count{package_name="dexter",package_version="1.2.3",skyhook_name="simple-skyhook",state="erroring"} 0
+skyhook_package_state_count{package_name="dexter",package_version="1.2.3",skyhook_name="simple-skyhook",state="in_progress"} 0
+skyhook_package_state_count{package_name="dexter",package_version="1.2.3",skyhook_name="simple-skyhook",state="skipped"} 0
+skyhook_package_state_count{package_name="dexter",package_version="1.2.3",skyhook_name="simple-skyhook",state="unknown"} 0
+skyhook_package_state_count{package_name="foobar",package_version="1.2",skyhook_name="simple-skyhook",state="complete"} 0
+skyhook_package_state_count{package_name="foobar",package_version="1.2",skyhook_name="simple-skyhook",state="erroring"} 0
+skyhook_package_state_count{package_name="foobar",package_version="1.2",skyhook_name="simple-skyhook",state="in_progress"} 1
+skyhook_package_state_count{package_name="foobar",package_version="1.2",skyhook_name="simple-skyhook",state="skipped"} 0
+skyhook_package_state_count{package_name="foobar",package_version="1.2",skyhook_name="simple-skyhook",state="unknown"} 0
+skyhook_package_state_count{package_name="spencer",package_version="3.2.3",skyhook_name="simple-skyhook",state="complete"} 0
+skyhook_package_state_count{package_name="spencer",package_version="3.2.3",skyhook_name="simple-skyhook",state="erroring"} 0
+skyhook_package_state_count{package_name="spencer",package_version="3.2.3",skyhook_name="simple-skyhook",state="in_progress"} 1
+skyhook_package_state_count{package_name="spencer",package_version="3.2.3",skyhook_name="simple-skyhook",state="skipped"} 0
+skyhook_package_state_count{package_name="spencer",package_version="3.2.3",skyhook_name="simple-skyhook",state="unknown"} 0
 # HELP skyhook_package_restarts_count Number of restarts for this package
 # TYPE skyhook_package_restarts_count gauge
 skyhook_package_restarts_count{package_name="dexter",package_version="1.2.3",skyhook_name="simple-skyhook"} 0

--- a/k8s-tests/chainsaw/skyhook/simple-skyhook/chainsaw-test.yaml
+++ b/k8s-tests/chainsaw/skyhook/simple-skyhook/chainsaw-test.yaml
@@ -35,24 +35,28 @@ spec:
         file: skyhook.yaml
     - script:
         content: |
-          ../metrics_test.py skyhook_package_in_progress_count 1 -t package_name=dexter -t skyhook_name=simple-skyhook
           ../metrics_test.py skyhook_node_target_count 1 -t skyhook_name=simple-skyhook
-          ../metrics_test.py skyhook_package_in_progress_count 0 -t package_name=spencer -t skyhook_name=simple-skyhook --not-found
-          ../metrics_test.py skyhook_package_in_progress_count 0 -t package_name=foobar -t skyhook_name=simple-skyhook --not-found
+          ../metrics_test.py skyhook_package_state_count 1 -t package_name=dexter -t skyhook_name=simple-skyhook -t state=in_progress
+          ../metrics_test.py skyhook_package_stage_count 1 -t package_name=dexter -t skyhook_name=simple-skyhook -t stage=config
     - assert:
         file: assert_pods.yaml
     - script:
         content: |
-          ../metrics_test.py skyhook_package_complete_count 1 -t package_name=dexter -t skyhook_name=simple-skyhook
-          ../metrics_test.py skyhook_package_in_progress_count 1 -t package_name=spencer -t skyhook_name=simple-skyhook
-          ../metrics_test.py skyhook_package_in_progress_count 1 -t package_name=foobar -t skyhook_name=simple-skyhook
+          ../metrics_test.py skyhook_package_state_count 1 -t package_name=dexter -t skyhook_name=simple-skyhook -t state=complete
+          ../metrics_test.py skyhook_package_state_count 1 -t package_name=spencer -t skyhook_name=simple-skyhook -t state=in_progress
+          ../metrics_test.py skyhook_package_state_count 1 -t package_name=foobar -t skyhook_name=simple-skyhook -t state=in_progress
+          ../metrics_test.py skyhook_package_stage_count 1 -t package_name=dexter -t skyhook_name=simple-skyhook -t stage=config
+          ../metrics_test.py skyhook_package_stage_count 1 -t package_name=spencer -t skyhook_name=simple-skyhook -t stage=config
+          ../metrics_test.py skyhook_package_stage_count 1 -t package_name=foobar -t skyhook_name=simple-skyhook -t stage=config
     - assert:
         file: assert.yaml
     - script:
         content: |
-          ../metrics_test.py skyhook_package_complete_count 1 -t package_name=spencer -t skyhook_name=simple-skyhook
-          ../metrics_test.py skyhook_package_complete_count 1 -t package_name=foobar -t skyhook_name=simple-skyhook
-          ../metrics_test.py skyhook_node_complete_count 1 -t skyhook_name=simple-skyhook
+          ../metrics_test.py skyhook_node_status_count 1 -t skyhook_name=simple-skyhook -t status=complete
+          ../metrics_test.py skyhook_package_state_count 1 -t package_name=spencer -t skyhook_name=simple-skyhook -t state=complete
+          ../metrics_test.py skyhook_package_state_count 1 -t package_name=foobar -t skyhook_name=simple-skyhook -t state=complete
+          ../metrics_test.py skyhook_package_stage_count 1 -t package_name=spencer -t skyhook_name=simple-skyhook -t stage=config
+          ../metrics_test.py skyhook_package_stage_count 1 -t package_name=foobar -t skyhook_name=simple-skyhook -t stage=config
   - finally:
     - delete:
         file: limitrange.yaml

--- a/k8s-tests/chainsaw/skyhook/strict_order/chainsaw-test.yaml
+++ b/k8s-tests/chainsaw/skyhook/strict_order/chainsaw-test.yaml
@@ -42,16 +42,21 @@ spec:
         file: skyhook.yaml
     - script:
         content: |
-          ../metrics_test.py skyhook_disabled_count 1 -t skyhook_name=strict-order-skyhook-d
-          ../metrics_test.py skyhook_paused_count 1 -t skyhook_name=strict-order-skyhook-b
-          ../metrics_test.py skyhook_node_in_progress_count 1 -t skyhook_name=strict-order-skyhook-zzz
+          ../metrics_test.py skyhook_node_target_count 1 -t skyhook_name=strict-order-skyhook-d
+          ../metrics_test.py skyhook_node_target_count 1 -t skyhook_name=strict-order-skyhook-b
+          ../metrics_test.py skyhook_node_target_count 1 -t skyhook_name=strict-order-skyhook-zzz
+          ../metrics_test.py skyhook_status 1 -t skyhook_name=strict-order-skyhook-d -t status=disabled
+          ../metrics_test.py skyhook_status 1 -t skyhook_name=strict-order-skyhook-b -t status=paused
+          ../metrics_test.py skyhook_status 1 -t skyhook_name=strict-order-skyhook-c -t status=waiting
+          ../metrics_test.py skyhook_node_status_count 1 -t skyhook_name=strict-order-skyhook-zzz -t status=in_progress
     - assert:
         file: assert-a.yaml
     - script:
         content: |
-          ../metrics_test.py skyhook_node_in_progress_count 0 -t skyhook_name=strict-order-skyhook-zzz
-          ../metrics_test.py skyhook_node_complete_count 1 -t skyhook_name=strict-order-skyhook-zzz
-          ../metrics_test.py skyhook_package_complete_count 1 -t package_name=foobar -t package_version=1.2 -t skyhook_name=strict-order-skyhook-zzz
+          ../metrics_test.py skyhook_node_status_count 0 -t skyhook_name=strict-order-skyhook-zzz -t status=in_progress
+          ../metrics_test.py skyhook_node_status_count 1 -t skyhook_name=strict-order-skyhook-zzz -t status=complete
+          ../metrics_test.py skyhook_status 1 -t skyhook_name=strict-order-skyhook-c -t status=waiting
+          ../metrics_test.py skyhook_package_state_count 1 -t package_name=foobar -t package_version=1.2 -t skyhook_name=strict-order-skyhook-zzz -t state=complete
           ../metrics_test.py skyhook_package_stage_count 1 -t package_name=foobar -t package_version=1.2 -t skyhook_name=strict-order-skyhook-zzz -t stage=config
     # make sure that if it was going to start b it will start b
     - sleep:
@@ -65,10 +70,10 @@ spec:
         file: assert-b.yaml
     - script:
         content: |
-          ../metrics_test.py skyhook_node_in_progress_count 1 -t skyhook_name=strict-order-skyhook-c
-          ../metrics_test.py skyhook_node_complete_count 1 -t skyhook_name=strict-order-skyhook-b
-          ../metrics_test.py skyhook_disabled_count 1 -t skyhook_name=strict-order-skyhook-d
-          ../metrics_test.py skyhook_paused_count 0 -t skyhook_name=strict-order-skyhook-b
+          ../metrics_test.py skyhook_node_status_count 1 -t skyhook_name=strict-order-skyhook-c -t status=in_progress
+          ../metrics_test.py skyhook_node_status_count 1 -t skyhook_name=strict-order-skyhook-b -t status=complete
+          ../metrics_test.py skyhook_status 1 -t skyhook_name=strict-order-skyhook-d -t status=disabled
+          ../metrics_test.py skyhook_status 0 -t skyhook_name=strict-order-skyhook-b -t status=paused
     - assert:
         file: assert-c.yaml
     - assert:
@@ -84,7 +89,7 @@ spec:
         file: skyhook-disable-update.yaml
     - script:
         content: |
-          ../metrics_test.py skyhook_node_in_progress_count 1 -t skyhook_name=strict-order-skyhook-d
-          ../metrics_test.py skyhook_disabled_count 0 -t skyhook_name=strict-order-skyhook-d
+          ../metrics_test.py skyhook_node_status_count 1 -t skyhook_name=strict-order-skyhook-d -t status=in_progress
+          ../metrics_test.py skyhook_status 1 -t skyhook_name=strict-order-skyhook-d -t status=disabled --not-found
     - assert:
         file: assert-e.yaml

--- a/k8s-tests/chainsaw/skyhook/taint-scheduling/chainsaw-test.yaml
+++ b/k8s-tests/chainsaw/skyhook/taint-scheduling/chainsaw-test.yaml
@@ -47,14 +47,18 @@ spec:
         file: assert.yaml
     - script:
         content: |
-          ../metrics_test.py skyhook_node_taint_tolerance_issue_count 1 -t skyhook_name=taint-scheduling
+          ../metrics_test.py skyhook_node_target_count 1 -t skyhook_name=taint-scheduling
+          ../metrics_test.py skyhook_node_status_count 1 -t skyhook_name=taint-scheduling -t status=blocked
+          ../metrics_test.py skyhook_node_status_count 1 -t skyhook_name=taint-scheduling -t status=blocked
     - patch:
         file: update-skyhook.yaml
     - assert:
         file: assert-update.yaml
     - script:
         content: |
-          ../metrics_test.py skyhook_node_taint_tolerance_issue_count 0 -t skyhook_name=taint-scheduling
+          ../metrics_test.py skyhook_node_target_count 1 -t skyhook_name=taint-scheduling
+          ../metrics_test.py skyhook_node_status_count 1 -t skyhook_name=taint-scheduling -t status=complete
+          ../metrics_test.py skyhook_node_status_count 0 -t skyhook_name=taint-scheduling -t status=blocked
     finally:
     - script:
         content: |

--- a/operator/api/v1alpha1/skyhook_types.go
+++ b/operator/api/v1alpha1/skyhook_types.go
@@ -596,8 +596,6 @@ const (
 	StateUnknown    State  = "unknown"
 )
 
-type Status string
-
 var (
 	States = []State{
 		StateComplete,
@@ -608,8 +606,21 @@ var (
 	}
 )
 
-// TODO: seems like we might be missing a waiting or queued status for nodes, not sure it makes sense at the upper level
-// unless we add a limit of number parallel packages, might be another good idea.
+type Status string
+
+var (
+	Statuses = []Status{
+		StatusComplete,
+		StatusBlocked,
+		StatusWaiting,
+		StatusDisabled,
+		StatusPaused,
+		StatusInProgress,
+		StatusErroring,
+		StatusUnknown,
+	}
+)
+
 const (
 	StatusComplete   Status = "complete"
 	StatusBlocked    Status = "blocked"

--- a/operator/internal/controller/metrics.go
+++ b/operator/internal/controller/metrics.go
@@ -25,160 +25,147 @@ import (
 )
 
 var (
+	// skyhook metrics
+	skyhook_status = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "skyhook_status",
+			Help: "Binary metric indicating the status of the Skyhook Custom Resource (1 if in that status, 0 otherwise)",
+		},
+		[]string{"skyhook_name", "status"},
+	)
+
+	// node metrics
+	skyhook_node_status_count = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "skyhook_node_status_count",
+			Help: "Number of nodes in the cluster by status for the Skyhook Custom Resource",
+		},
+		[]string{"skyhook_name", "status"},
+	)
+
 	skyhook_node_target_count = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "skyhook_node_target_count",
-			Help: "Number of nodes in the cluster that the Skyhook Custom Resource is targeting",
+			Help: "Total number of nodes targeted by this Skyhook Custom Resource",
 		},
 		[]string{"skyhook_name"},
 	)
 
-	skyhook_node_in_progress_count = prometheus.NewGaugeVec(
+	// package metrics
+	skyhook_package_state_count = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "skyhook_node_in_progress_count",
-			Help: "Number of nodes in the cluster that the Skyhook Custom Resource is currently working on",
+			Name: "skyhook_package_state_count",
+			Help: "Number of nodes in the cluster by state for this package",
 		},
-		[]string{"skyhook_name"},
+		[]string{"skyhook_name", "package_name", "package_version", "state"},
 	)
 
-	skyhook_node_complete_count = prometheus.NewGaugeVec(
+	skyhook_package_stage_count = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "skyhook_node_complete_count",
-			Help: "Number of nodes in the cluster that the Skyhook Custom Resource has finished working on",
+			Name: "skyhook_package_stage_count",
+			Help: "Number of nodes in the cluster by stage for this package",
 		},
-		[]string{"skyhook_name"},
-	)
-
-	skyhook_node_error_count = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "skyhook_node_error_count",
-			Help: "Number of nodes in the cluster that the Skyhook Custom Resource is erroring on",
-		},
-		[]string{"skyhook_name"},
-	)
-
-	skyhook_node_blocked_count = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "skyhook_node_blocked_count",
-			Help: "Number of nodes in the cluster that the Skyhook Custom Resource is blocked",
-		},
-		[]string{"skyhook_name"},
-	)
-
-	skyhook_complete_count = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "skyhook_complete_count",
-			Help: "A binary metric that is 1 if the Skyhook Custom Resource is complete, 0 otherwise",
-		},
-		[]string{"skyhook_name"},
-	)
-
-	skyhook_paused_count = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "skyhook_paused_count",
-			Help: "A binary metric that is 1 if the Skyhook Custom Resource is paused, 0 otherwise",
-		},
-		[]string{"skyhook_name"},
-	)
-
-	skyhook_disabled_count = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "skyhook_disabled_count",
-			Help: "A binary metric that is 1 if the Skyhook Custom Resource is disabled, 0 otherwise",
-		},
-		[]string{"skyhook_name"},
-	)
-
-	skyhook_package_in_progress_count = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "skyhook_package_in_progress_count",
-			Help: "Number of nodes in the cluster that are in progress for this package",
-		},
-		[]string{"skyhook_name", "package_name", "package_version"},
-	)
-
-	skyhook_package_error_count = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "skyhook_package_error_count",
-			Help: "Number of nodes in the cluster that have failed to apply this package",
-		},
-		[]string{"skyhook_name", "package_name", "package_version"},
-	)
-
-	skyhook_package_complete_count = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "skyhook_package_complete_count",
-			Help: "Number of nodes in the cluster that have applied this package",
-		},
-		[]string{"skyhook_name", "package_name", "package_version"},
+		[]string{"skyhook_name", "package_name", "package_version", "stage"},
 	)
 
 	skyhook_package_restarts_count = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "skyhook_package_restarts_count",
-			Help: "Number of restarts for this package",
+			Help: "Number of restarts for this package on this node",
 		},
 		[]string{"skyhook_name", "package_name", "package_version"},
-	)
-
-	// This should maybe a counter but ensuring the decrement is done correctly is tricky
-	skyhook_package_stage_count = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "skyhook_package_stage_count",
-			Help: "Number of nodes in the cluster that are in this stage for this package",
-		},
-		[]string{"skyhook_name", "package_name", "package_version", "stage"},
-	)
-
-	skyhook_node_taint_tolerance_issue_count = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "skyhook_node_taint_tolerance_issue_count",
-			Help: "Number of nodes in the cluster that have taint tolerance issues",
-		},
-		[]string{"skyhook_name"},
 	)
 )
 
 func zeroOutSkyhookMetrics(skyhook SkyhookNodes) {
-	skyhook_complete_count.DeleteLabelValues(skyhook.GetSkyhook().Name)
-	skyhook_paused_count.DeleteLabelValues(skyhook.GetSkyhook().Name)
-	skyhook_disabled_count.DeleteLabelValues(skyhook.GetSkyhook().Name)
-	skyhook_node_target_count.DeleteLabelValues(skyhook.GetSkyhook().Name)
-	skyhook_node_in_progress_count.DeleteLabelValues(skyhook.GetSkyhook().Name)
-	skyhook_node_complete_count.DeleteLabelValues(skyhook.GetSkyhook().Name)
-	skyhook_node_error_count.DeleteLabelValues(skyhook.GetSkyhook().Name)
-	skyhook_node_blocked_count.DeleteLabelValues(skyhook.GetSkyhook().Name)
-	skyhook_node_taint_tolerance_issue_count.DeleteLabelValues(skyhook.GetSkyhook().Name)
+	skyhookName := skyhook.GetSkyhook().Name
+
+	// Clean up node status metrics
+	for _, status := range v1alpha1.Statuses {
+		skyhook_node_status_count.DeleteLabelValues(skyhookName, string(status))
+	}
+
+	// Clean up target count metric
+	skyhook_node_target_count.DeleteLabelValues(skyhookName)
+
+	// Clean up skyhook state metrics
+	for _, status := range v1alpha1.Statuses {
+		skyhook_status.DeleteLabelValues(skyhookName, string(status))
+	}
+
 	for _, _package := range skyhook.GetSkyhook().Spec.Packages {
 		zeroOutSkyhookPackageMetrics(skyhook.GetSkyhook().Name, _package.Name, _package.Version)
 	}
 }
 
 func zeroOutSkyhookPackageMetrics(skyhookName, packageName, packageVersion string) {
-	skyhook_package_in_progress_count.DeleteLabelValues(skyhookName, packageName, packageVersion)
-	skyhook_package_error_count.DeleteLabelValues(skyhookName, packageName, packageVersion)
-	skyhook_package_complete_count.DeleteLabelValues(skyhookName, packageName, packageVersion)
 	skyhook_package_restarts_count.DeleteLabelValues(skyhookName, packageName, packageVersion)
+
+	for _, state := range v1alpha1.States {
+		skyhook_package_state_count.DeleteLabelValues(skyhookName, packageName, packageVersion, string(state))
+	}
+
 	for _, stage := range v1alpha1.Stages {
 		skyhook_package_stage_count.DeleteLabelValues(skyhookName, packageName, packageVersion, string(stage))
 	}
 }
 
+func ResetSkyhookMetricsToZero(skyhook SkyhookNodes) {
+	skyhookName := skyhook.GetSkyhook().Name
+
+	for _, status := range v1alpha1.Statuses {
+		SetNodeStatusMetrics(skyhookName, status, 0)
+	}
+
+	for _, status := range v1alpha1.Statuses {
+		SetSkyhookStatusMetrics(skyhookName, status, false)
+	}
+
+	for _, pkg := range skyhook.GetSkyhook().Spec.Packages {
+		for _, state := range v1alpha1.States {
+			SetPackageStateMetrics(skyhookName, pkg.Name, pkg.Version, state, 0)
+		}
+		for _, stage := range v1alpha1.Stages {
+			SetPackageStageMetrics(skyhookName, pkg.Name, pkg.Version, stage, 0)
+		}
+	}
+}
+
+func SetNodeStatusMetrics(skyhookName string, status v1alpha1.Status, count float64) {
+	skyhook_node_status_count.WithLabelValues(skyhookName, string(status)).Set(count)
+}
+
+func SetSkyhookStatusMetrics(skyhookName string, state v1alpha1.Status, active bool) {
+	value := float64(0)
+	if active {
+		value = 1
+	}
+	skyhook_status.WithLabelValues(skyhookName, string(state)).Set(value)
+}
+
+func SetPackageStateMetrics(skyhookName, packageName, packageVersion string, state v1alpha1.State, count float64) {
+	skyhook_package_state_count.WithLabelValues(skyhookName, packageName, packageVersion, string(state)).Set(count)
+}
+
+func SetPackageStageMetrics(skyhookName, packageName, packageVersion string, stage v1alpha1.Stage, count float64) {
+	skyhook_package_stage_count.WithLabelValues(skyhookName, packageName, packageVersion, string(stage)).Set(count)
+}
+
+func SetPackageRestartsMetrics(skyhookName, packageName, packageVersion string, restarts int32) {
+	skyhook_package_restarts_count.WithLabelValues(skyhookName, packageName, packageVersion).Set(float64(restarts))
+}
+
+func SetNodeTargetCountMetrics(skyhookName string, count float64) {
+	skyhook_node_target_count.WithLabelValues(skyhookName).Set(count)
+}
+
 func init() {
 	metrics.Registry.MustRegister(
+		skyhook_status,
+		skyhook_node_status_count,
 		skyhook_node_target_count,
-		skyhook_node_in_progress_count,
-		skyhook_node_complete_count,
-		skyhook_node_error_count,
-		skyhook_node_blocked_count,
-		skyhook_complete_count,
-		skyhook_paused_count,
-		skyhook_disabled_count,
-		skyhook_package_in_progress_count,
-		skyhook_package_error_count,
-		skyhook_package_complete_count,
+		skyhook_package_state_count,
 		skyhook_package_stage_count,
 		skyhook_package_restarts_count,
-		skyhook_node_taint_tolerance_issue_count,
 	)
 }

--- a/operator/internal/controller/skyhook_controller.go
+++ b/operator/internal/controller/skyhook_controller.go
@@ -1939,19 +1939,6 @@ func (r *SkyhookReconciler) ValidateRunningPackages(ctx context.Context, skyhook
 		}
 	}
 
-	// update the metrics for each package, version, and stage
-	for package_name, package_map := range stages {
-		for version, stage_counts := range package_map {
-			for stage, count := range stage_counts {
-				skyhook_package_stage_count.WithLabelValues(
-					skyhook.GetSkyhook().Name,
-					package_name,
-					version,
-					string(stage)).Set(float64(count))
-			}
-		}
-	}
-
 	return update, utilerrors.NewAggregate(errs)
 }
 


### PR DESCRIPTION
# **Updated Skyhook Metrics**

## Overview
This PR introduces improvements to Skyhook's metrics system, providing the ability to monitor Skyhook Custom Resources, node states, and package deployment progress across Kubernetes clusters.

## **Key Changes**

### **Metrics Improvements**
- **updated metric definitions** in `operator/internal/controller/metrics.go`
- **consolidated node status tracking** using `skyhook_node_status_count` with status labels
- **enhanced package metrics** with detailed state and stage tracking

### **New Metrics Added**
- `skyhook_status` - binary status indicator for Skyhook Custom Resources
- `skyhook_node_status_count` - node counts by status (complete, in_progress, erroring, blocked, waiting)
- `skyhook_node_target_count` - total targeted nodes per Skyhook
- `skyhook_package_state_count` - package state tracking across nodes
- `skyhook_package_stage_count` - package stage progression monitoring
- `skyhook_package_restarts_count` - package restart tracking for reliability monitoring

### **Documentation**
- **restructured metrics documentation** in `docs/metrics/README.md`
- **added comprehensive metric descriptions** with all labels and possible values
- **fixed documentation inconsistencies** and typos

### **Testing**
- **updated test assertions** in k8s-tests to use new metric names
- **metrics validation** in chainsaw tests
