### PR TITLE
fix: webhook controller dropped CREATE/UPDATE operations for DeploymentPolicy validating rules

### DIFF
--- a/operator/internal/controller/webhook_controller.go
+++ b/operator/internal/controller/webhook_controller.go
@@ -476,7 +476,7 @@ func skyhookRules() []admissionregistrationv1.RuleWithOperations {
 func deploymentPolicyValidatingRules() []admissionregistrationv1.RuleWithOperations {
 	mutrules := deploymentPolicyMutatingRules()
 	oprs := mutrules[0].Operations
-	newops := make([]admissionregistrationv1.OperationType, 0, len(oprs)+1)
+	newops := make([]admissionregistrationv1.OperationType, len(oprs), len(oprs)+1)
 	copy(newops, oprs)
 	newops = append(newops, admissionregistrationv1.Delete)
 	mutrules[0].Operations = newops

--- a/operator/internal/controller/webhook_controller_test.go
+++ b/operator/internal/controller/webhook_controller_test.go
@@ -233,6 +233,37 @@ var _ = Describe("WebhookController", Ordered, func() {
 		})
 	})
 
+	Describe("webhook rule generation", func() {
+		It("should include CREATE, UPDATE, and DELETE for deploymentPolicy validating rules", func() {
+			rules := deploymentPolicyValidatingRules()
+			Expect(rules).To(HaveLen(1))
+			Expect(rules[0].Operations).To(ConsistOf(
+				admissionregistrationv1.Create,
+				admissionregistrationv1.Update,
+				admissionregistrationv1.Delete,
+			))
+			Expect(rules[0].Rule.Resources).To(Equal([]string{"deploymentpolicies"}))
+		})
+
+		It("should include CREATE and UPDATE for deploymentPolicy mutating rules", func() {
+			rules := deploymentPolicyMutatingRules()
+			Expect(rules).To(HaveLen(1))
+			Expect(rules[0].Operations).To(ConsistOf(
+				admissionregistrationv1.Create,
+				admissionregistrationv1.Update,
+			))
+		})
+
+		It("should include CREATE and UPDATE for skyhook rules", func() {
+			rules := skyhookRules()
+			Expect(rules).To(HaveLen(1))
+			Expect(rules[0].Operations).To(ConsistOf(
+				admissionregistrationv1.Create,
+				admissionregistrationv1.Update,
+			))
+		})
+	})
+
 	Describe("webhook rules comparison", func() {
 		It("should detect when rules are different", func() {
 			oldRules := []admissionregistrationv1.RuleWithOperations{


### PR DESCRIPTION


copy() with a zero-length destination slice copies nothing — the controller was enforcing [DELETE] instead of [CREATE, UPDATE, DELETE], causing ArgoCD to flag the ValidatingWebhookConfiguration as perpetually OutOfSync.