### PR TITLE
fix: deployment policy edge cases

### DIFF
--- a/operator/internal/controller/skyhook_controller.go
+++ b/operator/internal/controller/skyhook_controller.go
@@ -2320,7 +2320,7 @@ func partitionNodesIntoCompartments(clusterState *clusterState) error {
 		// 1. Nodes currently InProgress
 		// 2. Nodes that completed/failed in the last batch (their counts are in BatchState)
 		nodesToKeep := make(map[string]string) // node name -> compartment name
-		
+
 		if skyhook.GetSkyhook().Status.CompartmentStatuses != nil {
 			for compartmentName, status := range skyhook.GetSkyhook().Status.CompartmentStatuses {
 				// Keep nodes that are in progress
@@ -2331,7 +2331,7 @@ func partitionNodesIntoCompartments(clusterState *clusterState) error {
 						}
 					}
 				}
-				
+
 				// Keep nodes that are part of the current batch state counts
 				// These nodes' completion/failure was counted in the last batch evaluation
 				// Moving them would break the delta calculation in the next evaluation
@@ -2356,13 +2356,13 @@ func partitionNodesIntoCompartments(clusterState *clusterState) error {
 
 		for _, node := range skyhook.GetNodes() {
 			nodeName := node.GetNode().Name
-			
+
 			// If node should be kept in its current compartment, keep it there
 			if existingCompartment, shouldKeep := nodesToKeep[nodeName]; shouldKeep {
 				skyhook.AddCompartmentNode(existingCompartment, node)
 				continue
 			}
-			
+
 			// For all other nodes, assign based on current policy
 			compartmentName, err := skyhook.AssignNodeToCompartment(node)
 			if err != nil {


### PR DESCRIPTION
Fixes 5 critical bugs in compartment and deployment strategy handling that could cause controller crashes, data loss, and incorrect batch accounting during dynamic policy updates.

### Bugs Fixed

1. **Division by zero crash** - Skip batch evaluation when all nodes transition to Blocked status
2. **Memory leak** - Remove stale compartment statuses when compartments are deleted from policies
3. **Lost batch state on rename** - Detect and warn when compartments are renamed, preventing silent progress loss
4. **Incorrect batch accounting** - Prevent node reassignment during active batch processing to maintain accurate delta calculations
5. **Negative delta crash** - Clamp negative deltas when completed nodes leave compartments