### PR TITLE
refactor: consolidate BuildState and compartment batch selection logic

### DIFF
--- a/operator/internal/controller/skyhook_controller.go
+++ b/operator/internal/controller/skyhook_controller.go
@@ -293,13 +293,6 @@ func (r *SkyhookReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return ctrl.Result{}, err
 	}
 
-	// PARTITION nodes into compartments for each skyhook that uses deployment policies
-	err = partitionNodesIntoCompartments(clusterState)
-	if err != nil {
-		logger.Error(err, "error partitioning nodes into compartments")
-		return ctrl.Result{}, err
-	}
-
 	if yes, result, err := shouldReturn(r.HandleMigrations(ctx, clusterState)); yes {
 		return result, err
 	}

--- a/operator/internal/controller/skyhook_controller_test.go
+++ b/operator/internal/controller/skyhook_controller_test.go
@@ -1433,8 +1433,6 @@ var _ = Describe("Resource Comparison", func() {
 
 		clusterState, err := BuildState(skyhooks, nodes, deploymentPolicies)
 		Expect(err).ToNot(HaveOccurred())
-		err = partitionNodesIntoCompartments(clusterState)
-		Expect(err).ToNot(HaveOccurred())
 		Expect(clusterState.skyhooks[0].GetCompartments()).To(HaveLen(3))
 		Expect(clusterState.skyhooks[0].GetCompartments()["compartment-a"].GetNodes()).To(HaveLen(2))
 		Expect(clusterState.skyhooks[0].GetCompartments()["compartment-b"].GetNodes()).To(HaveLen(1))

--- a/operator/internal/wrapper/compartment.go
+++ b/operator/internal/wrapper/compartment.go
@@ -131,9 +131,7 @@ func (c *Compartment) createNewBatch() []SkyhookNode {
 	if c.Strategy != nil {
 		batchSize = c.Strategy.CalculateBatchSize(len(c.Nodes), &c.BatchState)
 	} else {
-		ceiling := CalculateCeiling(c.Budget, len(c.Nodes))
-		availableCapacity := ceiling - c.getInProgressCount()
-		batchSize = max(0, availableCapacity)
+		batchSize = CalculateCeiling(c.Budget, len(c.Nodes))
 	}
 
 	if batchSize <= 0 {
@@ -141,7 +139,7 @@ func (c *Compartment) createNewBatch() []SkyhookNode {
 	}
 
 	selectedNodes := make([]SkyhookNode, 0)
-	priority := []v1alpha1.Status{v1alpha1.StatusInProgress, v1alpha1.StatusUnknown, v1alpha1.StatusBlocked, v1alpha1.StatusErroring}
+	priority := []v1alpha1.Status{v1alpha1.StatusUnknown, v1alpha1.StatusBlocked, v1alpha1.StatusErroring}
 
 	for _, status := range priority {
 		for _, node := range c.Nodes {


### PR DESCRIPTION
- Extract deployment policy initialization into `initializeCompartmentsFromPolicy` for readability
- Move `partitionNodesIntoCompartments` call inside `BuildState` to consolidate state building
- Remove dead code in `createNewBatch`: `StatusInProgress` check and `getInProgressCount()` 