### PR TITLE
feat: add container sha as optional field to package

### DIFF
--- a/chart/templates/skyhook-crd.yaml
+++ b/chart/templates/skyhook-crd.yaml
@@ -231,6 +231,13 @@ spec:
                         The keys stored in Data must not overlap with the keys in
                         the BinaryData field, this is enforced during validation process.
                       type: object
+                    containerSHA:
+                      description: |-
+                        ContainerSHA is the SHA256 digest of the container image for verification purposes.
+                        When specified, this will be used instead of the version tag to pull the exact image.
+                        Format: sha256:1234567890abcdef...
+                      example: sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef
+                      type: string
                     dependsOn:
                       additionalProperties:
                         type: string
@@ -694,6 +701,10 @@ spec:
                 additionalProperties:
                   additionalProperties:
                     properties:
+                      containerSHA:
+                        description: ContainerSHA is the SHA256 digest that was actually
+                          deployed
+                        type: string
                       image:
                         description: Image for the package
                         type: string

--- a/k8s-tests/chainsaw/skyhook/simple-skyhook/assert.yaml
+++ b/k8s-tests/chainsaw/skyhook/simple-skyhook/assert.yaml
@@ -34,6 +34,7 @@ metadata:
             "name": "foobar",
             "version": "1.2",
             "image": "ghcr.io/nvidia/skyhook/agentless",
+            "containerSHA": "sha256:a9cc86f68d73e874bf2dfbabab5e8a8f710ad78411a03764d1b42aa1b5cda7dd",
             "stage": "config",
             "state": "complete"
         },
@@ -74,6 +75,7 @@ status:
           state: complete
           version: '1.2'
           image: ghcr.io/nvidia/skyhook/agentless
+          containerSHA: sha256:a9cc86f68d73e874bf2dfbabab5e8a8f710ad78411a03764d1b42aa1b5cda7dd
           stage: config
         spencer|3.2.3:
           name: spencer

--- a/k8s-tests/chainsaw/skyhook/simple-skyhook/skyhook.yaml
+++ b/k8s-tests/chainsaw/skyhook/simple-skyhook/skyhook.yaml
@@ -42,6 +42,7 @@ spec:
     foobar:
       version: "1.2"
       image: ghcr.io/nvidia/skyhook/agentless
+      containerSHA: "sha256:a9cc86f68d73e874bf2dfbabab5e8a8f710ad78411a03764d1b42aa1b5cda7dd"
       dependsOn:
         dexter: "1.2.3"
       env: 

--- a/operator/api/v1alpha1/skyhook_types_test.go
+++ b/operator/api/v1alpha1/skyhook_types_test.go
@@ -298,19 +298,19 @@ var _ = Describe("Skyhook Types", func() {
 		Expect(nodeState.Upsert(PackageRef{
 			Name:    "foo",
 			Version: "1.2.3",
-		}, "", StateComplete, stage, 2)).To(BeTrue())
+		}, "", StateComplete, stage, 2, "")).To(BeTrue())
 		Expect(nodeState.Upsert(PackageRef{
 			Name:    "bar",
 			Version: "2.3",
-		}, "", StateComplete, stage, 2)).To(BeTrue())
+		}, "", StateComplete, stage, 2, "")).To(BeTrue())
 		Expect(nodeState.Upsert(PackageRef{ // replace
 			Name:    "bar",
 			Version: "2",
-		}, "", StateComplete, stage, 2)).To(BeTrue())
+		}, "", StateComplete, stage, 2, "")).To(BeTrue())
 		Expect(nodeState.Upsert(PackageRef{ // exists
 			Name:    "bar",
 			Version: "2",
-		}, "", StateComplete, stage, 2)).To(BeFalse())
+		}, "", StateComplete, stage, 2, "")).To(BeFalse())
 
 		interrupts := map[string][]*Interrupt{}
 		configUpdates := map[string][]string{}

--- a/operator/config/crd/bases/skyhook.nvidia.com_skyhooks.yaml
+++ b/operator/config/crd/bases/skyhook.nvidia.com_skyhooks.yaml
@@ -225,6 +225,13 @@ spec:
                         The keys stored in Data must not overlap with the keys in
                         the BinaryData field, this is enforced during validation process.
                       type: object
+                    containerSHA:
+                      description: |-
+                        ContainerSHA is the SHA256 digest of the container image for verification purposes.
+                        When specified, this will be used instead of the version tag to pull the exact image.
+                        Format: sha256:1234567890abcdef...
+                      example: sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef
+                      type: string
                     dependsOn:
                       additionalProperties:
                         type: string
@@ -695,6 +702,10 @@ spec:
                 additionalProperties:
                   additionalProperties:
                     properties:
+                      containerSHA:
+                        description: ContainerSHA is the SHA256 digest that was actually
+                          deployed
+                        type: string
                       image:
                         description: Image for the package
                         type: string

--- a/operator/internal/controller/annotations.go
+++ b/operator/internal/controller/annotations.go
@@ -31,6 +31,7 @@ type PackageSkyhook struct {
 	Skyhook             string         `json:"skyhook"`
 	Stage               v1alpha1.Stage `json:"stage"`
 	Image               string         `json:"image"`
+	ContainerSHA        string         `json:"containerSHA,omitempty"`
 	Invalid             bool           `json:"invalid,omitempty"`
 }
 
@@ -59,10 +60,11 @@ func SetPackages(pod *corev1.Pod, skyhook *v1alpha1.Skyhook, image string, stage
 	}
 
 	strk := &PackageSkyhook{
-		Skyhook:    skyhook.Name,
-		Stage:      stage,
-		PackageRef: _package.PackageRef,
-		Image:      image,
+		Skyhook:      skyhook.Name,
+		Stage:        stage,
+		PackageRef:   _package.PackageRef,
+		Image:        image,
+		ContainerSHA: _package.ContainerSHA,
 	}
 
 	data, err := json.Marshal(strk)

--- a/operator/internal/controller/pod_controller.go
+++ b/operator/internal/controller/pod_controller.go
@@ -164,7 +164,7 @@ func (r *SkyhookReconciler) UpdateNodeState(ctx context.Context, pod *corev1.Pod
 	}
 
 	if !updated {
-		err = skyhookNode.Upsert(packagePtr.PackageRef, packagePtr.Image, state, packagePtr.Stage, restarts)
+		err = skyhookNode.Upsert(packagePtr.PackageRef, packagePtr.Image, state, packagePtr.Stage, restarts, packagePtr.ContainerSHA)
 		if err != nil {
 			return false, err
 		}
@@ -240,7 +240,7 @@ func (r *SkyhookReconciler) HandleCompletePod(ctx context.Context, skyhookNode w
 			if exists {
 				// If the uninstall was caused by a version changed progress forward the new version that was waiting
 				// on the uninstall to finish
-				err = skyhookNode.Upsert(_package.PackageRef, _package.Image, v1alpha1.StateComplete, v1alpha1.StageUninstall, 0)
+				err = skyhookNode.Upsert(_package.PackageRef, _package.Image, v1alpha1.StateComplete, v1alpha1.StageUninstall, 0, _package.ContainerSHA)
 				if err != nil {
 					return false, fmt.Errorf("error updating node status: %w", err)
 				}

--- a/operator/internal/wrapper/node.go
+++ b/operator/internal/wrapper/node.go
@@ -62,7 +62,7 @@ type SkyhookNodeOnly interface {
 	State() (v1alpha1.NodeState, error)
 	SetState(state v1alpha1.NodeState) error
 	RemoveState(_package v1alpha1.PackageRef) error
-	Upsert(_package v1alpha1.PackageRef, image string, state v1alpha1.State, stage v1alpha1.Stage, restarts int32) error
+	Upsert(_package v1alpha1.PackageRef, image string, state v1alpha1.State, stage v1alpha1.Stage, restarts int32, containerSHA string) error
 	GetNode() *corev1.Node
 	Taint(key string)
 	RemoveTaint(key string)
@@ -283,8 +283,8 @@ func (node *skyhookNode) RemoveState(_package v1alpha1.PackageRef) error {
 	return nil
 }
 
-func (node *skyhookNode) Upsert(_package v1alpha1.PackageRef, image string, state v1alpha1.State, stage v1alpha1.Stage, restarts int32) error {
-	changed := node.nodeState.Upsert(_package, image, state, stage, restarts)
+func (node *skyhookNode) Upsert(_package v1alpha1.PackageRef, image string, state v1alpha1.State, stage v1alpha1.Stage, restarts int32, containerSHA string) error {
+	changed := node.nodeState.Upsert(_package, image, state, stage, restarts, containerSHA)
 	if changed {
 		if node.skyhook != nil {
 			node.skyhook.Updated = true

--- a/operator/internal/wrapper/node_test.go
+++ b/operator/internal/wrapper/node_test.go
@@ -84,7 +84,7 @@ var _ = Describe("SkyhookNode", func() {
 			Expect(pkgs[1].Name).To(Equal("b-package"))
 
 			// Complete b-package
-			err = skyhookNode.Upsert(v1alpha1.PackageRef{Name: "b-package", Version: "1.0"}, "image", v1alpha1.StateComplete, v1alpha1.StageConfig, 0)
+			err = skyhookNode.Upsert(v1alpha1.PackageRef{Name: "b-package", Version: "1.0"}, "image", v1alpha1.StateComplete, v1alpha1.StageConfig, 0, "")
 			Expect(err).NotTo(HaveOccurred())
 			// Should still get a-package since c-package depends on both a and b
 			pkgs, err = skyhookNode.RunNext()
@@ -93,7 +93,7 @@ var _ = Describe("SkyhookNode", func() {
 			Expect(pkgs[0].Name).To(Equal("a-package"))
 
 			// Complete a-package
-			err = skyhookNode.Upsert(v1alpha1.PackageRef{Name: "a-package", Version: "1.0"}, "image", v1alpha1.StateComplete, v1alpha1.StageConfig, 0)
+			err = skyhookNode.Upsert(v1alpha1.PackageRef{Name: "a-package", Version: "1.0"}, "image", v1alpha1.StateComplete, v1alpha1.StageConfig, 0, "")
 			Expect(err).NotTo(HaveOccurred())
 			// Now should get c-package since both dependencies are complete
 			pkgs, err = skyhookNode.RunNext()
@@ -102,7 +102,7 @@ var _ = Describe("SkyhookNode", func() {
 			Expect(pkgs[0].Name).To(Equal("c-package"))
 
 			// Complete c-package
-			err = skyhookNode.Upsert(v1alpha1.PackageRef{Name: "c-package", Version: "1.0"}, "image", v1alpha1.StateComplete, v1alpha1.StageConfig, 0)
+			err = skyhookNode.Upsert(v1alpha1.PackageRef{Name: "c-package", Version: "1.0"}, "image", v1alpha1.StateComplete, v1alpha1.StageConfig, 0, "")
 			Expect(err).NotTo(HaveOccurred())
 			// Now should get d-package since c-package is complete
 			pkgs, err = skyhookNode.RunNext()
@@ -112,7 +112,7 @@ var _ = Describe("SkyhookNode", func() {
 			Expect(pkgs[1].Name).To(Equal("e-package"))
 
 			// Complete e-package
-			err = skyhookNode.Upsert(v1alpha1.PackageRef{Name: "e-package", Version: "1.0"}, "image", v1alpha1.StateComplete, v1alpha1.StageConfig, 0)
+			err = skyhookNode.Upsert(v1alpha1.PackageRef{Name: "e-package", Version: "1.0"}, "image", v1alpha1.StateComplete, v1alpha1.StageConfig, 0, "")
 			Expect(err).NotTo(HaveOccurred())
 			// Now should get d-package since c-package and e-package are complete
 			pkgs, err = skyhookNode.RunNext()
@@ -121,7 +121,7 @@ var _ = Describe("SkyhookNode", func() {
 			Expect(pkgs[0].Name).To(Equal("d-package"))
 
 			// Complete d-package
-			err = skyhookNode.Upsert(v1alpha1.PackageRef{Name: "d-package", Version: "1.0"}, "image", v1alpha1.StateComplete, v1alpha1.StageConfig, 0)
+			err = skyhookNode.Upsert(v1alpha1.PackageRef{Name: "d-package", Version: "1.0"}, "image", v1alpha1.StateComplete, v1alpha1.StageConfig, 0, "")
 			Expect(err).NotTo(HaveOccurred())
 			// Now should get f-package since both d-package and e-package are complete
 			pkgs, err = skyhookNode.RunNext()
@@ -130,7 +130,7 @@ var _ = Describe("SkyhookNode", func() {
 			Expect(pkgs[0].Name).To(Equal("f-package"))
 
 			// Complete f-package
-			err = skyhookNode.Upsert(v1alpha1.PackageRef{Name: "f-package", Version: "1.0"}, "image", v1alpha1.StateComplete, v1alpha1.StageConfig, 0)
+			err = skyhookNode.Upsert(v1alpha1.PackageRef{Name: "f-package", Version: "1.0"}, "image", v1alpha1.StateComplete, v1alpha1.StageConfig, 0, "")
 			Expect(err).NotTo(HaveOccurred())
 			// Now should get nothing since all packages are complete
 			pkgs, err = skyhookNode.RunNext()

--- a/operator/internal/wrapper/zz.migration.0.5.0.go
+++ b/operator/internal/wrapper/zz.migration.0.5.0.go
@@ -42,7 +42,7 @@ func migrateNodeTo_0_5_0(node *skyhookNode, logger logr.Logger) error {
 			if exists && packageStatus.Version == _package.Version {
 
 				// upsert to migrate
-				err := node.Upsert(packageStatusRef, _package.Image, packageStatus.State, packageStatus.Stage, packageStatus.Restarts)
+				err := node.Upsert(packageStatusRef, _package.Image, packageStatus.State, packageStatus.Stage, packageStatus.Restarts, "")
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
Adds optional `containerSHA` field to package specs

### Changes

**API & CRD:**
- Added `containerSHA` field to `Package` spec and `PackageStatus`
- Updated CRD and Helm chart with new field

**Implementation:**
- Added `getPackageImage()` helper to use digest format (`image@sha256:...`) when `containerSHA` is specified
- Updated pod creation to pull images by digest when available
- Propagated `containerSHA` through `PackageSkyhook` annotations and `NodeState.Upsert()`

**Testing:**
- Updated all unit tests to handle new parameter
- Updated e2e test to use real multi-arch manifest digest for `agentless:1.2`

### Usage

```yaml
packages:
  my-package:
    version: "1.0"
    image: ghcr.io/example/image
    containerSHA: "sha256:abc123..."  # Optional: ensures exact image
```

When specified, Kubernetes pulls `image@sha256:...` instead of `image:version`, guaranteeing the exact container regardless of tag changes.