### PR TITLE
chore(chart): update min k8s version in chart

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -5,9 +5,9 @@ type: application
 # This is the chart version. This version number must be incremented each time you make changes to the helm chart. OR
 # it the agent version is updated, or operator version is updated.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v0.15.0
+version: v0.15.1
 # This is the version number operator container being deployed.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 appVersion: v0.15.0
 # this is the minimum version of kubernetes that the operator supports/tested against.
-kubeVersion: ">=1.30.0-0"
+kubeVersion: ">=1.27.0-0"


### PR DESCRIPTION

## Description
Updated min version in helm chart for k8s. Ran tests they all passed. Still recommend to update to a later version.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/skyhook/blob/main/CONTRIBUTING.md).
- [x] My commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
