### PR TITLE
feat(cli): Add lifecycle management commands (pause, resume, disable, enable)

### DIFF
--- a/k8s-tests/chainsaw/cli/lifecycle/assert-disabled.yaml
+++ b/k8s-tests/chainsaw/cli/lifecycle/assert-disabled.yaml
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: skyhook.nvidia.com/v1alpha1
+kind: Skyhook
+metadata:
+  name: cli-lifecycle-test
+  annotations:
+    skyhook.nvidia.com/disable: "true"

--- a/k8s-tests/chainsaw/cli/lifecycle/assert-enabled.yaml
+++ b/k8s-tests/chainsaw/cli/lifecycle/assert-enabled.yaml
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: skyhook.nvidia.com/v1alpha1
+kind: Skyhook
+metadata:
+  name: cli-lifecycle-test
+  # Note: Chainsaw will verify that disable annotation is NOT present

--- a/k8s-tests/chainsaw/cli/lifecycle/assert-paused-and-disabled.yaml
+++ b/k8s-tests/chainsaw/cli/lifecycle/assert-paused-and-disabled.yaml
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: skyhook.nvidia.com/v1alpha1
+kind: Skyhook
+metadata:
+  name: cli-lifecycle-test
+  annotations:
+    skyhook.nvidia.com/pause: "true"
+    skyhook.nvidia.com/disable: "true"

--- a/k8s-tests/chainsaw/cli/lifecycle/assert-paused.yaml
+++ b/k8s-tests/chainsaw/cli/lifecycle/assert-paused.yaml
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: skyhook.nvidia.com/v1alpha1
+kind: Skyhook
+metadata:
+  name: cli-lifecycle-test
+  annotations:
+    skyhook.nvidia.com/pause: "true"

--- a/k8s-tests/chainsaw/cli/lifecycle/assert-resumed.yaml
+++ b/k8s-tests/chainsaw/cli/lifecycle/assert-resumed.yaml
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: skyhook.nvidia.com/v1alpha1
+kind: Skyhook
+metadata:
+  name: cli-lifecycle-test
+  # Note: Chainsaw will verify that pause annotation is NOT present
+  # by checking the resource exists without that annotation

--- a/k8s-tests/chainsaw/cli/lifecycle/assert-still-disabled.yaml
+++ b/k8s-tests/chainsaw/cli/lifecycle/assert-still-disabled.yaml
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: skyhook.nvidia.com/v1alpha1
+kind: Skyhook
+metadata:
+  name: cli-lifecycle-test
+  annotations:
+    # pause annotation should be removed, but disable should remain
+    skyhook.nvidia.com/disable: "true"

--- a/k8s-tests/chainsaw/cli/lifecycle/chainsaw-test.yaml
+++ b/k8s-tests/chainsaw/cli/lifecycle/chainsaw-test.yaml
@@ -1,0 +1,121 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: cli-lifecycle
+spec:
+  description: |
+    Test all CLI lifecycle commands:
+    - pause: pauses a Skyhook from processing
+    - resume: resumes a paused Skyhook
+    - disable: disables a Skyhook completely
+    - enable: enables a disabled Skyhook
+  timeouts:
+    assert: 60s
+    exec: 30s
+  steps:
+  # Step 1: Create a Skyhook
+  - name: setup-skyhook
+    try:
+    - apply:
+        file: skyhook.yaml
+    - script:
+        timeout: 30s
+        content: |
+          echo "Waiting for Skyhook to be created..."
+          for i in $(seq 1 15); do
+            if kubectl get skyhook cli-lifecycle-test 2>/dev/null; then
+              echo "Skyhook created"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "Timeout waiting for Skyhook"
+          exit 1
+
+  # Step 2: Test pause command
+  - name: test-pause
+    try:
+    - script:
+        timeout: 30s
+        content: |
+          ../../../../operator/bin/skyhook pause cli-lifecycle-test --confirm
+    - assert:
+        file: assert-paused.yaml
+
+  # Step 3: Test resume command
+  - name: test-resume
+    try:
+    - script:
+        timeout: 30s
+        content: |
+          ../../../../operator/bin/skyhook resume cli-lifecycle-test
+    - assert:
+        file: assert-resumed.yaml
+
+  # Step 4: Test disable command
+  - name: test-disable
+    try:
+    - script:
+        timeout: 30s
+        content: |
+          ../../../../operator/bin/skyhook disable cli-lifecycle-test --confirm
+    - assert:
+        file: assert-disabled.yaml
+
+  # Step 5: Test enable command
+  - name: test-enable
+    try:
+    - script:
+        timeout: 30s
+        content: |
+          ../../../../operator/bin/skyhook enable cli-lifecycle-test
+    - assert:
+        file: assert-enabled.yaml
+
+  # Step 6: Test pause and disable together
+  - name: test-pause-and-disable
+    try:
+    - script:
+        timeout: 30s
+        content: |
+          ../../../../operator/bin/skyhook pause cli-lifecycle-test --confirm
+          ../../../../operator/bin/skyhook disable cli-lifecycle-test --confirm
+    - assert:
+        file: assert-paused-and-disabled.yaml
+    - script:
+        timeout: 30s
+        content: |
+          # Resume should only remove pause, not disable
+          ../../../../operator/bin/skyhook resume cli-lifecycle-test
+    - assert:
+        file: assert-still-disabled.yaml
+    - script:
+        timeout: 30s
+        content: |
+          # Enable should remove disable
+          ../../../../operator/bin/skyhook enable cli-lifecycle-test
+
+  # Cleanup
+  - name: cleanup
+    try:
+    - script:
+        content: |
+          kubectl delete skyhook cli-lifecycle-test 2>/dev/null || true
+

--- a/k8s-tests/chainsaw/cli/lifecycle/skyhook.yaml
+++ b/k8s-tests/chainsaw/cli/lifecycle/skyhook.yaml
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: skyhook.nvidia.com/v1alpha1
+kind: Skyhook
+metadata:
+  name: cli-lifecycle-test
+spec:
+  nodeSelectors:
+    matchLabels:
+      skyhook.nvidia.com/test-node: skyhooke2e
+  packages:
+    test-package:
+      version: "1.0.0"
+      image: ghcr.io/nvidia/skyhook-packages/shellscript
+      configMap:
+        apply.sh: |
+          #!/bin/bash
+          echo "Lifecycle test apply"
+          sleep 2
+

--- a/k8s-tests/chainsaw/cli/node/chainsaw-test.yaml
+++ b/k8s-tests/chainsaw/cli/node/chainsaw-test.yaml
@@ -30,26 +30,11 @@ spec:
     assert: 120s
     exec: 90s
   steps:
-  # Step 1: Create a Skyhook and wait for activity
+  # Step 1: Create a Skyhook
   - name: setup-skyhook
     try:
     - apply:
         file: skyhook.yaml
-    - script:
-        timeout: 60s
-        content: |
-          NODE=$(kubectl get nodes -l skyhook.nvidia.com/test-node=skyhooke2e -o jsonpath='{.items[0].metadata.name}')
-          echo "Waiting for Skyhook activity on node $NODE..."
-          for i in $(seq 1 30); do
-            ANNOTATION=$(kubectl get node "$NODE" -o jsonpath='{.metadata.annotations.skyhook\.nvidia\.com/nodeState_cli-node-test}' 2>/dev/null)
-            if [ -n "$ANNOTATION" ]; then
-              echo "Skyhook activity detected"
-              exit 0
-            fi
-            sleep 2
-          done
-          echo "Timeout waiting for activity"
-          exit 1
 
   # Step 2: Test node list (table format)
   - name: test-node-list

--- a/k8s-tests/chainsaw/cli/package/assert-complete.yaml
+++ b/k8s-tests/chainsaw/cli/package/assert-complete.yaml
@@ -18,15 +18,6 @@ apiVersion: skyhook.nvidia.com/v1alpha1
 kind: Skyhook
 metadata:
   name: cli-package-test
-spec:
-  nodeSelectors:
-    matchLabels:
-      skyhook.nvidia.com/test-node: skyhooke2e
-  packages:
-    hello-world:
-      version: "3.2.3"
-      image: ghcr.io/nvidia/skyhook/agentless
-      env:
-        - name: SLEEP_LEN
-          value: "5"
+status:
+  status: complete
 

--- a/k8s-tests/chainsaw/cli/package/chainsaw-test.yaml
+++ b/k8s-tests/chainsaw/cli/package/chainsaw-test.yaml
@@ -29,26 +29,11 @@ spec:
     assert: 120s
     exec: 90s
   steps:
-  # Step 1: Create a Skyhook and wait for package activity
+  # Step 1: Create a Skyhook
   - name: setup-skyhook
     try:
     - apply:
         file: skyhook.yaml
-    - script:
-        timeout: 60s
-        content: |
-          NODE=$(kubectl get nodes -l skyhook.nvidia.com/test-node=skyhooke2e -o jsonpath='{.items[0].metadata.name}')
-          echo "Waiting for Skyhook activity on node $NODE..."
-          for i in $(seq 1 30); do
-            ANNOTATION=$(kubectl get node "$NODE" -o jsonpath='{.metadata.annotations.skyhook\.nvidia\.com/nodeState_cli-package-test}' 2>/dev/null)
-            if [ -n "$ANNOTATION" ]; then
-              echo "Skyhook activity detected"
-              exit 0
-            fi
-            sleep 2
-          done
-          echo "Timeout waiting for activity"
-          exit 1
 
   # Step 2: Test package status (table format)
   - name: test-package-status
@@ -73,9 +58,12 @@ spec:
           # Run logs command - it should succeed (may show waiting or actual logs)
           ../../../../operator/bin/skyhook package logs hello-world --skyhook cli-package-test --node "$NODE"
 
-  # Step 4: Test package rerun
+  # Step 4: Wait for package to complete, then test rerun
   - name: test-package-rerun
     try:
+    - assert:
+        timeout: 120s
+        file: assert-complete.yaml
     - script:
         timeout: 30s
         content: |

--- a/operator/internal/cli/cli.go
+++ b/operator/internal/cli/cli.go
@@ -69,6 +69,10 @@ func NewSkyhookCommand(ctx *context.CLIContext) *cobra.Command {
 		NewVersionCmd(ctx),
 		pkg.NewPackageCmd(ctx),
 		node.NewNodeCmd(ctx),
+		NewPauseCmd(ctx),
+		NewResumeCmd(ctx),
+		NewDisableCmd(ctx),
+		NewEnableCmd(ctx),
 	)
 
 	return skyhookCmd

--- a/operator/internal/cli/disable.go
+++ b/operator/internal/cli/disable.go
@@ -1,0 +1,87 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/NVIDIA/skyhook/operator/internal/cli/client"
+	cliContext "github.com/NVIDIA/skyhook/operator/internal/cli/context"
+	"github.com/NVIDIA/skyhook/operator/internal/cli/utils"
+)
+
+// disableOptions holds the options for the disable command
+type disableOptions struct {
+	confirm bool
+}
+
+// BindToCmd binds the options to the command flags
+func (o *disableOptions) BindToCmd(cmd *cobra.Command) {
+	cmd.Flags().BoolVarP(&o.confirm, "confirm", "y", false, "Skip confirmation prompt")
+}
+
+// NewDisableCmd creates the disable command
+func NewDisableCmd(ctx *cliContext.CLIContext) *cobra.Command {
+	opts := &disableOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "disable <skyhook-name>",
+		Short: "Disable a Skyhook completely",
+		Long: `Disable a Skyhook by setting the disable annotation.
+
+When a Skyhook is disabled, the operator will completely stop processing
+and the Skyhook will be effectively inactive.`,
+		Example: `  # Disable a Skyhook
+  kubectl skyhook disable gpu-init
+
+  # Disable without confirmation
+  kubectl skyhook disable gpu-init --confirm`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			skyhookName := args[0]
+
+			if !opts.confirm {
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "This will disable Skyhook %q. Continue? [y/N]: ", skyhookName)
+				var response string
+				if _, err := fmt.Scanln(&response); err != nil || (response != "y" && response != "Y") {
+					_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Aborted.")
+					return nil
+				}
+			}
+
+			clientFactory := client.NewFactory(ctx.GlobalFlags.ConfigFlags)
+			kubeClient, err := clientFactory.Client()
+			if err != nil {
+				return fmt.Errorf("initializing kubernetes client: %w", err)
+			}
+
+			if err := utils.SetSkyhookAnnotation(cmd.Context(), kubeClient.Dynamic(), skyhookName, utils.DisableAnnotation, "true"); err != nil {
+				return err
+			}
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Skyhook %q disabled\n", skyhookName)
+			return nil
+		},
+	}
+
+	opts.BindToCmd(cmd)
+
+	return cmd
+}

--- a/operator/internal/cli/disable_test.go
+++ b/operator/internal/cli/disable_test.go
@@ -1,0 +1,66 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cli
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/NVIDIA/skyhook/operator/internal/cli/context"
+)
+
+var _ = Describe("Disable Command", func() {
+	Describe("NewDisableCmd", func() {
+		It("should create command with correct properties", func() {
+			ctx := context.NewCLIContext(nil)
+			cmd := NewDisableCmd(ctx)
+
+			Expect(cmd.Use).To(Equal("disable <skyhook-name>"))
+			Expect(cmd.Short).To(ContainSubstring("Disable"))
+		})
+
+		It("should have confirm flag with shorthand", func() {
+			ctx := context.NewCLIContext(nil)
+			cmd := NewDisableCmd(ctx)
+
+			confirmFlag := cmd.Flags().Lookup("confirm")
+			Expect(confirmFlag).NotTo(BeNil())
+			Expect(confirmFlag.Shorthand).To(Equal("y"))
+			Expect(confirmFlag.DefValue).To(Equal("false"))
+		})
+
+		It("should require exactly one argument", func() {
+			ctx := context.NewCLIContext(nil)
+			cmd := NewDisableCmd(ctx)
+
+			err := cmd.Args(cmd, []string{})
+			Expect(err).To(HaveOccurred())
+
+			err = cmd.Args(cmd, []string{"skyhook1"})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should have examples in help", func() {
+			ctx := context.NewCLIContext(nil)
+			cmd := NewDisableCmd(ctx)
+
+			Expect(cmd.Example).To(ContainSubstring("kubectl skyhook disable"))
+		})
+	})
+})

--- a/operator/internal/cli/enable.go
+++ b/operator/internal/cli/enable.go
@@ -1,0 +1,60 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/NVIDIA/skyhook/operator/internal/cli/client"
+	cliContext "github.com/NVIDIA/skyhook/operator/internal/cli/context"
+	"github.com/NVIDIA/skyhook/operator/internal/cli/utils"
+)
+
+// NewEnableCmd creates the enable command
+func NewEnableCmd(ctx *cliContext.CLIContext) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "enable <skyhook-name>",
+		Short: "Enable a disabled Skyhook",
+		Long: `Enable a disabled Skyhook by removing the disable annotation.
+
+The operator will resume normal processing after this command.`,
+		Example: `  # Enable a disabled Skyhook
+  kubectl skyhook enable gpu-init`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			skyhookName := args[0]
+
+			clientFactory := client.NewFactory(ctx.GlobalFlags.ConfigFlags)
+			kubeClient, err := clientFactory.Client()
+			if err != nil {
+				return fmt.Errorf("initializing kubernetes client: %w", err)
+			}
+
+			if err := utils.RemoveSkyhookAnnotation(cmd.Context(), kubeClient.Dynamic(), skyhookName, utils.DisableAnnotation); err != nil {
+				return err
+			}
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Skyhook %q enabled\n", skyhookName)
+			return nil
+		},
+	}
+
+	return cmd
+}

--- a/operator/internal/cli/enable_test.go
+++ b/operator/internal/cli/enable_test.go
@@ -1,0 +1,64 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cli
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/NVIDIA/skyhook/operator/internal/cli/context"
+)
+
+var _ = Describe("Enable Command", func() {
+	Describe("NewEnableCmd", func() {
+		It("should create command with correct properties", func() {
+			ctx := context.NewCLIContext(nil)
+			cmd := NewEnableCmd(ctx)
+
+			Expect(cmd.Use).To(Equal("enable <skyhook-name>"))
+			Expect(cmd.Short).To(ContainSubstring("Enable"))
+		})
+
+		It("should not have confirm flag (enable is safe)", func() {
+			ctx := context.NewCLIContext(nil)
+			cmd := NewEnableCmd(ctx)
+
+			confirmFlag := cmd.Flags().Lookup("confirm")
+			Expect(confirmFlag).To(BeNil())
+		})
+
+		It("should require exactly one argument", func() {
+			ctx := context.NewCLIContext(nil)
+			cmd := NewEnableCmd(ctx)
+
+			err := cmd.Args(cmd, []string{})
+			Expect(err).To(HaveOccurred())
+
+			err = cmd.Args(cmd, []string{"skyhook1"})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should have examples in help", func() {
+			ctx := context.NewCLIContext(nil)
+			cmd := NewEnableCmd(ctx)
+
+			Expect(cmd.Example).To(ContainSubstring("kubectl skyhook enable"))
+		})
+	})
+})

--- a/operator/internal/cli/pause.go
+++ b/operator/internal/cli/pause.go
@@ -1,0 +1,87 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/NVIDIA/skyhook/operator/internal/cli/client"
+	cliContext "github.com/NVIDIA/skyhook/operator/internal/cli/context"
+	"github.com/NVIDIA/skyhook/operator/internal/cli/utils"
+)
+
+// pauseOptions holds the options for the pause command
+type pauseOptions struct {
+	confirm bool
+}
+
+// BindToCmd binds the options to the command flags
+func (o *pauseOptions) BindToCmd(cmd *cobra.Command) {
+	cmd.Flags().BoolVarP(&o.confirm, "confirm", "y", false, "Skip confirmation prompt")
+}
+
+// NewPauseCmd creates the pause command
+func NewPauseCmd(ctx *cliContext.CLIContext) *cobra.Command {
+	opts := &pauseOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "pause <skyhook-name>",
+		Short: "Pause a Skyhook from processing",
+		Long: `Pause a Skyhook by setting the pause annotation.
+
+When a Skyhook is paused, the operator will stop processing new nodes
+but will not interrupt any currently running operations.`,
+		Example: `  # Pause a Skyhook
+  kubectl skyhook pause gpu-init
+
+  # Pause without confirmation
+  kubectl skyhook pause gpu-init --confirm`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			skyhookName := args[0]
+
+			if !opts.confirm {
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "This will pause Skyhook %q. Continue? [y/N]: ", skyhookName)
+				var response string
+				if _, err := fmt.Scanln(&response); err != nil || (response != "y" && response != "Y") {
+					_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Aborted.")
+					return nil
+				}
+			}
+
+			clientFactory := client.NewFactory(ctx.GlobalFlags.ConfigFlags)
+			kubeClient, err := clientFactory.Client()
+			if err != nil {
+				return fmt.Errorf("initializing kubernetes client: %w", err)
+			}
+
+			if err := utils.SetSkyhookAnnotation(cmd.Context(), kubeClient.Dynamic(), skyhookName, utils.PauseAnnotation, "true"); err != nil {
+				return err
+			}
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Skyhook %q paused\n", skyhookName)
+			return nil
+		},
+	}
+
+	opts.BindToCmd(cmd)
+
+	return cmd
+}

--- a/operator/internal/cli/pause_test.go
+++ b/operator/internal/cli/pause_test.go
@@ -1,0 +1,69 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cli
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/NVIDIA/skyhook/operator/internal/cli/context"
+)
+
+var _ = Describe("Pause Command", func() {
+	Describe("NewPauseCmd", func() {
+		It("should create command with correct properties", func() {
+			ctx := context.NewCLIContext(nil)
+			cmd := NewPauseCmd(ctx)
+
+			Expect(cmd.Use).To(Equal("pause <skyhook-name>"))
+			Expect(cmd.Short).To(ContainSubstring("Pause"))
+		})
+
+		It("should have confirm flag with shorthand", func() {
+			ctx := context.NewCLIContext(nil)
+			cmd := NewPauseCmd(ctx)
+
+			confirmFlag := cmd.Flags().Lookup("confirm")
+			Expect(confirmFlag).NotTo(BeNil())
+			Expect(confirmFlag.Shorthand).To(Equal("y"))
+			Expect(confirmFlag.DefValue).To(Equal("false"))
+		})
+
+		It("should require exactly one argument", func() {
+			ctx := context.NewCLIContext(nil)
+			cmd := NewPauseCmd(ctx)
+
+			err := cmd.Args(cmd, []string{})
+			Expect(err).To(HaveOccurred())
+
+			err = cmd.Args(cmd, []string{"skyhook1", "skyhook2"})
+			Expect(err).To(HaveOccurred())
+
+			err = cmd.Args(cmd, []string{"skyhook1"})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should have examples in help", func() {
+			ctx := context.NewCLIContext(nil)
+			cmd := NewPauseCmd(ctx)
+
+			Expect(cmd.Example).To(ContainSubstring("kubectl skyhook pause"))
+		})
+	})
+})

--- a/operator/internal/cli/resume.go
+++ b/operator/internal/cli/resume.go
@@ -1,0 +1,60 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/NVIDIA/skyhook/operator/internal/cli/client"
+	cliContext "github.com/NVIDIA/skyhook/operator/internal/cli/context"
+	"github.com/NVIDIA/skyhook/operator/internal/cli/utils"
+)
+
+// NewResumeCmd creates the resume command
+func NewResumeCmd(ctx *cliContext.CLIContext) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "resume <skyhook-name>",
+		Short: "Resume a paused Skyhook",
+		Long: `Resume a paused Skyhook by removing the pause annotation.
+
+The operator will resume processing nodes after this command.`,
+		Example: `  # Resume a paused Skyhook
+  kubectl skyhook resume gpu-init`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			skyhookName := args[0]
+
+			clientFactory := client.NewFactory(ctx.GlobalFlags.ConfigFlags)
+			kubeClient, err := clientFactory.Client()
+			if err != nil {
+				return fmt.Errorf("initializing kubernetes client: %w", err)
+			}
+
+			if err := utils.RemoveSkyhookAnnotation(cmd.Context(), kubeClient.Dynamic(), skyhookName, utils.PauseAnnotation); err != nil {
+				return err
+			}
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Skyhook %q resumed\n", skyhookName)
+			return nil
+		},
+	}
+
+	return cmd
+}

--- a/operator/internal/cli/resume_test.go
+++ b/operator/internal/cli/resume_test.go
@@ -1,0 +1,64 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cli
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/NVIDIA/skyhook/operator/internal/cli/context"
+)
+
+var _ = Describe("Resume Command", func() {
+	Describe("NewResumeCmd", func() {
+		It("should create command with correct properties", func() {
+			ctx := context.NewCLIContext(nil)
+			cmd := NewResumeCmd(ctx)
+
+			Expect(cmd.Use).To(Equal("resume <skyhook-name>"))
+			Expect(cmd.Short).To(ContainSubstring("Resume"))
+		})
+
+		It("should not have confirm flag (resume is safe)", func() {
+			ctx := context.NewCLIContext(nil)
+			cmd := NewResumeCmd(ctx)
+
+			confirmFlag := cmd.Flags().Lookup("confirm")
+			Expect(confirmFlag).To(BeNil())
+		})
+
+		It("should require exactly one argument", func() {
+			ctx := context.NewCLIContext(nil)
+			cmd := NewResumeCmd(ctx)
+
+			err := cmd.Args(cmd, []string{})
+			Expect(err).To(HaveOccurred())
+
+			err = cmd.Args(cmd, []string{"skyhook1"})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should have examples in help", func() {
+			ctx := context.NewCLIContext(nil)
+			cmd := NewResumeCmd(ctx)
+
+			Expect(cmd.Example).To(ContainSubstring("kubectl skyhook resume"))
+		})
+	})
+})


### PR DESCRIPTION
## Summary
Adds CLI commands to control Skyhook lifecycle via annotations:

- `skyhook pause <name>` - Stops processing new nodes (sets `skyhook.nvidia.com/pause`)
- `skyhook resume <name>` - Resumes a paused Skyhook
- `skyhook disable <name>` - Completely disables a Skyhook (sets `skyhook.nvidia.com/disable`)
- `skyhook enable <name>` - Re-enables a disabled Skyhook

## Changes
- New commands in `operator/internal/cli/`
- Shared annotation helpers in `utils/utils.go`
- Unit tests for all commands
- Chainsaw e2e tests in `k8s-tests/chainsaw/cli/lifecycle/`