### PR TITLE
feat: add package configuration to node config map

### DIFF
--- a/k8s-tests/chainsaw/skyhook/config-skyhook/assert-update-no-interrupt.yaml
+++ b/k8s-tests/chainsaw/skyhook/config-skyhook/assert-update-no-interrupt.yaml
@@ -138,10 +138,14 @@ metadata:
     kind: Skyhook
     name: config-skyhook
 data:
-  (length(@)): 2
+  (length(@)): 3
   labels.json:
     (contains(@, 'skyhook.nvidia.com/test-node')): true
     (contains(@, 'skyhook.nvidia.com/status_config-skyhook')): true
   annotations.json:
     (contains(@, 'skyhook.nvidia.com/status_config-skyhook')): true
     (contains(@, 'skyhook.nvidia.com/nodeState_config-skyhook')): true
+  packages.json:
+    (contains(@, '"agentVersion"')): true
+    (contains(@, '"dexter"')): true
+    (contains(@, '"3.2.3"')): true

--- a/k8s-tests/chainsaw/skyhook/config-skyhook/assert-update-while-running.yaml
+++ b/k8s-tests/chainsaw/skyhook/config-skyhook/assert-update-while-running.yaml
@@ -147,10 +147,14 @@ metadata:
     kind: Skyhook
     name: config-skyhook
 data:
-  (length(@)): 2
+  (length(@)): 3
   labels.json:
     (contains(@, 'skyhook.nvidia.com/test-node')): true
     (contains(@, 'skyhook.nvidia.com/status_config-skyhook')): true
   annotations.json:
     (contains(@, 'skyhook.nvidia.com/status_config-skyhook')): true
     (contains(@, 'skyhook.nvidia.com/nodeState_config-skyhook')): true
+  packages.json:
+    (contains(@, '"agentVersion"')): true
+    (contains(@, '"dexter"')): true
+    (contains(@, '"3.2.3"')): true

--- a/k8s-tests/chainsaw/skyhook/config-skyhook/assert-update.yaml
+++ b/k8s-tests/chainsaw/skyhook/config-skyhook/assert-update.yaml
@@ -144,10 +144,16 @@ metadata:
     kind: Skyhook
     name: config-skyhook
 data:
-  (length(@)): 2
+  (length(@)): 3
   labels.json:
     (contains(@, 'skyhook.nvidia.com/test-node')): true
     (contains(@, 'skyhook.nvidia.com/status_config-skyhook')): true
   annotations.json:
     (contains(@, 'skyhook.nvidia.com/status_config-skyhook')): true
     (contains(@, 'skyhook.nvidia.com/nodeState_config-skyhook')): true
+  packages.json:
+    (contains(@, '"agentVersion"')): true
+    (contains(@, '"dexter"')): true
+    (contains(@, '"baxter"')): true
+    (contains(@, '"spencer"')): true
+    (contains(@, '"3.2.3"')): true

--- a/k8s-tests/chainsaw/skyhook/config-skyhook/assert.yaml
+++ b/k8s-tests/chainsaw/skyhook/config-skyhook/assert.yaml
@@ -152,10 +152,16 @@ metadata:
     kind: Skyhook
     name: config-skyhook
 data:
-  (length(@)): 2
+  (length(@)): 3
   labels.json:
     (contains(@, 'skyhook.nvidia.com/test-node')): true
     (contains(@, 'skyhook.nvidia.com/status_config-skyhook')): true
   annotations.json:
     (contains(@, 'skyhook.nvidia.com/status_config-skyhook')): true
     (contains(@, 'skyhook.nvidia.com/nodeState_config-skyhook')): true
+  packages.json:
+    (contains(@, '"agentVersion"')): true
+    (contains(@, '"dexter"')): true
+    (contains(@, '"baxter"')): true
+    (contains(@, '"spencer"')): true
+    (contains(@, '"3.2.3"')): true

--- a/k8s-tests/chainsaw/skyhook/delete-skyhook/assert.yaml
+++ b/k8s-tests/chainsaw/skyhook/delete-skyhook/assert.yaml
@@ -124,10 +124,14 @@ metadata:
     kind: Skyhook
     name: delete-skyhook
 data:
-  (length(@)): 2
+  (length(@)): 3
   labels.json:
     (contains(@, 'skyhook.nvidia.com/test-node')): true
     (contains(@, 'skyhook.nvidia.com/status_delete-skyhook')): true
   annotations.json:
     (contains(@, 'skyhook.nvidia.com/status_delete-skyhook')): true
     (contains(@, 'skyhook.nvidia.com/nodeState_delete-skyhook')): true
+  packages.json:
+    (contains(@, '"agentVersion"')): true
+    (contains(@, '"dexter"')): true
+    (contains(@, '"3.2.3"')): true

--- a/k8s-tests/chainsaw/skyhook/interrupt-grouping/assert.yaml
+++ b/k8s-tests/chainsaw/skyhook/interrupt-grouping/assert.yaml
@@ -229,10 +229,13 @@ metadata:
     kind: Skyhook
     name: interrupt-grouping
 data:
-  (length(@)): 2
+  (length(@)): 3
   labels.json:
     (contains(@, 'skyhook.nvidia.com/test-node')): true
     (contains(@, 'skyhook.nvidia.com/status_interrupt-grouping')): true
   annotations.json:
     (contains(@, 'skyhook.nvidia.com/status_interrupt-grouping')): true
     (contains(@, 'skyhook.nvidia.com/nodeState_interrupt-grouping')): true
+  packages.json:
+    (contains(@, '"agentVersion"')): true
+    (contains(@, '"dax"')): true

--- a/k8s-tests/chainsaw/skyhook/interrupt/assert-b.yaml
+++ b/k8s-tests/chainsaw/skyhook/interrupt/assert-b.yaml
@@ -260,10 +260,13 @@ metadata:
     kind: Skyhook
     name: interrupt
 data:
-  (length(@)): 2
+  (length(@)): 3
   labels.json:
     (contains(@, 'skyhook.nvidia.com/test-node')): true
     (contains(@, 'skyhook.nvidia.com/status_interrupt')): true
   annotations.json:
     (contains(@, 'skyhook.nvidia.com/status_interrupt')): true
     (contains(@, 'skyhook.nvidia.com/nodeState_interrupt')): true
+  packages.json:
+    (contains(@, '"agentVersion"')): true
+    (contains(@, '"dexter"')): true

--- a/k8s-tests/chainsaw/skyhook/simple-skyhook/assert.yaml
+++ b/k8s-tests/chainsaw/skyhook/simple-skyhook/assert.yaml
@@ -124,10 +124,13 @@ metadata:
     kind: Skyhook
     name: simple-skyhook
 data:
-  (length(@)): 2
+  (length(@)): 3
   labels.json:
     (contains(@, 'skyhook.nvidia.com/test-node')): true
     (contains(@, 'skyhook.nvidia.com/status_simple-skyhook')): true
   annotations.json:
     (contains(@, 'skyhook.nvidia.com/status_simple-skyhook')): true
     (contains(@, 'skyhook.nvidia.com/nodeState_simple-skyhook')): true
+  packages.json:
+    (contains(@, '"agentVersion"')): true
+    (contains(@, '"dexter"')): true

--- a/k8s-tests/chainsaw/skyhook/simple-update-skyhook/assert-update.yaml
+++ b/k8s-tests/chainsaw/skyhook/simple-update-skyhook/assert-update.yaml
@@ -151,10 +151,14 @@ metadata:
     kind: Skyhook
     name: simple-update-skyhook
 data:
-  (length(@)): 2
+  (length(@)): 3
   labels.json:
     (contains(@, 'skyhook.nvidia.com/test-node')): true
     (contains(@, 'skyhook.nvidia.com/status_simple-update-skyhook')): true
   annotations.json:
     (contains(@, 'skyhook.nvidia.com/status_simple-update-skyhook')): true
     (contains(@, 'skyhook.nvidia.com/nodeState_simple-update-skyhook')): true
+  packages.json:
+    (contains(@, '"agentVersion"')): true
+    (contains(@, '"baxter"')): true
+    (contains(@, '"2.3.1-test"')): true

--- a/k8s-tests/chainsaw/skyhook/simple-update-skyhook/assert.yaml
+++ b/k8s-tests/chainsaw/skyhook/simple-update-skyhook/assert.yaml
@@ -129,10 +129,14 @@ metadata:
     kind: Skyhook
     name: simple-update-skyhook
 data:
-  (length(@)): 2
+  (length(@)): 3
   labels.json:
     (contains(@, 'skyhook.nvidia.com/test-node')): true
     (contains(@, 'skyhook.nvidia.com/status_simple-update-skyhook')): true
   annotations.json:
     (contains(@, 'skyhook.nvidia.com/status_simple-update-skyhook')): true
     (contains(@, 'skyhook.nvidia.com/nodeState_simple-update-skyhook')): true
+  packages.json:
+    (contains(@, '"agentVersion"')): true
+    (contains(@, '"dexter"')): true
+    (contains(@, '"1.2.3"')): true

--- a/operator/internal/controller/skyhook_metadata.go
+++ b/operator/internal/controller/skyhook_metadata.go
@@ -1,0 +1,67 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controller
+
+import (
+	"encoding/json"
+
+	"github.com/NVIDIA/skyhook/operator/api/v1alpha1"
+	"github.com/NVIDIA/skyhook/operator/internal/wrapper"
+)
+
+// PackageMetadata defines the intermediary contract for a single package that the agent can consume
+type PackageMetadata struct {
+	Name               string                        `json:"name"`
+	Version            string                        `json:"version"`
+	Image              string                        `json:"image"`
+	AgentImageOverride string                        `json:"agentImageOverride,omitempty"`
+	Interrupt          *v1alpha1.Interrupt           `json:"interrupt,omitempty"`
+	ConfigInterrupts   map[string]v1alpha1.Interrupt `json:"configInterrupts,omitempty"`
+}
+
+// SkyhookMetadata defines the node metadata contract exposed to the agent
+type SkyhookMetadata struct {
+	AgentVersion string                     `json:"agentVersion"`
+	Packages     map[string]PackageMetadata `json:"packages"`
+}
+
+// NewSkyhookMetadata builds the intermediary SkyhookMetadata from the CR spec and operator options
+func NewSkyhookMetadata(opts SkyhookOperatorOptions, s *wrapper.Skyhook) SkyhookMetadata {
+	packages := make(map[string]PackageMetadata)
+	for name, p := range s.Spec.Packages {
+		packages[name] = PackageMetadata{
+			Name:               p.Name,
+			Version:            p.Version,
+			Image:              p.Image,
+			AgentImageOverride: p.AgentImageOverride,
+			Interrupt:          p.Interrupt,
+			ConfigInterrupts:   p.ConfigInterrupts,
+		}
+	}
+
+	return SkyhookMetadata{
+		AgentVersion: opts.AgentVersion(),
+		Packages:     packages,
+	}
+}
+
+// Marshal returns the JSON encoding for inclusion in the node metadata configmap
+func (m SkyhookMetadata) Marshal() ([]byte, error) {
+	return json.Marshal(m)
+}


### PR DESCRIPTION
Agents/steps need runtime context (agent version, package info). Previously node metadata CMs had only labels/annotations.

**- Implementation:**
  - Add `packages.json` to each node’s “metadata” ConfigMap:
    - `agentVersion` (parsed from operator `AgentImage`)
    - `packages`: name, version, image, optional `agentImageOverride`/`interrupt`/`configInterrupts`
  - Refresh/backfill via `ValidateNodeConfigmaps`
  - Add `AgentVersion()` helper on `SkyhookOperatorOptions`.
  - Introduce `SkyhookMetadata` intermediary (decoupled from CRD shape).
  - Marshal the stable metadata instead of writing CR internals directly.

**- Tests:**
  - Envtest: ensure `skyhook` namespace exists.
  - Chainsaw: assert `packages.json` exists with `agentVersion`, package names/versions.
