### PR TITLE
feat: add support for ignoring nodes via label

### DIFF
--- a/operator/internal/controller/cluster_state_v2_test.go
+++ b/operator/internal/controller/cluster_state_v2_test.go
@@ -114,6 +114,33 @@ var _ = Describe("cluster state v2 tests", func() {
 
 		Expect(CheckTaintToleration(tolerations, taints)).To(BeTrue())
 	})
+
+	It("When node has ignore label it is blocked", func() {
+		node := &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: "node1", Labels: map[string]string{v1alpha1.METADATA_PREFIX + "/ignore": "true"}},
+		}
+		skyhookNode, err := wrapper.NewSkyhookNode(node, &v1alpha1.Skyhook{})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(CheckNodeIgnoreLabel(skyhookNode)).To(BeTrue())
+	})
+
+	It("When node does not have ignore label it is not blocked", func() {
+		node := &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: "node1", Labels: map[string]string{}},
+		}
+		skyhookNode, err := wrapper.NewSkyhookNode(node, &v1alpha1.Skyhook{})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(CheckNodeIgnoreLabel(skyhookNode)).To(BeFalse())
+	})
+
+	It("When node has ignore label set to false it is not blocked", func() {
+		node := &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: "node1", Labels: map[string]string{v1alpha1.METADATA_PREFIX + "/ignore": "false"}},
+		}
+		skyhookNode, err := wrapper.NewSkyhookNode(node, &v1alpha1.Skyhook{})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(CheckNodeIgnoreLabel(skyhookNode)).To(BeFalse())
+	})
 })
 
 // --- Add GetNextSkyhook tests ---


### PR DESCRIPTION
Adds a `skyhook.nvidia.com/ignore=true` label that can be applied to nodes to exclude them from Skyhook processing.

**Changes:**
- New `CheckNodeIgnoreLabel()` helper to detect nodes with the ignore label
- Nodes with the label are set to `StatusBlocked` and skipped during batch selection
- Adds `NodesIgnored` condition to the Skyhook status reflecting which nodes (if any) are being ignored