### PR TITLE
fix: ci issues from rename and template changes

### DIFF
--- a/.github/workflows/cli-release.yaml
+++ b/.github/workflows/cli-release.yaml
@@ -38,7 +38,8 @@ jobs:
 
       - name: Install git-cliff
         run: |
-          curl -sSL "https://github.com/orhun/git-cliff/releases/latest/download/git-cliff-x86_64-unknown-linux-gnu.tar.gz" \
+          GC_VERSION=$(curl -sSf https://api.github.com/repos/orhun/git-cliff/releases/latest | grep '"tag_name"' | cut -d '"' -f 4)
+          curl -sSL "https://github.com/orhun/git-cliff/releases/download/${GC_VERSION}/git-cliff-${GC_VERSION#v}-x86_64-unknown-linux-gnu.tar.gz" \
             | tar xz --wildcards "*/git-cliff" --strip-components=1
           sudo mv git-cliff /usr/local/bin/
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,8 @@ jobs:
 
       - name: Install git-cliff
         run: |
-          curl -sSL "https://github.com/orhun/git-cliff/releases/latest/download/git-cliff-x86_64-unknown-linux-gnu.tar.gz" \
+          GC_VERSION=$(curl -sSf https://api.github.com/repos/orhun/git-cliff/releases/latest | grep '"tag_name"' | cut -d '"' -f 4)
+          curl -sSL "https://github.com/orhun/git-cliff/releases/download/${GC_VERSION}/git-cliff-${GC_VERSION#v}-x86_64-unknown-linux-gnu.tar.gz" \
             | tar xz --wildcards "*/git-cliff" --strip-components=1
           sudo mv git-cliff /usr/local/bin/
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -100,7 +100,7 @@ mirror-operator-image:
         HEALTHCHECK_TCP_PORT: "2376"
   variables:
     GHCR_REGISTRY: ghcr.io
-    GHCR_REGISTRY_IMAGE: "${GHCR_REGISTRY}/nvidia/skyhook/operator"
+    GHCR_REGISTRY_IMAGE: "${GHCR_REGISTRY}/nvidia/nodewright/operator"
     NVCR_REGISTRY_IMAGE: "${NVCR_REGISTRY}/skyhook/operator"
     DOCKER_HOST: tcp://docker:2376
     DOCKER_TLS_CERTDIR: "/certs"
@@ -136,7 +136,7 @@ mirror-agent-image:
         HEALTHCHECK_TCP_PORT: "2376"
   variables:
     GHCR_REGISTRY: ghcr.io
-    GHCR_REGISTRY_IMAGE: "${GHCR_REGISTRY}/nvidia/skyhook/agent"
+    GHCR_REGISTRY_IMAGE: "${GHCR_REGISTRY}/nvidia/nodewright/agent"
     NVCR_REGISTRY_IMAGE: "${NVCR_REGISTRY}/skyhook/agent"
     DOCKER_HOST: tcp://docker:2376
     DOCKER_TLS_CERTDIR: "/certs"

--- a/Makefile
+++ b/Makefile
@@ -88,12 +88,14 @@ changelog-preview: ## Preview unreleased changes for a component. Usage: make ch
 		--unreleased \
 		--strip header
 
+COMPONENTS := operator agent chart cli
+
 .PHONY: changelog-all
-changelog-all: ## Generate CHANGELOGs for all components.
-	$(MAKE) changelog COMPONENT=operator
-	$(MAKE) changelog COMPONENT=agent
-	$(MAKE) changelog COMPONENT=chart
-	$(MAKE) changelog COMPONENT=cli
+changelog-all: $(COMPONENTS:%=changelog-%) ## Generate CHANGELOGs for all components.
+
+.PHONY: $(COMPONENTS:%=changelog-%)
+$(COMPONENTS:%=changelog-%):
+	$(MAKE) changelog COMPONENT=$(@:changelog-%=%)
 
 ##@ Clean
 


### PR DESCRIPTION


## Description
fixing issue with ci coming from the rename, and the updates from the oss project template.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/skyhook/blob/main/CONTRIBUTING.md).
- [x] My commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
