### PR TITLE
fix(agent): Hotfix for interrupts in agent v6.3.0, and updated agent

### DIFF
--- a/containers/agent.Dockerfile
+++ b/containers/agent.Dockerfile
@@ -36,13 +36,13 @@ RUN make build build_version=${AGENT_VERSION}
 # Install the wheel in the builder stage
 RUN python3 -m venv venv && ./venv/bin/pip install /code/skyhook-agent/dist/skyhook_agent*.whl
 
-FROM nvcr.io/nvidia/distroless/python:3.12-v3.4.13
+FROM nvcr.io/nvidia/distroless/python:3.12-v3.4.15
 
 ARG AGENT_VERSION
 ARG GIT_SHA
 
 ## https://github.com/opencontainers/image-spec/blob/main/annotations.md
-LABEL org.opencontainers.image.base.name="nvcr.io/nvidia/distroless/python:3.12-v3.4.13" \
+LABEL org.opencontainers.image.base.name="nvcr.io/nvidia/distroless/python:3.12-v3.4.15" \
       org.opencontainers.image.licenses="Apache-2.0" \
       org.opencontainers.image.title="skyhook-agent" \
       org.opencontainers.image.version="${AGENT_VERSION}" \


### PR DESCRIPTION
# Bugfix: Fix interrupt flag handling and _run call for reboot commands in v6.2.0 and v6.3.0

## Problem
Two critical issues were preventing interrupts from working correctly in the agent versions v6.2.0 and v6.3.0:

1. **Missing arguments in `_run` call**: The `do_interrupt()` function wasn't passing the correct number of arguments to `_run()`, causing interrupts to fail to execute entirely as python would raise a runtime exception.

2. **Incorrect flag deletion for SIGTERM**: After the chroot changes where commands are executed in subprocesses, the `reboot` command was incorrectly having its flags removed. When a reboot command runs in a subprocess, it gets terminated by SIGTERM (return code -15) as the system shuts down, which was being treated as a failure. We weren't accounting for this and were removing the flags everytime a non-zero exit status was returned. This caused reboot interrupts to reboot-loop.

## Root Cause

### _run call issue
The `_run()` function signature requires specific parameters, but `do_interrupt()` wasn't passing them correctly, preventing interrupt commands from executing. Specifically the root_mount wasn't getting passed correctly, and this wasn't properly tested in our unit tests.

### SIGTERM handling issue
The interrupt flag deletion logic wasn't accounting for the fact that:
- Reboot commands would now return -15 (SIGTERM) when the system shuts down as the OS would SIGTERM the process that is running the reboot
- This is expected behavior, not an actual failure
- Removing the flag made it appear the interrupt never ran successfully

## Solution

### Fixed _run call
- Updated `do_interrupt()` to pass the correct arguments to `_run()`
- Ensures interrupt commands can actually execute

### Fixed SIGTERM handling
- Updated the flag deletion logic to preserve interrupt flags when the return code is -15 (SIGTERM) for a reboot
- This ensures:
  - NodeRestart interrupts with -15 return codes keep their flags (successful reboot)
  - Other interrupt types still work as expected
  - Only actual failures (non-SIGTERM exit codes) remove flags

## Changes
- **Modified `controller.py`**: 
  - Fixed `_run()` call in `do_interrupt()` with proper arguments
  - Updated flag deletion condition to `if not (interrupt.type == interrupts.NodeRestart._type() and return_code == -15)`
- **Added comprehensive test coverage**:
  - `test_interrupt_reboot_SIGTERM_preserves_flag` - verifies SIGTERM handling
  - `test_interrupt_calls_run_with_correct_parameters` and changed existing unit tests - verifies that do_interrupt calls `_run` with the correct arguments
- **Updated the agent's base python distroless image for security reasons and NSPECT alerts**

## Testing
- Added test coverage for both the argument passing fix and SIGTERM scenarios
- Verified that interrupts can now execute and handle reboot scenarios correctly
- Verified that other service interrupts still work as expected with these changes