### PR TITLE
chore: update go version to 1.26.2

### DIFF
--- a/.github/workflows/agent-ci.yaml
+++ b/.github/workflows/agent-ci.yaml
@@ -35,7 +35,7 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
-  GO_VERSION: 1.26.0
+  GO_VERSION: 1.26.2
   PYTHON_VERSION: 3.13
   DEBIAN_VERSION: trixie
 jobs:

--- a/.github/workflows/cli-release.yaml
+++ b/.github/workflows/cli-release.yaml
@@ -23,7 +23,7 @@ on:
       - cli/*
 
 env:
-  GO_VERSION: 1.26.0
+  GO_VERSION: 1.26.2
 
 jobs:
   release:

--- a/.github/workflows/operator-ci.yaml
+++ b/.github/workflows/operator-ci.yaml
@@ -41,7 +41,7 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
-  GO_VERSION: 1.26.0
+  GO_VERSION: 1.26.2
   DEBIAN_VERSION: trixie
   PLATFORMS: linux/amd64,linux/arm64
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 #
@@ -24,7 +24,7 @@ variables:
   KUBERNETES_CPU_REQUEST: "2"
   KUBERNETES_MEMORY_LIMIT: "6Gi"
   KUBERNETES_MEMORY_REQUEST: "3Gi"
-  GO_VERSION: 1.23.4
+  GO_VERSION: 1.26.2
   ARCH_LIST: "linux/amd64,linux/arm64"
 
 workflow:

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -16,7 +16,7 @@ include deps.mk
 
 ## Version of the operator
 VERSION ?= $(GIT_TAG_LAST)
-GO_VERSION ?= 1.26.0
+GO_VERSION ?= 1.26.2
 DEBIAN_VERSION ?= trixie
 DISTROLESS_VERSION ?= 4.0.2
 

--- a/operator/README.md
+++ b/operator/README.md
@@ -88,10 +88,10 @@ Packages can depend on each other, so if you needed `something_important` to be 
 ## Development
 
 ### Prerequisites
-- go version v1.23.8+
+- go version v1.26.2+
 - docker version 17.03+ or podman 4.9.4+ (project makefile kind of assumes podman)
 - kubectl version v1.27.3+.
-- Access to a Kubernetes v1.27+ cluster. (We test on 1.30, could work on older, not tested. Could be api compatibilities issues.)
+- Access to a Kubernetes v1.27+ cluster. (We test on 1.32+, could work on older, not regularly tested. Could be api compatibilities issues.)
 
 
 **Install the CRDs into the cluster:**

--- a/operator/go.mod
+++ b/operator/go.mod
@@ -1,6 +1,6 @@
 module github.com/NVIDIA/nodewright/operator
 
-go 1.26.0
+go 1.26.2
 
 require (
 	github.com/go-logr/logr v1.4.3


### PR DESCRIPTION

## Description
Update go version to latest 1.26.2

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/skyhook/blob/main/CONTRIBUTING.md).
- [x] My commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
