### PR TITLE
fix: resolve webhook caBundle deadlock during helm upgrade

### DIFF
--- a/chart/templates/mutating-webhook.yaml
+++ b/chart/templates/mutating-webhook.yaml
@@ -7,7 +7,6 @@ webhooks:
 - admissionReviewVersions:
   - v1
   clientConfig:
-    caBundle: ""
     service:
       name: skyhook-operator-webhook-service
       namespace: {{ .Release.Namespace }}
@@ -35,7 +34,6 @@ webhooks:
 - admissionReviewVersions:
   - v1
   clientConfig:
-    caBundle: ""
     service:
       name: skyhook-operator-webhook-service
       namespace: {{ .Release.Namespace }}

--- a/chart/templates/validating-webhook.yaml
+++ b/chart/templates/validating-webhook.yaml
@@ -7,7 +7,6 @@ webhooks:
 - admissionReviewVersions:
   - v1
   clientConfig:
-    caBundle: ""
     service:
       name: skyhook-operator-webhook-service
       namespace: {{ .Release.Namespace }}
@@ -34,7 +33,6 @@ webhooks:
 - admissionReviewVersions:
   - v1
   clientConfig:
-    caBundle: ""
     service:
       name: skyhook-operator-webhook-service
       namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
During helm upgrade, the webhook configurations' caBundle field was reset to empty, causing new pods to fail readiness checks while the old leader pod never detected the change (only watched the cert Secret, with a 24h requeue). This created a deadlock where no pod could fix the caBundle.

- Watch ValidatingWebhookConfiguration and MutatingWebhookConfiguration so the leader detects caBundle changes immediately
- Use bytes.Equal for caBundle comparison instead of len==0 so stale values are corrected, not just empty ones
- Remove caBundle from Helm webhook templates so upgrades stop resetting operator-managed values