### PR TITLE
feat: add status badges and Coveralls coverage integration

### DIFF
--- a/.github/workflows/operator-ci.yaml
+++ b/.github/workflows/operator-ci.yaml
@@ -127,9 +127,18 @@ jobs:
         env:
           COVERALLS_TOKEN: ${{ secrets.COVERALLS_TOKEN }}
         run: |
-          cd operator
+          # Install goveralls
           go install github.com/mattn/goveralls@latest
-          goveralls -coverprofile=reporting/cover.out -service=github -repotoken=$COVERALLS_TOKEN -parallel
+          # Run goveralls from operator directory (where go.mod is located)
+          cd operator
+          # Verify coverage file exists
+          if [ ! -f reporting/cover.out ]; then
+            echo "ERROR: Coverage file not found at reporting/cover.out"
+            ls -la reporting/ || echo "reporting directory does not exist"
+            exit 1
+          fi
+          # Upload coverage (run from operator/ directory, path is relative to operator/)
+          goveralls -coverprofile=reporting/cover.out -service=github -repotoken=$COVERALLS_TOKEN
   
   # Build multi-platform container image and push to registry
   build-and-push-operator:

--- a/.github/workflows/operator-ci.yaml
+++ b/.github/workflows/operator-ci.yaml
@@ -121,6 +121,15 @@ jobs:
           else
             make ${{ matrix.make-target }}
           fi
+      # Upload coverage to Coveralls using goveralls (Go-specific tool)
+      - name: Upload coverage to Coveralls
+        if: matrix.test-suite == 'e2e' && matrix.k8s-version == '1.34.0'
+        env:
+          COVERALLS_TOKEN: ${{ secrets.COVERALLS_TOKEN }}
+        run: |
+          cd operator
+          go install github.com/mattn/goveralls@latest
+          goveralls -coverprofile=reporting/cover.out -service=github -repotoken=$COVERALLS_TOKEN -parallel
   
   # Build multi-platform container image and push to registry
   build-and-push-operator:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # skyhook
 
+[![Pipeline Status](https://github.com/NVIDIA/skyhook/actions/workflows/operator-ci.yaml/badge.svg)](https://github.com/NVIDIA/skyhook/actions/workflows/operator-ci.yaml)
+[![Coverage Status](https://coveralls.io/repos/github/NVIDIA/skyhook/badge.svg)](https://coveralls.io/github/NVIDIA/skyhook)
+[![Go Report Card](https://goreportcard.com/badge/github.com/NVIDIA/skyhook/operator)](https://goreportcard.com/report/github.com/NVIDIA/skyhook/operator)
+
 **Skyhook** is a Kubernetes-aware package manager for cluster administrators to safely modify and maintain underlying host declaratively at scale.
 
 ## Why Skyhook?


### PR DESCRIPTION
Add status badges to README and integrate Coveralls for code coverage reporting.

## Changes

- Add status badges to README:
  - Pipeline Status (GitHub Actions)
  - Code Coverage (Coveralls)
  - Go Report Card

- Integrate Coveralls coverage reporting:
  - Upload coverage reports using `goveralls` after e2e tests
  - Configured for parallel builds with matrix strategy