### PR TITLE
fix(chart): Use image tags instead of digest for multi-registry support

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -3,6 +3,8 @@ kind: Deployment
 metadata:
   name: {{ include "chart.fullname" . }}-controller-manager
   namespace: "{{ .Release.Namespace }}"
+  annotations:
+    checkov.io/skip1: CKV_K8S_43=Image digest not required - we use tags
   labels:
     app: {{ include "chart.fullname" . }}-controller-manager
     app.kubernetes.io/component: manager
@@ -93,7 +95,7 @@ spec:
         - name: KUBERNETES_CLUSTER_DOMAIN
           value: {{ quote .Values.kubernetesClusterDomain }}
         image: {{ .Values.controllerManager.manager.image.repository }}{{- if .Values.controllerManager.manager.image.digest }}{{- if .Values.controllerManager.manager.image.tag }}:{{ .Values.controllerManager.manager.image.tag }}@{{ .Values.controllerManager.manager.image.digest }}{{- else }}@{{ .Values.controllerManager.manager.image.digest }}{{- end }}{{- else }}:{{ .Values.controllerManager.manager.image.tag | default .Chart.AppVersion }}{{- end }}
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         livenessProbe:
           httpGet:
             path: /healthz

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -85,7 +85,7 @@ controllerManager:
     image:
       repository: nvcr.io/nvidia/skyhook/operator
       tag: "" ## if both tag and digest are omitted, defaults to the chart appVersion
-      digest: "sha256:b3acae2320d9d768fff455f5986fea9084b099291ecdd258d1580180dabc4efe" # manifest list digest (multi-arch)
+      digest: "" # manifest list digest (multi-arch)
     ## agentImage: is the image used for the agent container. This image is the default for this install, but can be overridden in the CR at package level.
     agent:
       repository: nvcr.io/nvidia/skyhook/agent


### PR DESCRIPTION
## Summary
Remove digest-based image pulls in favor of tag-based pulls to support deployments across multiple registries (GitHub, nvcr.io).

## Changes
- Changed `imagePullPolicy` from `IfNotPresent` to `Always` for the manager container
- Added Checkov skip annotations for `CKV_K8S_43` (digest requirement)

## Context
The v0.10.0 chart was non-functional due to an incorrect digest being specified. Since images are deployed to multiple registries with different digests, using tags is more appropriate and flexible. Users can still specify digests in their deployments if desired.