### PR TITLE
fix!: make imagePullSecret optional to prevent kubelet errors

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -34,7 +34,7 @@ Settings | Description | Default |
 | controllerManager.manager.agent.repository | Where to get the image from | "ghcr.io/nvidia/skyhook/agent" |
 | controllerManager.manager.agent.tag | what version of the agent to run | defaults to the current latest, but is not latest example v6.1.5 |
 | controllerManager.manager.agent.digest | content-addressable pin for the agent image. Same precedence rules as above: if both tag and digest are provided, the digest controls which image is pulled. | "" |
-| imagePullSecret | the secret used to pull the operator controller image, agent image, and package images. | node-init-secret |
+| imagePullSecret | the secret used to pull the operator controller image, agent image, and package images. | "" |
 | estimatedPackageCount | estimated number of packages to be installed on the cluster, this is used to calculate the resources for the operator controller. | 1 |
 | estimatedNodeCount | estimated number of nodes in the cluster, this is used to calculate the resources for the operator controller | 1 |
 
@@ -43,6 +43,22 @@ Settings | Description | Default |
 - **runtimeRequired**: If your systems nodes have this taint make sure to add the toleration to the controllerManager.tolerations
 - **CRD**: This project currently has one CRD and its not managed the ["recommended" way](https://helm.sh/docs/chart_best_practices/custom_resource_definitions/). Its part of the templates. Meaning it will be updated with the `helm upgrade`. We decided it was better do it this way for this project. Doing it either way has consequences and this route has worked well for upgrades so far our deployments.
 - **Image pinning (tag vs digest)**: You can set either an image tag or a digest. If both are set, the digest is prioritized; the tag is ignored for selection and may appear as `tag@digest` only for readability. This applies to both operator and agent images.
+
+## Upgrade Notes
+
+### Breaking Change: imagePullSecret Default Changed
+
+**Previous behavior:** The `imagePullSecret` value defaulted to `node-init-secret`. If this secret didn't exist, kubelet logs would show errors about the missing secret.
+
+**New behavior:** The `imagePullSecret` value now defaults to empty (`""`). No imagePullSecrets will be added to pods unless explicitly configured.
+
+**Migration:** If you rely on `node-init-secret` for pulling images from private registries, you must now explicitly set `imagePullSecret` in your values:
+
+```yaml
+imagePullSecret: "node-init-secret"
+```
+
+If you use public images (like the default ghcr.io images), no action is needed.
 
 ### Resource Management
 Skyhook uses Kubernetes LimitRange to set default CPU/memory requests/limits for all containers in the namespace. You can override these per-package in your Skyhook CR. Strict validation is enforced. See [../docs/resource_management.md](../docs/resource_management.md) for details and examples.

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -166,7 +166,9 @@ spec:
         securityContext: {{- toYaml .Values.controllerManager.kubeRbacProxy.containerSecurityContext
           | nindent 10 }}
       imagePullSecrets:
+      {{- if .Values.imagePullSecret }}
         - name: {{ quote .Values.imagePullSecret }}
+      {{- end }}
       volumes:
       - name: kube-api-access
         projected:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -136,7 +136,7 @@ rbac:
   createSkyhookViewerRole: false
   createSkyhookEditorRole: false
 ## imagePullSecret: is the secret used to pull the operator controller image, agent image, and package images.
-imagePullSecret: node-init-secret
+imagePullSecret: ""
 ## useHostNetwork: Whether the Operator pods should use hostNetwork: true or false
 useHostNetwork: false
 ## estimatedPackageCount: estimated number of packages to be installed on the cluster

--- a/operator/config/manager/manager.yaml
+++ b/operator/config/manager/manager.yaml
@@ -79,8 +79,8 @@ spec:
         # versions < 1.19 or on vendors versions which do NOT support this field by default (i.e. Openshift < 4.11 ).
         # seccompProfile:
         #   type: RuntimeDefault
-      imagePullSecrets: 
-        - name: node-init-secret
+      # imagePullSecrets: 
+      #   - name: node-init-secret
       containers:
       - command:
         - /manager
@@ -98,7 +98,7 @@ spec:
           - name: NAMESPACE
             value: skyhook-operator-system
           - name: IMAGE_PULL_SECRET
-            value: node-init-secret
+            value: ""
           - name: COPY_DIR_ROOT
             value: /var/lib/skyhook
           - name: REAPPLY_ON_REBOOT

--- a/operator/internal/controller/skyhook_controller.go
+++ b/operator/internal/controller/skyhook_controller.go
@@ -73,7 +73,7 @@ const (
 type SkyhookOperatorOptions struct {
 	Namespace            string        `env:"NAMESPACE, default=skyhook"`
 	MaxInterval          time.Duration `env:"DEFAULT_INTERVAL, default=10m"`
-	ImagePullSecret      string        `env:"IMAGE_PULL_SECRET, default=node-init-secret"` //TODO: should this be defaulted?
+	ImagePullSecret      string        `env:"IMAGE_PULL_SECRET"`
 	CopyDirRoot          string        `env:"COPY_DIR_ROOT, default=/var/lib/skyhook"`
 	ReapplyOnReboot      bool          `env:"REAPPLY_ON_REBOOT, default=false"`
 	RuntimeRequiredTaint string        `env:"RUNTIME_REQUIRED_TAINT, default=skyhook.nvidia.com=runtime-required:NoSchedule"`
@@ -1608,11 +1608,6 @@ func createInterruptPodForPackage(opts SkyhookOperatorOptions, _interrupt *v1alp
 					},
 				},
 			},
-			ImagePullSecrets: []corev1.LocalObjectReference{
-				{
-					Name: opts.ImagePullSecret,
-				},
-			},
 			HostPID:     true,
 			HostNetwork: true,
 			// If you change these go change the SelectNode toleration in cluster_state.go
@@ -1625,6 +1620,13 @@ func createInterruptPodForPackage(opts SkyhookOperatorOptions, _interrupt *v1alp
 			}, skyhook.Spec.AdditionalTolerations...),
 			Volumes: volumes,
 		},
+	}
+	if opts.ImagePullSecret != "" {
+		pod.Spec.ImagePullSecrets = []corev1.LocalObjectReference{
+			{
+				Name: opts.ImagePullSecret,
+			},
+		}
 	}
 	return pod
 }
@@ -1819,11 +1821,6 @@ func createPodFromPackage(opts SkyhookOperatorOptions, _package *v1alpha1.Packag
 					},
 				},
 			},
-			ImagePullSecrets: []corev1.LocalObjectReference{
-				{
-					Name: opts.ImagePullSecret,
-				},
-			},
 			Volumes:     volumes,
 			HostPID:     true,
 			HostNetwork: true,
@@ -1836,6 +1833,13 @@ func createPodFromPackage(opts SkyhookOperatorOptions, _package *v1alpha1.Packag
 				opts.GetRuntimeRequiredToleration(),
 			}, skyhook.Spec.AdditionalTolerations...),
 		},
+	}
+	if opts.ImagePullSecret != "" {
+		pod.Spec.ImagePullSecrets = []corev1.LocalObjectReference{
+			{
+				Name: opts.ImagePullSecret,
+			},
+		}
 	}
 	if _package.GracefulShutdown != nil {
 		pod.Spec.TerminationGracePeriodSeconds = ptr(int64(_package.GracefulShutdown.Duration.Seconds()))


### PR DESCRIPTION
BREAKING CHANGE: imagePullSecret now defaults to empty string instead of "node-init-secret"

Previously, imagePullSecret defaulted to "node-init-secret" which caused kubelet to log errors when the secret didn't exist. This change makes the secret truly optional:

- chart/values.yaml: Change default from "node-init-secret" to ""
- chart/templates/deployment.yaml: Only add imagePullSecrets when set
- operator/internal/controller/skyhook_controller.go: Remove default value and conditionally add ImagePullSecrets to pods
- operator/config/manager/manager.yaml: Remove hardcoded secret
- Update documentation with migration instructions

Users pulling from private registries must now explicitly set imagePullSecret in their Helm values. Users with public images (default ghcr.io) need no changes.