### PR TITLE
fix: batch stickiness — nodes in NodePriority finish all packages before new nodes are picked

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ coverage.out
 
 # Symlinks created by Makefile build-cli
 k8s-tests/chainsaw/*/skyhook-cli
+docs/plans/*
+.claude/

--- a/chart/templates/skyhook-crd.yaml
+++ b/chart/templates/skyhook-crd.yaml
@@ -712,6 +712,11 @@ spec:
                 description: NodeBootIds tracks the boot ids of nodes for triggering
                   on reboot
                 type: object
+              nodeOrderOffset:
+                description: |-
+                  NodeOrderOffset tracks the cumulative count of nodes removed from NodePriority.
+                  Used with NodePriority to compute monotonic SKYHOOK_NODE_ORDER across batches.
+                type: integer
               nodePriority:
                 additionalProperties:
                   format: date-time

--- a/k8s-tests/chainsaw/cli/reset/assert-nodes-reset.yaml
+++ b/k8s-tests/chainsaw/cli/reset/assert-nodes-reset.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 #
@@ -29,4 +29,11 @@ metadata:
     (contains(keys(@), "skyhook.nvidia.com/cordon_cli-reset-test")): false
     skyhook.nvidia.com/status_cli-reset-test: disabled ## disabled after clearing
     # skyhook.nvidia.com/version_cli-reset-test: .* ## also rest after clearing
-
+---
+# Verify node ordering is reset after CLI reset
+apiVersion: skyhook.nvidia.com/v1alpha1
+kind: Skyhook
+metadata:
+  name: cli-reset-test
+status:
+  nodeOrderOffset: 0

--- a/k8s-tests/chainsaw/skyhook/strict-order/assert-both-nodes-complete.yaml
+++ b/k8s-tests/chainsaw/skyhook/strict-order/assert-both-nodes-complete.yaml
@@ -29,6 +29,16 @@ metadata:
     skyhook.nvidia.com/status_strict-order-skyhook-c: complete
     skyhook.nvidia.com/status_strict-order-skyhook-d: disabled
 ---
+# Verify nodeOrderOffset incremented as nodes completed and were pruned from NodePriority
+# With 2 nodes, each skyhook should have offset=2 after both complete
+apiVersion: skyhook.nvidia.com/v1alpha1
+kind: Skyhook
+metadata:
+  name: strict-order-skyhook-zzz
+status:
+  nodeOrderOffset: 2
+  (length(nodePriority || `{}`)): 0
+---
 # Worker2 node complete (d still disabled)
 apiVersion: v1
 kind: Node

--- a/k8s-tests/chainsaw/skyhook/strict-order/chainsaw-test.yaml
+++ b/k8s-tests/chainsaw/skyhook/strict-order/chainsaw-test.yaml
@@ -77,6 +77,39 @@ spec:
     try:
     - sleep:
         duration: 5s
+    # Verify SKYHOOK_NODE_ORDER is set on the config pod for zzz on kind-worker (before zzz completes)
+    - assert:
+        resource:
+          apiVersion: v1
+          kind: Pod
+          metadata:
+            namespace: skyhook
+            labels:
+              skyhook.nvidia.com/name: strict-order-skyhook-zzz
+              skyhook.nvidia.com/package: foobar-1.2
+            annotations:
+              ("skyhook.nvidia.com/package" && parse_json("skyhook.nvidia.com/package")):
+                {
+                  "name": "foobar",
+                  "version": "1.2",
+                  "skyhook": "strict-order-skyhook-zzz",
+                  "stage": "config",
+                  "image": "ghcr.io/nvidia/skyhook/agentless"
+                }
+          spec:
+            nodeName: kind-worker
+            initContainers:
+              - name: foobar-init
+              - name: foobar-config
+                env:
+                  ([5]):
+                    name: SKYHOOK_NODE_ORDER
+                    value: "0"
+              - name: foobar-configcheck
+                env:
+                  ([5]):
+                    name: SKYHOOK_NODE_ORDER
+                    value: "0"
     - assert:
         file: assert-node1-priority1-complete-node2-blocked.yaml
     - script:
@@ -85,7 +118,6 @@ spec:
           ../../metrics_test.py skyhook_node_status_count 1 -t skyhook_name=strict-order-skyhook-zzz -t status=complete
           ../../metrics_test.py skyhook_node_status_count 1 -t skyhook_name=strict-order-skyhook-zzz -t status=blocked
           ../../metrics_test.py skyhook_package_state_count 1 -t package_name=foobar -t package_version=1.2 -t skyhook_name=strict-order-skyhook-zzz -t state=complete
-
 
     # Unblock worker2 only (keep b paused) so it can catch up through zzz and gate
   - name: unblock-worker2
@@ -96,7 +128,39 @@ spec:
         content: |
           ## Remove blocking taint from worker2 - it will catch up through zzz then gate
           kubectl taint node kind-worker2 test-block- 2>/dev/null || true
-
+    # Verify SKYHOOK_NODE_ORDER is set on the zzz config pod for kind-worker2 (after taint removed)
+    - assert:
+        resource:
+          apiVersion: v1
+          kind: Pod
+          metadata:
+            namespace: skyhook
+            labels:
+              skyhook.nvidia.com/name: strict-order-skyhook-zzz
+              skyhook.nvidia.com/package: foobar-1.2
+            annotations:
+              ("skyhook.nvidia.com/package" && parse_json("skyhook.nvidia.com/package")):
+                {
+                  "name": "foobar",
+                  "version": "1.2",
+                  "skyhook": "strict-order-skyhook-zzz",
+                  "stage": "config",
+                  "image": "ghcr.io/nvidia/skyhook/agentless"
+                }
+          spec:
+            nodeName: kind-worker2
+            initContainers:
+              - name: foobar-init
+              - name: foobar-config
+                env:
+                  ([5]):
+                    name: SKYHOOK_NODE_ORDER
+                    value: "1"
+              - name: foobar-configcheck
+                env:
+                  ([5]):
+                    name: SKYHOOK_NODE_ORDER
+                    value: "1"
 
   # Phase 3b: Assert sequencing: all gate blocks worker from priority 3
   # Worker completes gate (priority 2) but must WAIT for worker2 to also complete gate

--- a/operator/api/v1alpha1/skyhook_types.go
+++ b/operator/api/v1alpha1/skyhook_types.go
@@ -371,6 +371,10 @@ type SkyhookStatus struct {
 	// NodePriority tracks what nodes we are working on. This is makes the interrupts budgets sticky.
 	NodePriority map[string]metav1.Time `json:"nodePriority,omitempty"`
 
+	// NodeOrderOffset tracks the cumulative count of nodes removed from NodePriority.
+	// Used with NodePriority to compute monotonic SKYHOOK_NODE_ORDER across batches.
+	NodeOrderOffset int `json:"nodeOrderOffset,omitempty"`
+
 	// ConfigUpdates tracks config updates
 	ConfigUpdates map[string][]string `json:"configUpdates,omitempty"`
 

--- a/operator/cmd/cli/app/reset.go
+++ b/operator/cmd/cli/app/reset.go
@@ -257,14 +257,30 @@ func resetBatchStateForReset(ctx context.Context, cmd *cobra.Command, kubeClient
 		return
 	}
 
+	// Reset node ordering in memory
+	skyhook.Status.NodeOrderOffset = 0
+	skyhook.Status.NodePriority = nil
+
 	if len(skyhook.Status.CompartmentStatuses) == 0 {
+		// No compartments — use raw patch to clear omitempty fields explicitly
+		if err := utils.PatchSkyhookStatusRaw(ctx, kubeClient.Dynamic(), skyhookName,
+			[]byte(`{"status":{"nodeOrderOffset":0,"nodePriority":null}}`)); err != nil {
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: failed to reset node ordering: %v\n", err)
+		}
 		return
 	}
 
+	// With compartments, PatchSkyhookStatus writes the full status.
+	// NodeOrderOffset=0 is dropped by omitempty, so follow up with raw patch.
 	skyhook.ResetCompartmentBatchStates()
 	if err := utils.PatchSkyhookStatus(ctx, kubeClient.Dynamic(), skyhookName, skyhook.Status); err != nil {
 		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: failed to reset batch state: %v\n", err)
 		return
+	}
+	// Raw patch to clear omitempty fields that PatchSkyhookStatus can't zero
+	if err := utils.PatchSkyhookStatusRaw(ctx, kubeClient.Dynamic(), skyhookName,
+		[]byte(`{"status":{"nodeOrderOffset":0,"nodePriority":null}}`)); err != nil {
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: failed to reset node ordering: %v\n", err)
 	}
 	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Batch state reset for Skyhook %q\n", skyhookName)
 }

--- a/operator/config/crd/bases/skyhook.nvidia.com_skyhooks.yaml
+++ b/operator/config/crd/bases/skyhook.nvidia.com_skyhooks.yaml
@@ -719,6 +719,11 @@ spec:
                 description: NodeBootIds tracks the boot ids of nodes for triggering
                   on reboot
                 type: object
+              nodeOrderOffset:
+                description: |-
+                  NodeOrderOffset tracks the cumulative count of nodes removed from NodePriority.
+                  Used with NodePriority to compute monotonic SKYHOOK_NODE_ORDER across batches.
+                type: integer
               nodePriority:
                 additionalProperties:
                   format: date-time

--- a/operator/internal/cli/utils/utils.go
+++ b/operator/internal/cli/utils/utils.go
@@ -456,6 +456,24 @@ func ExtractImageTag(image string) string {
 	return strings.TrimSpace(parts[len(parts)-1])
 }
 
+// PatchSkyhookStatusRaw patches the skyhook status with raw JSON bytes.
+// Use this when you need explicit null values to clear omitempty fields.
+func PatchSkyhookStatusRaw(ctx context.Context, dynamicClient dynamic.Interface, skyhookName string, patchBytes []byte) error {
+	gvr := v1alpha1.GroupVersion.WithResource("skyhooks")
+	_, err := dynamicClient.Resource(gvr).Patch(
+		ctx,
+		skyhookName,
+		types.MergePatchType,
+		patchBytes,
+		metav1.PatchOptions{},
+		"status",
+	)
+	if err != nil {
+		return fmt.Errorf("patching skyhook %q status: %w", skyhookName, err)
+	}
+	return nil
+}
+
 // PatchSkyhookStatus patches the status subresource of a Skyhook CR using the dynamic client.
 // This is used to update status fields without triggering a spec update.
 func PatchSkyhookStatus(ctx context.Context, dynamicClient dynamic.Interface, skyhookName string, status v1alpha1.SkyhookStatus) error {

--- a/operator/internal/controller/cluster_state_v2.go
+++ b/operator/internal/controller/cluster_state_v2.go
@@ -144,7 +144,12 @@ func BuildState(skyhooks *v1alpha1.SkyhookList, nodes *corev1.NodeList, deployme
 
 	for _, skyhook := range ret.skyhooks {
 		sort.Slice(skyhook.GetNodes(), func(i, j int) bool {
-			return skyhook.GetNodes()[i].GetNode().CreationTimestamp.Before(&skyhook.GetNodes()[j].GetNode().CreationTimestamp)
+			ti := skyhook.GetNodes()[i].GetNode().CreationTimestamp
+			tj := skyhook.GetNodes()[j].GetNode().CreationTimestamp
+			if !ti.Equal(&tj) {
+				return ti.Before(&tj)
+			}
+			return skyhook.GetNodes()[i].GetNode().Name < skyhook.GetNodes()[j].GetNode().Name
 		})
 	}
 
@@ -648,8 +653,7 @@ func (s *NodePicker) primeAndPruneNodes(skyhook SkyhookNodes) {
 		// prune
 		// if the node is complete, remove it from the priority list
 		if nodeStatus, _ := skyhook.GetNode(n); nodeStatus == v1alpha1.StatusComplete {
-			delete(skyhook.GetSkyhook().Status.NodePriority, n)
-			skyhook.GetSkyhook().Updated = true
+			skyhook.GetSkyhook().RemoveNodePriority(n)
 		} else {
 			s.priorityNodes[n] = t.Time
 		}
@@ -1458,11 +1462,17 @@ func CleanupRemovedNodes(skyhook SkyhookNodes) {
 
 	status := skyhook.GetSkyhook().Status
 
-	// Check and remove nodes from all status maps
+	// NodePriority needs special handling to track offset
+	for name := range status.NodePriority {
+		if _, ok := currentNodeNames[name]; !ok {
+			skyhook.GetSkyhook().RemoveNodePriority(name)
+		}
+	}
+
+	// Check and remove nodes from remaining status maps
 	change := cleanupNodeMap(status.NodeState, currentNodeNames)
 	change = cleanupNodeMap(status.NodeStatus, currentNodeNames) || change
 	change = cleanupNodeMap(status.NodeBootIds, currentNodeNames) || change
-	change = cleanupNodeMap(status.NodePriority, currentNodeNames) || change
 
 	// Only set Updated flag if there were changes
 	if change {

--- a/operator/internal/controller/cluster_state_v2_test.go
+++ b/operator/internal/controller/cluster_state_v2_test.go
@@ -901,6 +901,9 @@ var _ = Describe("CleanupRemovedNodes", func() {
 		Expect(mockSkyhook.Status.ConfigUpdates).To(HaveKey("package2"))
 		Expect(mockSkyhook.Status.ConfigUpdates).To(HaveKey("package3"))
 
+		// Verify NodeOrderOffset was incremented for the removed node
+		Expect(mockSkyhook.Status.NodeOrderOffset).To(Equal(1))
+
 		// Verify that Updated flag was set since changes were made
 		Expect(mockSkyhook.Updated).To(BeTrue())
 	})
@@ -963,7 +966,10 @@ var _ = Describe("CleanupRemovedNodes", func() {
 		// ConfigUpdates should remain unchanged since it's keyed by package names, not node names
 		Expect(mockSkyhook.Status.ConfigUpdates).To(HaveKey("package1"))
 
-		// Verify that Updated flag was set since changes were made
+		// Verify NodeOrderOffset was NOT incremented
+		Expect(mockSkyhook.Status.NodeOrderOffset).To(Equal(0))
+
+		// Verify that Updated flag was NOT set since no changes were made
 		Expect(mockSkyhook.Updated).To(BeFalse())
 	})
 

--- a/operator/internal/controller/skyhook_controller.go
+++ b/operator/internal/controller/skyhook_controller.go
@@ -29,6 +29,7 @@ import (
 	"reflect"
 	"slices"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -684,10 +685,7 @@ func (r *SkyhookReconciler) SaveNodesAndSkyhook(ctx context.Context, clusterStat
 				r.recorder.Eventf(node.GetNode(), EventTypeNormal, EventsReasonSkyhookStateChange, "Skyhook [%s] complete.", skyhook.GetSkyhook().Name)
 
 				// since node is complete remove from priority
-				if _, ok := skyhook.GetSkyhook().Status.NodePriority[node.GetNode().Name]; ok {
-					delete(skyhook.GetSkyhook().Status.NodePriority, node.GetNode().Name)
-					skyhook.GetSkyhook().Updated = true
-				}
+				skyhook.GetSkyhook().RemoveNodePriority(node.GetNode().Name)
 			}
 		}
 
@@ -1594,7 +1592,7 @@ func createInterruptPodForPackage(opts SkyhookOperatorOptions, _interrupt *v1alp
 					Name:  InterruptContainerName,
 					Image: getAgentImage(opts, _package),
 					Args:  []string{"interrupt", "/root", copyDir, argEncode},
-					Env:   getAgentConfigEnvVars(opts, _package.Name, _package.Version, skyhook.ResourceID(), skyhook.Name),
+					Env:   getAgentConfigEnvVars(opts, _package.Name, _package.Version, skyhook.ResourceID(), skyhook.Name, skyhook.NodeOrder(nodeName)),
 					SecurityContext: &corev1.SecurityContext{
 						Privileged: ptr(true),
 					},
@@ -1674,7 +1672,7 @@ func getPackageImage(_package *v1alpha1.Package) string {
 	return fmt.Sprintf("%s:%s", _package.Image, _package.Version)
 }
 
-func getAgentConfigEnvVars(opts SkyhookOperatorOptions, packageName string, packageVersion string, resourceID string, skyhookName string) []corev1.EnvVar {
+func getAgentConfigEnvVars(opts SkyhookOperatorOptions, packageName string, packageVersion string, resourceID string, skyhookName string, nodeOrder int) []corev1.EnvVar {
 	return []corev1.EnvVar{
 		{
 			Name:  "SKYHOOK_LOG_DIR",
@@ -1691,6 +1689,10 @@ func getAgentConfigEnvVars(opts SkyhookOperatorOptions, packageName string, pack
 		{
 			Name:  "SKYHOOK_RESOURCE_ID",
 			Value: fmt.Sprintf("%s_%s_%s", resourceID, packageName, packageVersion),
+		},
+		{
+			Name:  "SKYHOOK_NODE_ORDER",
+			Value: strconv.Itoa(nodeOrder),
 		},
 	}
 }
@@ -1765,7 +1767,7 @@ func createPodFromPackage(opts SkyhookOperatorOptions, _package *v1alpha1.Packag
 
 	agentEnvs := append(
 		_package.Env,
-		getAgentConfigEnvVars(opts, _package.Name, _package.Version, skyhook.ResourceID(), skyhook.Name)...,
+		getAgentConfigEnvVars(opts, _package.Name, _package.Version, skyhook.ResourceID(), skyhook.Name, skyhook.NodeOrder(nodeName))...,
 	)
 
 	pod := &corev1.Pod{
@@ -1931,7 +1933,7 @@ func podMatchesPackage(opts SkyhookOperatorOptions, _package *v1alpha1.Package, 
 		// TODO: This is ignoring all the static env vars that are set by operator config.
 		// It probably should be just SKYHOOK_RESOURCE_ID that is ignored. Otherwise,
 		// a user will have to manually delete the pod to update the package when operator is updated.
-		dummyAgentEnv := getAgentConfigEnvVars(opts, "", "", "", "")
+		dummyAgentEnv := getAgentConfigEnvVars(opts, "", "", "", "", 0)
 		excludedEnvs := make([]string, len(dummyAgentEnv))
 		for i, env := range dummyAgentEnv {
 			excludedEnvs[i] = env.Name

--- a/operator/internal/controller/skyhook_controller_test.go
+++ b/operator/internal/controller/skyhook_controller_test.go
@@ -492,7 +492,7 @@ var _ = Describe("skyhook controller tests", func() {
 		}
 		Expect(opts.Validate()).To(BeNil())
 
-		envs := getAgentConfigEnvVars(opts, "package", "version", "id", "skyhook_name")
+		envs := getAgentConfigEnvVars(opts, "package", "version", "id", "skyhook_name", 0)
 		expected := []corev1.EnvVar{
 			{
 				Name:  "SKYHOOK_LOG_DIR",
@@ -510,8 +510,58 @@ var _ = Describe("skyhook controller tests", func() {
 				Name:  "SKYHOOK_RESOURCE_ID",
 				Value: "id_package_version",
 			},
+			{
+				Name:  "SKYHOOK_NODE_ORDER",
+				Value: "0",
+			},
 		}
 		Expect(envs).To(BeEquivalentTo(expected))
+	})
+
+	It("should set monotonic SKYHOOK_NODE_ORDER across nodes and batches", func() {
+		now := time.Now()
+		testSkyhook := wrapper.NewSkyhookWrapper(&v1alpha1.Skyhook{
+			Status: v1alpha1.SkyhookStatus{
+				NodePriority: map[string]metav1.Time{
+					"node-a": metav1.NewTime(now),
+					"node-b": metav1.NewTime(now.Add(1 * time.Second)),
+				},
+			},
+		})
+		testPackage := &v1alpha1.Package{
+			PackageRef: v1alpha1.PackageRef{Name: "pkg", Version: "1.0"},
+			Image:      "test:latest",
+		}
+
+		// Batch 1: node-a=0, node-b=1
+		podA := createPodFromPackage(operator.opts, testPackage, testSkyhook, "node-a", v1alpha1.StageApply)
+		podB := createPodFromPackage(operator.opts, testPackage, testSkyhook, "node-b", v1alpha1.StageApply)
+
+		getNodeOrder := func(pod *corev1.Pod) string {
+			for _, c := range pod.Spec.InitContainers {
+				for _, env := range c.Env {
+					if env.Name == "SKYHOOK_NODE_ORDER" {
+						return env.Value
+					}
+				}
+			}
+			return ""
+		}
+
+		Expect(getNodeOrder(podA)).To(Equal("0"))
+		Expect(getNodeOrder(podB)).To(Equal("1"))
+
+		// Simulate batch completion: remove both nodes, offset becomes 2
+		testSkyhook.RemoveNodePriority("node-a")
+		testSkyhook.RemoveNodePriority("node-b")
+		Expect(testSkyhook.Status.NodeOrderOffset).To(Equal(2))
+
+		// Batch 2: add node-c, should get order 2
+		testSkyhook.Status.NodePriority = map[string]metav1.Time{
+			"node-c": metav1.NewTime(now.Add(2 * time.Second)),
+		}
+		podC := createPodFromPackage(operator.opts, testPackage, testSkyhook, "node-c", v1alpha1.StageApply)
+		Expect(getNodeOrder(podC)).To(Equal("2"))
 	})
 
 	It("should pick highest priority interrupt", func() {

--- a/operator/internal/wrapper/compartment.go
+++ b/operator/internal/wrapper/compartment.go
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  *
@@ -21,6 +21,10 @@ package wrapper
 import (
 	"github.com/NVIDIA/skyhook/operator/api/v1alpha1"
 )
+
+// Compartment invariant: all nodes in a Compartment belong to the same Skyhook.
+// Compartments are populated per-Skyhook in BuildState and partitionNodesIntoCompartments,
+// so node.GetSkyhook() returns the same Skyhook for every node in the compartment.
 
 func NewCompartmentWrapper(c *v1alpha1.Compartment, batchState *v1alpha1.BatchProcessingState) *Compartment {
 	comp := &Compartment{
@@ -112,8 +116,37 @@ func (c *Compartment) GetNodesForNextBatch() []SkyhookNode {
 		return c.getInProgressNodes()
 	}
 
+	// Sticky batch: nodes in NodePriority that aren't Complete yet should
+	// continue processing before we pick new nodes. This handles the case where
+	// IntrospectNode transitions nodes from InProgress → Waiting between packages.
+	if stickyNodes := c.getStickyBatchNodes(); len(stickyNodes) > 0 {
+		return stickyNodes
+	}
+
 	// No batch in progress, create a new one
 	return c.createNewBatch()
+}
+
+// getStickyBatchNodes returns nodes that are in NodePriority but not yet Complete.
+// These nodes were previously picked for a batch and should finish all their packages
+// before new nodes are selected.
+func (c *Compartment) getStickyBatchNodes() []SkyhookNode {
+	if len(c.Nodes) == 0 {
+		return nil
+	}
+
+	skyhook := c.Nodes[0].GetSkyhook()
+	if skyhook == nil || skyhook.Skyhook == nil || skyhook.Status.NodePriority == nil {
+		return nil
+	}
+
+	stickyNodes := make([]SkyhookNode, 0)
+	for _, node := range c.Nodes {
+		if _, inPriority := skyhook.Status.NodePriority[node.GetNode().Name]; inPriority && !node.IsComplete() {
+			stickyNodes = append(stickyNodes, node)
+		}
+	}
+	return stickyNodes
 }
 
 func (c *Compartment) getInProgressNodes() []SkyhookNode {

--- a/operator/internal/wrapper/compartment_test.go
+++ b/operator/internal/wrapper/compartment_test.go
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  *
@@ -16,19 +16,32 @@
  * limitations under the License.
  */
 
-package wrapper
+package wrapper_test
 
 import (
 	"github.com/NVIDIA/skyhook/operator/api/v1alpha1"
+	"github.com/NVIDIA/skyhook/operator/internal/wrapper"
+	mockwrapper "github.com/NVIDIA/skyhook/operator/internal/wrapper/mock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 )
+
+func newMockNode(t FullGinkgoTInterface, name string, status v1alpha1.Status, complete bool, skyhook *wrapper.Skyhook) *mockwrapper.MockSkyhookNode {
+	mock := mockwrapper.NewMockSkyhookNode(t)
+	mock.EXPECT().GetNode().Return(&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: name}}).Maybe()
+	mock.EXPECT().GetSkyhook().Return(skyhook).Maybe()
+	mock.EXPECT().Status().Return(status).Maybe()
+	mock.EXPECT().IsComplete().Return(complete).Maybe()
+	return mock
+}
 
 var _ = Describe("Compartment", func() {
 	Context("calculateCeiling", func() {
 		It("should calculate ceiling for count budget", func() {
-			compartment := &Compartment{
+			compartment := &wrapper.Compartment{
 				Compartment: v1alpha1.Compartment{
 					Budget: v1alpha1.DeploymentBudget{Count: ptr.To(3)},
 				},
@@ -39,12 +52,12 @@ var _ = Describe("Compartment", func() {
 				compartment.Nodes = append(compartment.Nodes, nil)
 			}
 
-			ceiling := CalculateCeiling(compartment.Budget, len(compartment.Nodes))
+			ceiling := wrapper.CalculateCeiling(compartment.Budget, len(compartment.Nodes))
 			Expect(ceiling).To(Equal(3))
 		})
 
 		It("should calculate ceiling for percent budget", func() {
-			compartment := &Compartment{
+			compartment := &wrapper.Compartment{
 				Compartment: v1alpha1.Compartment{
 					Budget: v1alpha1.DeploymentBudget{Percent: ptr.To(30)},
 				},
@@ -55,12 +68,12 @@ var _ = Describe("Compartment", func() {
 				compartment.Nodes = append(compartment.Nodes, nil)
 			}
 
-			ceiling := CalculateCeiling(compartment.Budget, len(compartment.Nodes))
+			ceiling := wrapper.CalculateCeiling(compartment.Budget, len(compartment.Nodes))
 			Expect(ceiling).To(Equal(3)) // max(1, int(10 * 0.3)) = 3
 		})
 
 		It("should handle small percent budgets with minimum 1", func() {
-			compartment := &Compartment{
+			compartment := &wrapper.Compartment{
 				Compartment: v1alpha1.Compartment{
 					Budget: v1alpha1.DeploymentBudget{Percent: ptr.To(30)},
 				},
@@ -71,18 +84,18 @@ var _ = Describe("Compartment", func() {
 				compartment.Nodes = append(compartment.Nodes, nil)
 			}
 
-			ceiling := CalculateCeiling(compartment.Budget, len(compartment.Nodes))
+			ceiling := wrapper.CalculateCeiling(compartment.Budget, len(compartment.Nodes))
 			Expect(ceiling).To(Equal(1)) // max(1, int(2 * 0.3)) = max(1, 0) = 1
 		})
 
 		It("should return 0 for no nodes", func() {
-			compartment := &Compartment{
+			compartment := &wrapper.Compartment{
 				Compartment: v1alpha1.Compartment{
 					Budget: v1alpha1.DeploymentBudget{Percent: ptr.To(50)},
 				},
 			}
 
-			ceiling := CalculateCeiling(compartment.Budget, len(compartment.Nodes))
+			ceiling := wrapper.CalculateCeiling(compartment.Budget, len(compartment.Nodes))
 			Expect(ceiling).To(Equal(0))
 		})
 	})
@@ -96,7 +109,7 @@ var _ = Describe("Compartment", func() {
 				FailedNodes:         1,
 			}
 
-			compartment := NewCompartmentWrapper(&v1alpha1.Compartment{
+			compartment := wrapper.NewCompartmentWrapper(&v1alpha1.Compartment{
 				Name:   "test",
 				Budget: v1alpha1.DeploymentBudget{Count: ptr.To(5)},
 			}, batchState)
@@ -109,7 +122,7 @@ var _ = Describe("Compartment", func() {
 		})
 
 		It("should create compartment with default batch state when nil", func() {
-			compartment := NewCompartmentWrapper(&v1alpha1.Compartment{
+			compartment := wrapper.NewCompartmentWrapper(&v1alpha1.Compartment{
 				Name:   "test",
 				Budget: v1alpha1.DeploymentBudget{Count: ptr.To(5)},
 			}, nil)
@@ -124,7 +137,7 @@ var _ = Describe("Compartment", func() {
 
 	Context("EvaluateAndUpdateBatchState", func() {
 		It("should update basic state without strategy", func() {
-			compartment := NewCompartmentWrapper(&v1alpha1.Compartment{
+			compartment := wrapper.NewCompartmentWrapper(&v1alpha1.Compartment{
 				Name:   "test-compartment",
 				Budget: v1alpha1.DeploymentBudget{Count: ptr.To(10)},
 			}, &v1alpha1.BatchProcessingState{
@@ -150,7 +163,7 @@ var _ = Describe("Compartment", func() {
 				},
 			}
 
-			compartment := NewCompartmentWrapper(&v1alpha1.Compartment{
+			compartment := wrapper.NewCompartmentWrapper(&v1alpha1.Compartment{
 				Name:     "test-compartment",
 				Budget:   v1alpha1.DeploymentBudget{Count: ptr.To(10)},
 				Strategy: strategy,
@@ -184,7 +197,7 @@ var _ = Describe("Compartment", func() {
 				},
 			}
 
-			compartment := NewCompartmentWrapper(&v1alpha1.Compartment{
+			compartment := wrapper.NewCompartmentWrapper(&v1alpha1.Compartment{
 				Name:     "test-compartment",
 				Budget:   v1alpha1.DeploymentBudget{Count: ptr.To(10)},
 				Strategy: strategy,
@@ -218,7 +231,7 @@ var _ = Describe("Compartment", func() {
 				},
 			}
 
-			compartment := NewCompartmentWrapper(&v1alpha1.Compartment{
+			compartment := wrapper.NewCompartmentWrapper(&v1alpha1.Compartment{
 				Name:     "test-compartment",
 				Budget:   v1alpha1.DeploymentBudget{Count: ptr.To(10)},
 				Strategy: strategy,
@@ -242,6 +255,187 @@ var _ = Describe("Compartment", func() {
 			state := compartment.GetBatchState()
 			Expect(state.ConsecutiveFailures).To(Equal(2)) // Should increment
 			Expect(state.ShouldStop).To(BeFalse())         // Should NOT stop (above safety limit)
+		})
+	})
+
+	Context("GetNodesForNextBatch with stickiness", func() {
+		var skyhook *wrapper.Skyhook
+
+		BeforeEach(func() {
+			skyhook = &wrapper.Skyhook{
+				Skyhook: &v1alpha1.Skyhook{},
+			}
+		})
+
+		It("should return sticky nodes instead of creating a new batch", func() {
+			// node-1 is in NodePriority (sticky) and Waiting (between packages)
+			// node-2 and node-3 are Waiting but NOT in NodePriority
+			skyhook.Status.NodePriority = map[string]metav1.Time{
+				"node-1": metav1.Now(),
+			}
+
+			compartment := &wrapper.Compartment{
+				Compartment: v1alpha1.Compartment{
+					Budget: v1alpha1.DeploymentBudget{Count: ptr.To(1)},
+				},
+				BatchState: v1alpha1.BatchProcessingState{CurrentBatch: 1},
+				Nodes: []wrapper.SkyhookNode{
+					newMockNode(GinkgoT(), "node-1", v1alpha1.StatusWaiting, false, skyhook),
+					newMockNode(GinkgoT(), "node-2", v1alpha1.StatusWaiting, false, skyhook),
+					newMockNode(GinkgoT(), "node-3", v1alpha1.StatusWaiting, false, skyhook),
+				},
+			}
+
+			result := compartment.GetNodesForNextBatch()
+			Expect(result).To(HaveLen(1))
+			Expect(result[0].GetNode().Name).To(Equal("node-1"))
+		})
+
+		It("should skip complete sticky nodes and fall through to new batch", func() {
+			// node-1 was in NodePriority but is now Complete
+			skyhook.Status.NodePriority = map[string]metav1.Time{
+				"node-1": metav1.Now(),
+			}
+
+			compartment := &wrapper.Compartment{
+				Compartment: v1alpha1.Compartment{
+					Budget: v1alpha1.DeploymentBudget{Count: ptr.To(1)},
+				},
+				BatchState: v1alpha1.BatchProcessingState{CurrentBatch: 1},
+				Nodes: []wrapper.SkyhookNode{
+					newMockNode(GinkgoT(), "node-1", v1alpha1.StatusComplete, true, skyhook),
+					newMockNode(GinkgoT(), "node-2", v1alpha1.StatusWaiting, false, skyhook),
+					newMockNode(GinkgoT(), "node-3", v1alpha1.StatusWaiting, false, skyhook),
+				},
+			}
+
+			result := compartment.GetNodesForNextBatch()
+			// Should fall through to createNewBatch and pick node-2
+			Expect(result).To(HaveLen(1))
+			Expect(result[0].GetNode().Name).To(Equal("node-2"))
+		})
+
+		It("should return InProgress nodes even when sticky nodes exist", func() {
+			skyhook.Status.NodePriority = map[string]metav1.Time{
+				"node-1": metav1.Now(),
+				"node-2": metav1.Now(),
+			}
+
+			compartment := &wrapper.Compartment{
+				Compartment: v1alpha1.Compartment{
+					Budget: v1alpha1.DeploymentBudget{Count: ptr.To(1)},
+				},
+				BatchState: v1alpha1.BatchProcessingState{CurrentBatch: 1},
+				Nodes: []wrapper.SkyhookNode{
+					newMockNode(GinkgoT(), "node-1", v1alpha1.StatusInProgress, false, skyhook),
+					newMockNode(GinkgoT(), "node-2", v1alpha1.StatusWaiting, false, skyhook),
+				},
+			}
+
+			result := compartment.GetNodesForNextBatch()
+			// InProgress takes precedence over sticky
+			Expect(result).To(HaveLen(1))
+			Expect(result[0].GetNode().Name).To(Equal("node-1"))
+		})
+
+		It("should fall through to new batch when NodePriority is nil", func() {
+			// No NodePriority set at all
+			compartment := &wrapper.Compartment{
+				Compartment: v1alpha1.Compartment{
+					Budget: v1alpha1.DeploymentBudget{Count: ptr.To(1)},
+				},
+				BatchState: v1alpha1.BatchProcessingState{CurrentBatch: 1},
+				Nodes: []wrapper.SkyhookNode{
+					newMockNode(GinkgoT(), "node-1", v1alpha1.StatusWaiting, false, skyhook),
+					newMockNode(GinkgoT(), "node-2", v1alpha1.StatusWaiting, false, skyhook),
+				},
+			}
+
+			result := compartment.GetNodesForNextBatch()
+			Expect(result).To(HaveLen(1))
+			Expect(result[0].GetNode().Name).To(Equal("node-1"))
+		})
+
+		It("should return multiple sticky nodes when batch size allows", func() {
+			skyhook.Status.NodePriority = map[string]metav1.Time{
+				"node-1": metav1.Now(),
+				"node-2": metav1.Now(),
+			}
+
+			compartment := &wrapper.Compartment{
+				Compartment: v1alpha1.Compartment{
+					Budget: v1alpha1.DeploymentBudget{Count: ptr.To(3)},
+				},
+				BatchState: v1alpha1.BatchProcessingState{CurrentBatch: 1},
+				Nodes: []wrapper.SkyhookNode{
+					newMockNode(GinkgoT(), "node-1", v1alpha1.StatusWaiting, false, skyhook),
+					newMockNode(GinkgoT(), "node-2", v1alpha1.StatusWaiting, false, skyhook),
+					newMockNode(GinkgoT(), "node-3", v1alpha1.StatusWaiting, false, skyhook),
+				},
+			}
+
+			result := compartment.GetNodesForNextBatch()
+			// Both sticky nodes returned
+			Expect(result).To(HaveLen(2))
+			names := []string{result[0].GetNode().Name, result[1].GetNode().Name}
+			Expect(names).To(ConsistOf("node-1", "node-2"))
+		})
+
+		It("should not include non-sticky nodes in the sticky batch", func() {
+			// Only node-1 is sticky — node-2 and node-3 must NOT be returned
+			// even though they are Waiting and not Complete
+			skyhook.Status.NodePriority = map[string]metav1.Time{
+				"node-1": metav1.Now(),
+			}
+
+			compartment := &wrapper.Compartment{
+				Compartment: v1alpha1.Compartment{
+					Budget: v1alpha1.DeploymentBudget{Count: ptr.To(3)},
+				},
+				BatchState: v1alpha1.BatchProcessingState{CurrentBatch: 1},
+				Nodes: []wrapper.SkyhookNode{
+					newMockNode(GinkgoT(), "node-1", v1alpha1.StatusWaiting, false, skyhook),
+					newMockNode(GinkgoT(), "node-2", v1alpha1.StatusWaiting, false, skyhook),
+					newMockNode(GinkgoT(), "node-3", v1alpha1.StatusWaiting, false, skyhook),
+				},
+			}
+
+			result := compartment.GetNodesForNextBatch()
+			Expect(result).To(HaveLen(1))
+			Expect(result[0].GetNode().Name).To(Equal("node-1"))
+			// Explicitly verify the other nodes are NOT in the result
+			for _, node := range result {
+				Expect(node.GetNode().Name).NotTo(Equal("node-2"))
+				Expect(node.GetNode().Name).NotTo(Equal("node-3"))
+			}
+		})
+
+		It("should not leak non-sticky nodes even when budget exceeds sticky count", func() {
+			// Budget allows 5 nodes, but only 2 are sticky — should return exactly 2
+			skyhook.Status.NodePriority = map[string]metav1.Time{
+				"node-1": metav1.Now(),
+				"node-3": metav1.Now(),
+			}
+
+			compartment := &wrapper.Compartment{
+				Compartment: v1alpha1.Compartment{
+					Budget: v1alpha1.DeploymentBudget{Count: ptr.To(5)},
+				},
+				BatchState: v1alpha1.BatchProcessingState{CurrentBatch: 1},
+				Nodes: []wrapper.SkyhookNode{
+					newMockNode(GinkgoT(), "node-1", v1alpha1.StatusWaiting, false, skyhook),
+					newMockNode(GinkgoT(), "node-2", v1alpha1.StatusWaiting, false, skyhook),
+					newMockNode(GinkgoT(), "node-3", v1alpha1.StatusWaiting, false, skyhook),
+					newMockNode(GinkgoT(), "node-4", v1alpha1.StatusWaiting, false, skyhook),
+				},
+			}
+
+			result := compartment.GetNodesForNextBatch()
+			Expect(result).To(HaveLen(2))
+			names := []string{result[0].GetNode().Name, result[1].GetNode().Name}
+			Expect(names).To(ConsistOf("node-1", "node-3"))
+			Expect(names).NotTo(ContainElement("node-2"))
+			Expect(names).NotTo(ContainElement("node-4"))
 		})
 	})
 })

--- a/operator/internal/wrapper/skyhook.go
+++ b/operator/internal/wrapper/skyhook.go
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  *
@@ -21,6 +21,7 @@ package wrapper
 import (
 	"fmt"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/NVIDIA/skyhook/operator/api/v1alpha1"
@@ -263,4 +264,48 @@ func (s *Skyhook) Migrate(logger logr.Logger) error {
 	}
 
 	return nil
+}
+
+// RemoveNodePriority removes a node from NodePriority and increments NodeOrderOffset.
+// If the node is not in NodePriority, this is a no-op (offset is not bumped).
+func (s *Skyhook) RemoveNodePriority(name string) {
+	if s.Status.NodePriority == nil {
+		return
+	}
+	if _, ok := s.Status.NodePriority[name]; !ok {
+		return
+	}
+	delete(s.Status.NodePriority, name)
+	s.Status.NodeOrderOffset++
+	s.Updated = true
+}
+
+// NodeOrder returns the monotonic order for a node based on its position in
+// NodePriority (sorted by timestamp, name tiebreaker) plus NodeOrderOffset.
+// Returns 0 if the node is not found in NodePriority.
+func (s *Skyhook) NodeOrder(nodeName string) int {
+	if s.Status.NodePriority == nil {
+		return 0
+	}
+
+	type entry struct {
+		name string
+		time metav1.Time
+	}
+	entries := make([]entry, 0, len(s.Status.NodePriority))
+	for n, t := range s.Status.NodePriority {
+		entries = append(entries, entry{n, t})
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		if !entries[i].time.Equal(&entries[j].time) {
+			return entries[i].time.Before(&entries[j].time)
+		}
+		return entries[i].name < entries[j].name
+	})
+	for i, e := range entries {
+		if e.name == nodeName {
+			return s.Status.NodeOrderOffset + i
+		}
+	}
+	return 0
 }

--- a/operator/internal/wrapper/skyhook_test.go
+++ b/operator/internal/wrapper/skyhook_test.go
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  *
@@ -19,9 +19,12 @@
 package wrapper
 
 import (
+	"time"
+
 	"github.com/NVIDIA/skyhook/operator/api/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var _ = Describe("Skyhook wrapper tests", func() {
@@ -258,5 +261,113 @@ var _ = Describe("Skyhook wrapper tests", func() {
 				},
 			},
 		}))
+	})
+
+	Context("RemoveNodePriority", func() {
+		It("should delete node and increment offset", func() {
+			skyhook := &Skyhook{
+				Skyhook: &v1alpha1.Skyhook{
+					Status: v1alpha1.SkyhookStatus{
+						NodePriority: map[string]metav1.Time{
+							"node-1": metav1.Now(),
+							"node-2": metav1.Now(),
+						},
+					},
+				},
+			}
+
+			skyhook.RemoveNodePriority("node-1")
+			Expect(skyhook.Status.NodePriority).NotTo(HaveKey("node-1"))
+			Expect(skyhook.Status.NodePriority).To(HaveKey("node-2"))
+			Expect(skyhook.Status.NodeOrderOffset).To(Equal(1))
+			Expect(skyhook.Updated).To(BeTrue())
+		})
+
+		It("should be a no-op for missing node", func() {
+			skyhook := &Skyhook{
+				Skyhook: &v1alpha1.Skyhook{
+					Status: v1alpha1.SkyhookStatus{
+						NodePriority: map[string]metav1.Time{
+							"node-1": metav1.Now(),
+						},
+					},
+				},
+			}
+
+			skyhook.RemoveNodePriority("node-missing")
+			Expect(skyhook.Status.NodePriority).To(HaveKey("node-1"))
+			Expect(skyhook.Status.NodeOrderOffset).To(Equal(0))
+			Expect(skyhook.Updated).To(BeFalse())
+		})
+
+		It("should be a no-op for nil map", func() {
+			skyhook := &Skyhook{
+				Skyhook: &v1alpha1.Skyhook{},
+			}
+
+			skyhook.RemoveNodePriority("node-1")
+			Expect(skyhook.Status.NodeOrderOffset).To(Equal(0))
+			Expect(skyhook.Updated).To(BeFalse())
+		})
+	})
+
+	Context("NodeOrder", func() {
+		It("should return offset + position for node in priority", func() {
+			now := time.Now()
+			skyhook := &Skyhook{
+				Skyhook: &v1alpha1.Skyhook{
+					Status: v1alpha1.SkyhookStatus{
+						NodeOrderOffset: 3,
+						NodePriority: map[string]metav1.Time{
+							"node-a": metav1.NewTime(now),
+							"node-b": metav1.NewTime(now.Add(1 * time.Second)),
+						},
+					},
+				},
+			}
+
+			Expect(skyhook.NodeOrder("node-a")).To(Equal(3)) // offset 3 + index 0
+			Expect(skyhook.NodeOrder("node-b")).To(Equal(4)) // offset 3 + index 1
+		})
+
+		It("should use name as tiebreaker for same timestamps", func() {
+			now := time.Now()
+			skyhook := &Skyhook{
+				Skyhook: &v1alpha1.Skyhook{
+					Status: v1alpha1.SkyhookStatus{
+						NodePriority: map[string]metav1.Time{
+							"node-b": metav1.NewTime(now),
+							"node-a": metav1.NewTime(now),
+						},
+					},
+				},
+			}
+
+			Expect(skyhook.NodeOrder("node-a")).To(Equal(0)) // a before b
+			Expect(skyhook.NodeOrder("node-b")).To(Equal(1))
+		})
+
+		It("should return 0 for node not in priority", func() {
+			skyhook := &Skyhook{
+				Skyhook: &v1alpha1.Skyhook{
+					Status: v1alpha1.SkyhookStatus{
+						NodeOrderOffset: 5,
+						NodePriority: map[string]metav1.Time{
+							"node-1": metav1.Now(),
+						},
+					},
+				},
+			}
+
+			Expect(skyhook.NodeOrder("node-missing")).To(Equal(0))
+		})
+
+		It("should return 0 for nil map", func() {
+			skyhook := &Skyhook{
+				Skyhook: &v1alpha1.Skyhook{},
+			}
+
+			Expect(skyhook.NodeOrder("node-1")).To(Equal(0))
+		})
 	})
 })


### PR DESCRIPTION
## Summary

- **Batch stickiness fix**: Nodes picked for a batch now finish all their packages before new nodes are selected. Previously, `IntrospectNode` transitioning nodes from InProgress → Waiting between packages caused `GetNodesForNextBatch()` to pick new nodes prematurely — a Fixed 1-by-1 strategy would process all nodes in parallel instead of sequentially.

- **Monotonic node ordering**: Pods now receive `SKYHOOK_NODE_ORDER` env var so packages can know their position (e.g., first node runs `kubeadm upgrade apply`, subsequent nodes run `kubeadm upgrade node`). Order is computed from `NodeOrderOffset + position` in the sorted `NodePriority` map, and all pruning goes through `RemoveNodePriority` to keep the offset in sync.

- **CLI reset**: `skyhook reset` now clears `NodeOrderOffset` and `NodePriority` so ordering starts fresh. Removed `omitempty` from both fields so `nil`/`0` values serialize correctly in merge patches.

## Test plan

- [x] Unit tests: `RemoveNodePriority` (offset increment, no-op on missing/nil), `NodeOrder` (offset+position, name tiebreaker), `CleanupRemovedNodes` (offset assertion), `createPodFromPackage` (monotonic order across batches), `getStickyBatchNodes` (sticky returned, complete excluded, anti-leak tests)
- [x] E2E strict-order: Assert `SKYHOOK_NODE_ORDER=0` on kind-worker config pod, `SKYHOOK_NODE_ORDER=1` on kind-worker2 config pod, `nodeOrderOffset: 2` on completed Skyhook status
- [x] E2E CLI reset: Assert `nodeOrderOffset: 0` after `skyhook reset`
