### PR TITLE
fix: sync chart CRD deploymentPolicy type and add smoke test

### DIFF
--- a/chart/templates/skyhook-crd.yaml
+++ b/chart/templates/skyhook-crd.yaml
@@ -108,18 +108,7 @@ spec:
               deploymentPolicy:
                 description: DeploymentPolicy is the name of a DeploymentPolicy for
                   rollout settings
-                properties:
-                  name:
-                    default: ""
-                    description: |-
-                      Name of the referent.
-                      This field is effectively required, but due to backwards compatibility is
-                      allowed to be empty. Instances of this type with an empty value here are
-                      almost certainly wrong.
-                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                    type: string
-                type: object
-                x-kubernetes-map-type: atomic
+                type: string
               interruptionBudget:
                 description: InterruptionBudget configures how many nodes that match
                   node selectors that allowed to be interrupted at once.

--- a/k8s-tests/chainsaw/helm/helm-chart-test/assert-skyhook-complete.yaml
+++ b/k8s-tests/chainsaw/helm/helm-chart-test/assert-skyhook-complete.yaml
@@ -14,24 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-controllerManager:
-  # setting a toleration on the manager for testing purposes
-  tolerations:
-  - key: dedicated
-    operator: "Equal"
-    value: system-cpu
-    effect: NoSchedule
-  manager:
-    # telling the helm chart to use the test operator image
-    # for more info refer to the README
-    image:
-      repository: ghcr.io/nvidia/skyhook/operator
-      tag: latest ## THIS should change to be like a tag so it can point at a specific commit
-      digest: ""
-    # Use agentless mock image for testing - it just sleeps and exits successfully
-    agent:
-      repository: ghcr.io/nvidia/skyhook/agentless
-      tag: "6.2.0"
-      digest: ""
-webhook:
-  enable: false
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: skyhook.nvidia.com/v1alpha1
+kind: Skyhook
+metadata:
+  name: helm-test-skyhook
+status:
+  status: complete

--- a/k8s-tests/chainsaw/helm/helm-chart-test/chainsaw-test.yaml
+++ b/k8s-tests/chainsaw/helm/helm-chart-test/chainsaw-test.yaml
@@ -50,7 +50,18 @@ spec:
           ../install-helm-chart.sh foobar
     - assert:
         file: assert-scheduled.yaml
+    - apply:
+        file: deployment-policy.yaml
+    - apply:
+        file: skyhook.yaml
+    - assert:
+        file: assert-skyhook-complete.yaml
     finally:
+    - script:
+        content: |
+          ## Cleanup deployment policy test resources
+          kubectl delete skyhook helm-test-skyhook --ignore-not-found || true
+          kubectl delete deploymentpolicy helm-test-policy -n skyhook --ignore-not-found || true
     - script:
         content: |
           ## Remove taint from nodes

--- a/k8s-tests/chainsaw/helm/helm-chart-test/deployment-policy.yaml
+++ b/k8s-tests/chainsaw/helm/helm-chart-test/deployment-policy.yaml
@@ -14,24 +14,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-controllerManager:
-  # setting a toleration on the manager for testing purposes
-  tolerations:
-  - key: dedicated
-    operator: "Equal"
-    value: system-cpu
-    effect: NoSchedule
-  manager:
-    # telling the helm chart to use the test operator image
-    # for more info refer to the README
-    image:
-      repository: ghcr.io/nvidia/skyhook/operator
-      tag: latest ## THIS should change to be like a tag so it can point at a specific commit
-      digest: ""
-    # Use agentless mock image for testing - it just sleeps and exits successfully
-    agent:
-      repository: ghcr.io/nvidia/skyhook/agentless
-      tag: "6.2.0"
-      digest: ""
-webhook:
-  enable: false
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: skyhook.nvidia.com/v1alpha1
+kind: DeploymentPolicy
+metadata:
+  name: helm-test-policy
+  namespace: skyhook
+spec:
+  default:
+    budget:
+      percent: 100
+    strategy:
+      fixed:
+        initialBatch: 1
+        batchThreshold: 100
+        safetyLimit: 50

--- a/k8s-tests/chainsaw/helm/helm-chart-test/skyhook.yaml
+++ b/k8s-tests/chainsaw/helm/helm-chart-test/skyhook.yaml
@@ -14,24 +14,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-controllerManager:
-  # setting a toleration on the manager for testing purposes
-  tolerations:
-  - key: dedicated
-    operator: "Equal"
-    value: system-cpu
-    effect: NoSchedule
-  manager:
-    # telling the helm chart to use the test operator image
-    # for more info refer to the README
-    image:
-      repository: ghcr.io/nvidia/skyhook/operator
-      tag: latest ## THIS should change to be like a tag so it can point at a specific commit
-      digest: ""
-    # Use agentless mock image for testing - it just sleeps and exits successfully
-    agent:
-      repository: ghcr.io/nvidia/skyhook/agentless
-      tag: "6.2.0"
-      digest: ""
-webhook:
-  enable: false
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: skyhook.nvidia.com/v1alpha1
+kind: Skyhook
+metadata:
+  name: helm-test-skyhook
+spec:
+  nodeSelectors:
+    matchExpressions:
+      - key: node-role.kubernetes.io/control-plane
+        operator: DoesNotExist
+  deploymentPolicy: helm-test-policy
+  additionalTolerations:
+    - key: dedicated
+      value: system-cpu
+      effect: NoSchedule
+  packages:
+    helm-test:
+      version: "6.2.0"
+      image: ghcr.io/nvidia/skyhook/agentless
+      env:
+        - name: SLEEP_LEN
+          value: "1"


### PR DESCRIPTION
Fixes chart CRD where spec.deploymentPolicy was incorrectly typed as 
object instead of string, causing validation errors. Adds a 
DeploymentPolicy smoke test to helm-chart-test to catch similar 
issues during CI.

- Fix spec.deploymentPolicy type: object → string (matches operator CRD)
- Add DeploymentPolicy + Skyhook smoke test to helm-chart-test