### PR TITLE
fix: cleanup cli code

### DIFF
--- a/operator/cmd/cli/app/cli_test.go
+++ b/operator/cmd/cli/app/cli_test.go
@@ -247,7 +247,7 @@ var _ = Describe("Skyhook CLI Tests", func() {
 
 	Describe("defaultNamespace constant", func() {
 		It("should be set to skyhook", func() {
-			Expect(defaultNamespace).To(Equal("skyhook"))
+			Expect(context.DefaultNamespace).To(Equal("skyhook"))
 		})
 	})
 })

--- a/operator/cmd/cli/app/node/node_reset.go
+++ b/operator/cmd/cli/app/node/node_reset.go
@@ -138,6 +138,9 @@ func runNodeReset(ctx context.Context, cmd *cobra.Command, kubeClient *client.Cl
 
 		var nodeState v1alpha1.NodeState
 		if err := json.Unmarshal([]byte(annotation), &nodeState); err != nil {
+			if cliCtx.GlobalFlags.Verbose {
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: skipping node %q - invalid annotation: %v\n", nodeName, err)
+			}
 			continue
 		}
 

--- a/operator/cmd/cli/app/node/node_status.go
+++ b/operator/cmd/cli/app/node/node_status.go
@@ -40,13 +40,11 @@ const nodeStateAnnotationPrefix = v1alpha1.METADATA_PREFIX + "/nodeState_"
 // nodeStatusOptions holds the options for the node status command
 type nodeStatusOptions struct {
 	skyhookName string
-	output      string
 }
 
 // BindToCmd binds the options to the command flags
 func (o *nodeStatusOptions) BindToCmd(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&o.skyhookName, "skyhook", "", "Filter by Skyhook name")
-	cmd.Flags().StringVarP(&o.output, "output", "o", "table", "Output format: table, json, yaml, wide")
 }
 
 // NewStatusCmd creates the node status command
@@ -90,7 +88,7 @@ Node names can be exact matches or regex patterns.`,
 				return fmt.Errorf("initializing kubernetes client: %w", err)
 			}
 
-			return runNodeStatus(cmd.Context(), cmd.OutOrStdout(), kubeClient, args, opts)
+			return runNodeStatus(cmd.Context(), kubeClient, args, opts, ctx)
 		},
 	}
 
@@ -119,7 +117,8 @@ type nodeSkyhookPkgStatus struct {
 	Image    string `json:"image,omitempty"`
 }
 
-func runNodeStatus(ctx context.Context, out io.Writer, kubeClient *client.Client, nodePatterns []string, opts *nodeStatusOptions) error {
+func runNodeStatus(ctx context.Context, kubeClient *client.Client, nodePatterns []string, opts *nodeStatusOptions, cliCtx *cliContext.CLIContext) error {
+	out := cliCtx.Config().OutputWriter
 	// Get all nodes
 	nodeList, err := kubeClient.Kubernetes().CoreV1().Nodes().List(ctx, metav1.ListOptions{})
 	if err != nil {
@@ -175,6 +174,9 @@ func runNodeStatus(ctx context.Context, out io.Writer, kubeClient *client.Client
 
 			var nodeState v1alpha1.NodeState
 			if err := json.Unmarshal([]byte(annotationValue), &nodeState); err != nil {
+				if cliCtx.GlobalFlags.Verbose {
+					_, _ = fmt.Fprintf(cliCtx.Config().ErrorWriter, "Warning: skipping node %q skyhook %q - invalid annotation: %v\n", node.Name, skyhookName, err)
+				}
 				continue // Skip invalid annotations
 			}
 
@@ -243,12 +245,12 @@ func runNodeStatus(ctx context.Context, out io.Writer, kubeClient *client.Client
 	}
 
 	// Output based on format
-	switch opts.output {
-	case "json":
+	switch cliCtx.GlobalFlags.OutputFormat {
+	case utils.OutputFormatJSON:
 		return utils.OutputJSON(out, summaries)
-	case "yaml":
+	case utils.OutputFormatYAML:
 		return utils.OutputYAML(out, summaries)
-	case "wide":
+	case utils.OutputFormatWide:
 		return outputNodeStatusWide(out, summaries)
 	default:
 		return outputNodeStatusTable(out, summaries)
@@ -265,13 +267,6 @@ func nodeStatusTableConfig() utils.TableConfig[nodeSkyhookSummary] {
 				s.SkyhookName,
 				s.Status,
 				fmt.Sprintf("%d/%d", s.PackagesComplete, s.PackagesTotal),
-			}
-		},
-		WideHeaders: []string{"COMPLETE", "TOTAL"},
-		WideExtract: func(s nodeSkyhookSummary) []string {
-			return []string{
-				fmt.Sprintf("%d", s.PackagesComplete),
-				fmt.Sprintf("%d", s.PackagesTotal),
 			}
 		},
 	}

--- a/operator/cmd/cli/app/package/package_logs_test.go
+++ b/operator/cmd/cli/app/package/package_logs_test.go
@@ -282,7 +282,7 @@ var _ = Describe("Package Logs Command", func() {
 				packageName: "pkg1",
 			}
 
-			err := runLogs(gocontext.Background(), output, kubeClient, opts)
+			err := runLogs(gocontext.Background(), output, kubeClient, opts, "skyhook")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(output.String()).To(ContainSubstring("No pods found"))
 		})
@@ -292,7 +292,7 @@ var _ = Describe("Package Logs Command", func() {
 			pod := &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "other-pod",
-					Namespace: skyhookNamespace,
+					Namespace: context.DefaultNamespace,
 					Labels: map[string]string{
 						v1alpha1.METADATA_PREFIX + "/name":    "other-skyhook",
 						v1alpha1.METADATA_PREFIX + "/package": "other-pkg",
@@ -302,14 +302,14 @@ var _ = Describe("Package Logs Command", func() {
 					NodeName: "node1",
 				},
 			}
-			_, _ = fakeKube.CoreV1().Pods(skyhookNamespace).Create(gocontext.Background(), pod, metav1.CreateOptions{})
+			_, _ = fakeKube.CoreV1().Pods(context.DefaultNamespace).Create(gocontext.Background(), pod, metav1.CreateOptions{})
 
 			opts := &logsOptions{
 				skyhookName: testSkyhookNameLogs,
 				packageName: "pkg1",
 			}
 
-			err := runLogs(gocontext.Background(), output, kubeClient, opts)
+			err := runLogs(gocontext.Background(), output, kubeClient, opts, "skyhook")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(output.String()).To(ContainSubstring("No pods found"))
 		})
@@ -320,7 +320,7 @@ var _ = Describe("Package Logs Command", func() {
 				pod := &corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "pod-" + nodeName,
-						Namespace: skyhookNamespace,
+						Namespace: context.DefaultNamespace,
 						Labels: map[string]string{
 							v1alpha1.METADATA_PREFIX + "/name":    testSkyhookNameLogs,
 							v1alpha1.METADATA_PREFIX + "/package": "pkg1-1.0.0",
@@ -344,7 +344,7 @@ var _ = Describe("Package Logs Command", func() {
 						},
 					},
 				}
-				_, _ = fakeKube.CoreV1().Pods(skyhookNamespace).Create(gocontext.Background(), pod, metav1.CreateOptions{})
+				_, _ = fakeKube.CoreV1().Pods(context.DefaultNamespace).Create(gocontext.Background(), pod, metav1.CreateOptions{})
 			}
 
 			opts := &logsOptions{
@@ -353,7 +353,7 @@ var _ = Describe("Package Logs Command", func() {
 				node:        "node1",
 			}
 
-			err := runLogs(gocontext.Background(), output, kubeClient, opts)
+			err := runLogs(gocontext.Background(), output, kubeClient, opts, "skyhook")
 			Expect(err).NotTo(HaveOccurred())
 			// Should only show pod on node1
 			Expect(output.String()).To(ContainSubstring("pod-node1"))
@@ -364,7 +364,7 @@ var _ = Describe("Package Logs Command", func() {
 			pod := &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-pod",
-					Namespace: skyhookNamespace,
+					Namespace: context.DefaultNamespace,
 					Labels: map[string]string{
 						v1alpha1.METADATA_PREFIX + "/name":    testSkyhookNameLogs,
 						v1alpha1.METADATA_PREFIX + "/package": "pkg1-1.0.0",
@@ -388,14 +388,14 @@ var _ = Describe("Package Logs Command", func() {
 					},
 				},
 			}
-			_, _ = fakeKube.CoreV1().Pods(skyhookNamespace).Create(gocontext.Background(), pod, metav1.CreateOptions{})
+			_, _ = fakeKube.CoreV1().Pods(context.DefaultNamespace).Create(gocontext.Background(), pod, metav1.CreateOptions{})
 
 			opts := &logsOptions{
 				skyhookName: testSkyhookNameLogs,
 				packageName: "pkg1",
 			}
 
-			err := runLogs(gocontext.Background(), output, kubeClient, opts)
+			err := runLogs(gocontext.Background(), output, kubeClient, opts, "skyhook")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(output.String()).To(ContainSubstring("test-pod"))
 		})
@@ -404,7 +404,7 @@ var _ = Describe("Package Logs Command", func() {
 			pod := &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-pod",
-					Namespace: skyhookNamespace,
+					Namespace: context.DefaultNamespace,
 					Labels: map[string]string{
 						v1alpha1.METADATA_PREFIX + "/name":    testSkyhookNameLogs,
 						v1alpha1.METADATA_PREFIX + "/package": "other-pkg-1.0.0",
@@ -414,14 +414,14 @@ var _ = Describe("Package Logs Command", func() {
 					NodeName: "node1",
 				},
 			}
-			_, _ = fakeKube.CoreV1().Pods(skyhookNamespace).Create(gocontext.Background(), pod, metav1.CreateOptions{})
+			_, _ = fakeKube.CoreV1().Pods(context.DefaultNamespace).Create(gocontext.Background(), pod, metav1.CreateOptions{})
 
 			opts := &logsOptions{
 				skyhookName: testSkyhookNameLogs,
 				packageName: "pkg1",
 			}
 
-			err := runLogs(gocontext.Background(), output, kubeClient, opts)
+			err := runLogs(gocontext.Background(), output, kubeClient, opts, "skyhook")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(output.String()).To(ContainSubstring("No pods matched"))
 		})
@@ -534,7 +534,7 @@ var _ = Describe("Package Logs Command", func() {
 
 	Describe("skyhookNamespace constant", func() {
 		It("should be set to skyhook", func() {
-			Expect(skyhookNamespace).To(Equal("skyhook"))
+			Expect(context.DefaultNamespace).To(Equal("skyhook"))
 		})
 	})
 })

--- a/operator/cmd/cli/app/version.go
+++ b/operator/cmd/cli/app/version.go
@@ -34,8 +34,6 @@ import (
 	"github.com/NVIDIA/skyhook/operator/internal/version"
 )
 
-const defaultNamespace = "skyhook"
-
 // NewVersionCmd creates the version command.
 func NewVersionCmd(ctx *cliContext.CLIContext) *cobra.Command {
 	var timeout time.Duration
@@ -96,7 +94,7 @@ func discoverOperatorVersion(ctx context.Context, kube kubernetes.Interface, nam
 		return "", fmt.Errorf("nil kubernetes client")
 	}
 	if namespace == "" {
-		namespace = defaultNamespace
+		namespace = cliContext.DefaultNamespace
 	}
 
 	deploymentName := "skyhook-operator-controller-manager"

--- a/operator/internal/cli/context/context.go
+++ b/operator/internal/cli/context/context.go
@@ -28,7 +28,8 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
 
-const defaultNamespace = "skyhook"
+// DefaultNamespace is the default namespace for Skyhook resources
+const DefaultNamespace = "skyhook"
 
 // GlobalFlags holds persistent CLI flags that every command uses (kubeconfig, namespace, output, etc.).
 type GlobalFlags struct {
@@ -45,7 +46,7 @@ func NewGlobalFlags() *GlobalFlags {
 		flags.Namespace = new(string)
 	}
 	if *flags.Namespace == "" {
-		*flags.Namespace = defaultNamespace
+		*flags.Namespace = DefaultNamespace
 	}
 
 	return &GlobalFlags{
@@ -81,11 +82,11 @@ func (f *GlobalFlags) Validate() error {
 // Namespace returns the namespace selected via kubeconfig or flag (default "skyhook").
 func (f *GlobalFlags) Namespace() string {
 	if f.ConfigFlags == nil || f.ConfigFlags.Namespace == nil {
-		return defaultNamespace
+		return DefaultNamespace
 	}
 	ns := strings.TrimSpace(*f.ConfigFlags.Namespace)
 	if ns == "" {
-		return defaultNamespace
+		return DefaultNamespace
 	}
 	return ns
 }
@@ -150,8 +151,4 @@ func NewCLIContext(config *CLIConfig) *CLIContext {
 // Config returns the CLI configuration.
 func (c *CLIContext) Config() *CLIConfig {
 	return c.config
-}
-
-func (c *CLIContext) GetGlobalFlags() *GlobalFlags {
-	return c.GlobalFlags
 }

--- a/operator/internal/cli/context/context_test.go
+++ b/operator/internal/cli/context/context_test.go
@@ -186,9 +186,5 @@ var _ = Describe("CLI Context", func() {
 			Expect(ctx.Config()).To(Equal(config))
 		})
 
-		It("should return global flags via GetGlobalFlags", func() {
-			ctx := NewCLIContext(nil)
-			Expect(ctx.GetGlobalFlags()).To(Equal(ctx.GlobalFlags))
-		})
 	})
 })

--- a/operator/internal/cli/utils/utils.go
+++ b/operator/internal/cli/utils/utils.go
@@ -37,6 +37,14 @@ import (
 	"github.com/NVIDIA/skyhook/operator/api/v1alpha1"
 )
 
+// Output format constants
+const (
+	OutputFormatTable = "table"
+	OutputFormatJSON  = "json"
+	OutputFormatYAML  = "yaml"
+	OutputFormatWide  = "wide"
+)
+
 // MatchNodes matches node patterns against a list of available nodes.
 // Patterns can be exact node names or regex patterns.
 func MatchNodes(patterns []string, availableNodes []string) ([]string, error) {
@@ -73,14 +81,6 @@ func MatchNodes(patterns []string, availableNodes []string) ([]string, error) {
 	}
 
 	return result, nil
-}
-
-// EscapeJSONPointer escapes special characters in JSON Pointer tokens
-// per RFC 6901: ~ becomes ~0, / becomes ~1
-func EscapeJSONPointer(s string) string {
-	s = strings.ReplaceAll(s, "~", "~0")
-	s = strings.ReplaceAll(s, "/", "~1")
-	return s
 }
 
 // UnstructuredToSkyhook converts an unstructured object to a Skyhook.

--- a/operator/internal/cli/utils/utils_test.go
+++ b/operator/internal/cli/utils/utils_test.go
@@ -98,38 +98,4 @@ var _ = Describe("CLI Utility Functions", func() {
 		})
 
 	})
-
-	Describe("EscapeJSONPointer", func() {
-		It("should escape tilde", func() {
-			result := EscapeJSONPointer("key~value")
-			Expect(result).To(Equal("key~0value"))
-		})
-
-		It("should escape forward slash", func() {
-			result := EscapeJSONPointer("key/value")
-			Expect(result).To(Equal("key~1value"))
-		})
-
-		It("should escape both tilde and forward slash", func() {
-			result := EscapeJSONPointer("key~with/special")
-			Expect(result).To(Equal("key~0with~1special"))
-		})
-
-		It("should handle string without special characters", func() {
-			result := EscapeJSONPointer("normalkey")
-			Expect(result).To(Equal("normalkey"))
-		})
-
-		It("should handle empty string", func() {
-			result := EscapeJSONPointer("")
-			Expect(result).To(Equal(""))
-		})
-
-		It("should escape tilde before forward slash per RFC 6901", func() {
-			// RFC 6901 requires ~ to be escaped first, then /
-			// This ensures ~/value becomes ~0~1value, not ~01value
-			result := EscapeJSONPointer("~/value")
-			Expect(result).To(Equal("~0~1value"))
-		})
-	})
 })


### PR DESCRIPTION
Addresses code quality issues identified in CLI code review.

### Changes

- **Consolidate namespace constant**: Export `DefaultNamespace` from context package, remove duplicates
- **Standardize output flag**: Use global `--output` flag consistently across all commands
- **Fix `--verbose` flag**: Now logs warnings when skipping nodes with invalid JSON annotations
- **Add dry-run to lifecycle commands**: `pause`, `resume`, `disable`, `enable` now respect `--dry-run`
- **Fix confirmation prompts**: Use `cmd.InOrStdin()` for testable input handling
- **Remove hardcoded namespace**: `package logs` now uses the global namespace flag
- **Remove dead code**: `GetGlobalFlags()` method and unused test utilities