### PR TITLE
docs: update version references to v0.10.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ helm search repo skyhook ## should show the latest version
 
 # basic install
 helm install skyhook skyhook/skyhook-operator \
-  --version v0.9.2 \
+  --version v0.10.0 \
   --namespace skyhook \
   --create-namespace
 ```

--- a/docs/kubernetes-support.md
+++ b/docs/kubernetes-support.md
@@ -57,7 +57,7 @@ We understand many installations run slightly older Kubernetes versions. Our str
 
 **Choose your Skyhook version based on your Kubernetes version:**
 
-- **Kubernetes 1.34, 1.33, 1.32, or 1.31:** Use latest Skyhook (v0.9.0+)
+- **Kubernetes 1.34, 1.33, 1.32, or 1.31:** Use latest Skyhook (v0.9.x or v0.10.0)
 - **Kubernetes 1.30:** Use Skyhook v0.8.x (K8s 1.30 is EOL but v0.8.x still works)
 - **Kubernetes 1.29 or older:** Use Skyhook v0.8.x or older (check release notes for compatibility)
 

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -58,6 +58,7 @@ Skyhook uses **release branches** to manage patches and maintenance releases:
 ```bash
 release/v0.8.x    # Contains operator v0.8.0 + agent v6.3.0 + chart v0.8.x
 release/v0.9.x    # Contains operator v0.9.0 + (agent v6.3.0*) + chart v0.9.x
+release/v0.10.x   # Contains operator v0.10.0 + (agent v6.3.0*) + chart v0.10.x
 ```
 *Agent versions may not change every release - operator drives the release cycle
 


### PR DESCRIPTION
Update documentation to reflect the v0.10.0 release:

- README.md: Update Helm install command to use v0.10.0
- docs/kubernetes-support.md: Update compatibility matrix to reference v0.10.0+ for current Kubernetes versions (1.34, 1.33, 1.32, 1.31)
- docs/versioning.md: Add v0.10.x release branch entry

These changes ensure documentation accurately reflects the latest release and supported Kubernetes versions.