### PR TITLE
feat: add glob support for config interrupts

### DIFF
--- a/k8s-tests/chainsaw/skyhook/config-skyhook/assert-update-glob.yaml
+++ b/k8s-tests/chainsaw/skyhook/config-skyhook/assert-update-glob.yaml
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+apiVersion: v1
+kind: Node
+metadata:
+  labels:
+    skyhook.nvidia.com/test-node: skyhooke2e
+    skyhook.nvidia.com/status_config-skyhook: complete
+  annotations:
+    ("skyhook.nvidia.com/nodeState_config-skyhook" && parse_json("skyhook.nvidia.com/nodeState_config-skyhook")):
+      {
+        "dexter|1.2.3": {
+            "name": "dexter",
+            "version": "1.2.3",
+            "image": "ghcr.io/nvidia/skyhook/agentless",
+            "stage": "post-interrupt",
+            "state": "complete"
+        }
+      }
+    skyhook.nvidia.com/status_config-skyhook: complete
+status:
+  (conditions[?type == 'skyhook.nvidia.com/config-skyhook/NotReady']):
+  - reason: "Complete"
+    status: "False"
+  (conditions[?type == 'skyhook.nvidia.com/config-skyhook/Erroring']):
+  - reason: "Not Erroring"
+    status: "False"
+---
+apiVersion: skyhook.nvidia.com/v1alpha1
+kind: Skyhook
+metadata:
+  name: config-skyhook
+status:
+  status: complete
+  nodeState:
+    (values(@)):
+      - dexter|1.2.3:
+          name: dexter
+          state: complete
+          version: '1.2.3'
+          stage: post-interrupt
+          image: ghcr.io/nvidia/skyhook/agentless
+  nodeStatus:
+    (values(@)):
+      - complete
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: config-skyhook-dexter-1.2.3
+  namespace: skyhook
+  labels:
+    skyhook.nvidia.com/name: config-skyhook
+  ownerReferences:
+  - apiVersion: skyhook.nvidia.com/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Skyhook
+    name: config-skyhook
+data:
+  game.properties: |
+    changed via glob

--- a/k8s-tests/chainsaw/skyhook/config-skyhook/assert-update-glob.yaml
+++ b/k8s-tests/chainsaw/skyhook/config-skyhook/assert-update-glob.yaml
@@ -16,6 +16,35 @@
 
 ---
 apiVersion: v1
+kind: Pod
+metadata:
+  namespace: skyhook
+  labels:
+    skyhook.nvidia.com/name: config-skyhook
+    skyhook.nvidia.com/package: dexter-1.2.3
+  annotations:
+    ("skyhook.nvidia.com/package" && parse_json("skyhook.nvidia.com/package")):
+      {
+        "name": "dexter",
+        "version": "1.2.3",
+        "skyhook": "config-skyhook",
+        "stage": "config"
+      }
+spec:
+  initContainers:
+    - name: dexter-init
+    - name: dexter-config
+      args:
+        ([0]): config
+        ([1]): /root
+        (length(@)): 3
+    - name: dexter-configcheck
+      args:
+        ([0]): config-check
+        ([1]): /root
+        (length(@)): 3
+---
+apiVersion: v1
 kind: Node
 metadata:
   labels:

--- a/k8s-tests/chainsaw/skyhook/config-skyhook/chainsaw-test.yaml
+++ b/k8s-tests/chainsaw/skyhook/config-skyhook/chainsaw-test.yaml
@@ -65,3 +65,8 @@ spec:
         file: update-no-interrupt.yaml
     - assert:
         file: assert-update-no-interrupt.yaml
+  - try:
+    - apply:
+        file: update-glob.yaml
+    - assert:
+        file: assert-update-glob.yaml

--- a/k8s-tests/chainsaw/skyhook/config-skyhook/update-glob.yaml
+++ b/k8s-tests/chainsaw/skyhook/config-skyhook/update-glob.yaml
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: skyhook.nvidia.com/v1alpha1
+kind: Skyhook
+metadata:
+  name: config-skyhook
+spec:
+  packages:
+    dexter:
+      # Add a globbed configInterrupt that matches at least one key
+      configInterrupts:
+        "*.properties":
+          type: service
+          services: [rsyslog]
+      # Change a key that should match the glob
+      configMap:
+        game.properties: |
+          changed via glob

--- a/operator/internal/wrapper/skyhook.go
+++ b/operator/internal/wrapper/skyhook.go
@@ -159,8 +159,7 @@ func (s *Skyhook) GetConfigInterrupts() map[string][]*v1alpha1.Interrupt {
 					}
 					seen[key] = struct{}{}
 
-					intr := interrupt // copy to get stable address
-					interrupts[_package.Name] = append(interrupts[_package.Name], &intr)
+					interrupts[_package.Name] = append(interrupts[_package.Name], &interrupt)
 				}
 			}
 		}


### PR DESCRIPTION
### Summary
- Add glob support for `configInterrupts` so patterns with `*` can target multiple `ConfigMap` keys.
- Validation requires each pattern to match at least one key; exact keys still require exact matches.
- Runtime applies a union of all matching patterns and de-duplicates identical interrupts (same type + services).

### Implementation
- `operator/api/v1alpha1/skyhook_webhook.go`: Validate `configInterrupts` keys as exact or `*` globs using `filepath.Match`; error if a glob matches no keys.
- `operator/internal/wrapper/skyhook.go`: For each changed config key, match against all patterns with `filepath.Match`; collect all matching interrupts; de-duplicate by `type|services`; copy interrupt before taking address. Added `path/filepath` and `strings` imports.

### Test
- `operator/api/v1alpha1/skyhook_webhook_test.go`: Added tests that accept a glob which matches at least one key and reject a glob that matches none.