### PR TITLE
ci: add GoReleaser workflow for CLI releases

### DIFF
--- a/.github/workflows/cli-release.yaml
+++ b/.github/workflows/cli-release.yaml
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Build and release CLI binaries when cli/* tags are pushed
+# Uses GoReleaser for cross-platform builds (standard for kubectl plugins)
+name: CLI Release
+
+on:
+  push:
+    tags:
+      - cli/*
+
+env:
+  GO_VERSION: 1.24.6
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write  # Required to create releases
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Setup Go ${{ env.GO_VERSION }}
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: operator/go.sum
+
+      - name: Extract version from tag
+        id: version
+        run: |
+          # Tag is cli/v0.9.0, extract v0.9.0
+          VERSION=$(echo "${{ github.ref_name }}" | cut -f 2 -d /)
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "Building CLI version: ${VERSION}"
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean
+          workdir: operator
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GORELEASER_CURRENT_TAG: ${{ steps.version.outputs.version }}

--- a/operator/.gitignore
+++ b/operator/.gitignore
@@ -35,3 +35,6 @@ __debug_bin*
 docs/metrics/grafana-dashboards-configmap.yaml
 
 examples
+
+# GoReleaser artifacts
+dist/

--- a/operator/.goreleaser.yaml
+++ b/operator/.goreleaser.yaml
@@ -1,0 +1,101 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# GoReleaser configuration for kubectl-skyhook CLI
+# Triggered by cli/* tags via GitHub Actions
+# See: https://goreleaser.com/customization/
+
+version: 2
+
+project_name: kubectl-skyhook
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - id: kubectl-skyhook
+    main: ./cmd/cli/main.go
+    binary: kubectl-skyhook
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ignore:
+      - goos: windows
+        goarch: arm64
+    ldflags:
+      - -s -w
+      - -X github.com/NVIDIA/skyhook/operator/internal/version.VERSION={{.Version}}
+      - -X github.com/NVIDIA/skyhook/operator/internal/version.GIT_SHA={{.ShortCommit}}
+
+archives:
+  - id: kubectl-skyhook
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    formats:
+      - tar.gz
+    format_overrides:
+      - goos: windows
+        formats:
+          - zip
+
+checksum:
+  name_template: "checksums.txt"
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^chore:"
+      - Merge pull request
+      - Merge branch
+
+release:
+  github:
+    owner: NVIDIA
+    name: skyhook
+  name_template: "Skyhook CLI {{.Tag}}"
+  header: |
+    ## Skyhook CLI {{ .Version }}
+    
+    ### Installation
+    
+    Download and extract the appropriate archive for your platform:
+    
+    ```bash
+    # Linux (amd64)
+    curl -LO https://github.com/NVIDIA/skyhook/releases/download/{{ .Tag }}/kubectl-skyhook_{{ .Version }}_linux_amd64.tar.gz
+    tar -xzf kubectl-skyhook_{{ .Version }}_linux_amd64.tar.gz
+    sudo mv kubectl-skyhook /usr/local/bin/
+    
+    # macOS (Apple Silicon)
+    curl -LO https://github.com/NVIDIA/skyhook/releases/download/{{ .Tag }}/kubectl-skyhook_{{ .Version }}_darwin_arm64.tar.gz
+    tar -xzf kubectl-skyhook_{{ .Version }}_darwin_arm64.tar.gz
+    sudo mv kubectl-skyhook /usr/local/bin/
+    ```
+    
+    ### Verify installation
+    
+    ```bash
+    kubectl skyhook version --client-only
+    ```

--- a/operator/go.mod
+++ b/operator/go.mod
@@ -94,5 +94,5 @@ require (
 	k8s.io/kube-openapi v0.0.0-20250710124328-f3f2b991d03b // indirect
 	k8s.io/utils v0.0.0-20250604170112-4c0f3b243397
 	sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 // indirect
-	sigs.k8s.io/yaml v1.6.0 // indirect
+	sigs.k8s.io/yaml v1.6.0
 )


### PR DESCRIPTION
Adds automated CLI binary releases using GoReleaser.

### Changes
- Add `.github/workflows/cli-release.yaml` - triggers on `cli/*` tags
- Add `operator/.goreleaser.yaml` - cross-platform build config
- Add `dist/` to `.gitignore`

### Release Process
1. Push tag: `git tag cli/v0.9.0 && git push origin cli/v0.9.0`
2. Workflow builds binaries for linux/darwin/windows (amd64/arm64)
3. Creates GitHub release with archives and checksums

### Platforms
- Linux (amd64, arm64)
- macOS (amd64, arm64)
- Windows (amd64)