### PR TITLE
ci: run helm tests with ctlptl registry

### DIFF
--- a/.github/workflows/operator-ci.yaml
+++ b/.github/workflows/operator-ci.yaml
@@ -43,6 +43,7 @@ env:
   IMAGE_NAME: ${{ github.repository }}
   GO_VERSION: 1.26.2
   DEBIAN_VERSION: trixie
+  KIND_BINARY_VERSION: v0.31.0
   PLATFORMS: linux/amd64,linux/arm64
   PUSH_TO_REGISTRY: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
 
@@ -138,15 +139,15 @@ jobs:
         id: kind
         uses: helm/kind-action@v1
         with:
-          version: v0.31.0
+          version: ${{ env.KIND_BINARY_VERSION }}
           node_image: kindest/node:v${{ matrix.k8s-version }}
           config: ${{ matrix.kind-config || 'operator/config/local-dev/kind-config.yaml' }}
           cluster_name: kind
       - name: Install kind
         if: matrix.test-suite == 'helm-tests'
         run: |
-          curl -fsSL -o /tmp/kind-linux-amd64 https://kind.sigs.k8s.io/dl/v0.31.0/kind-linux-amd64
-          curl -fsSL -o /tmp/kind-linux-amd64.sha256sum https://kind.sigs.k8s.io/dl/v0.31.0/kind-linux-amd64.sha256sum
+          curl -fsSL -o /tmp/kind-linux-amd64 https://kind.sigs.k8s.io/dl/${KIND_BINARY_VERSION}/kind-linux-amd64
+          curl -fsSL -o /tmp/kind-linux-amd64.sha256sum https://kind.sigs.k8s.io/dl/${KIND_BINARY_VERSION}/kind-linux-amd64.sha256sum
           cd /tmp && sha256sum -c kind-linux-amd64.sha256sum
           sudo install /tmp/kind-linux-amd64 /usr/local/bin/kind
       - name: Create ctlptl KinD Cluster

--- a/.github/workflows/operator-ci.yaml
+++ b/.github/workflows/operator-ci.yaml
@@ -109,34 +109,6 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Create Kubernetes KinD Cluster v${{ matrix.k8s-version }}
-        if: matrix.test-suite != 'unit-tests' && matrix.test-suite != 'helm-tests' # unit tests don't need a cluster; helm-tests uses ctlptl
-        id: kind
-        uses: helm/kind-action@v1
-        with:
-          version: v0.31.0
-          node_image: kindest/node:v${{ matrix.k8s-version }}
-          config: ${{ matrix.kind-config || 'operator/config/local-dev/kind-config.yaml' }}
-          cluster_name: kind
-      - name: Install ctlptl
-        if: matrix.test-suite == 'helm-tests'
-        # ctlptl v0.9.3 does not publish checksum assets; keep the release URL pinned.
-        run: curl -fsSL https://github.com/tilt-dev/ctlptl/releases/download/v0.9.3/ctlptl.0.9.3.linux.x86_64.tar.gz | sudo tar -xzv -C /usr/local/bin ctlptl
-      - name: Install kind
-        if: matrix.test-suite == 'helm-tests'
-        run: |
-          curl -fsSL -o /tmp/kind-linux-amd64 https://kind.sigs.k8s.io/dl/v0.31.0/kind-linux-amd64
-          curl -fsSL -o /tmp/kind-linux-amd64.sha256sum https://kind.sigs.k8s.io/dl/v0.31.0/kind-linux-amd64.sha256sum
-          cd /tmp && sha256sum -c kind-linux-amd64.sha256sum
-          sudo install /tmp/kind-linux-amd64 /usr/local/bin/kind
-      - name: Create ctlptl KinD Cluster
-        if: matrix.test-suite == 'helm-tests'
-        run: ctlptl apply -f operator/config/local-dev/ctlptl-config.yaml
-      - name: Set up ctlptl KinD Cluster
-        if: matrix.test-suite == 'helm-tests'
-        run: |
-          cd operator
-          make setup-kind-cluster
       # Cache build tools and dependencies for faster builds
       - name: Restore cached Binaries
         id: cached-binaries
@@ -161,6 +133,30 @@ jobs:
           path: |
             ${{ github.workspace }}/operator/bin
             ~/.cache/go-build
+      - name: Create Kubernetes KinD Cluster v${{ matrix.k8s-version }}
+        if: matrix.test-suite != 'unit-tests' && matrix.test-suite != 'helm-tests' # unit tests don't need a cluster; helm-tests uses ctlptl
+        id: kind
+        uses: helm/kind-action@v1
+        with:
+          version: v0.31.0
+          node_image: kindest/node:v${{ matrix.k8s-version }}
+          config: ${{ matrix.kind-config || 'operator/config/local-dev/kind-config.yaml' }}
+          cluster_name: kind
+      - name: Install kind
+        if: matrix.test-suite == 'helm-tests'
+        run: |
+          curl -fsSL -o /tmp/kind-linux-amd64 https://kind.sigs.k8s.io/dl/v0.31.0/kind-linux-amd64
+          curl -fsSL -o /tmp/kind-linux-amd64.sha256sum https://kind.sigs.k8s.io/dl/v0.31.0/kind-linux-amd64.sha256sum
+          cd /tmp && sha256sum -c kind-linux-amd64.sha256sum
+          sudo install /tmp/kind-linux-amd64 /usr/local/bin/kind
+      - name: Create ctlptl KinD Cluster
+        if: matrix.test-suite == 'helm-tests'
+        run: ./operator/bin/ctlptl apply -f operator/config/local-dev/ctlptl-config.yaml
+      - name: Set up ctlptl KinD Cluster
+        if: matrix.test-suite == 'helm-tests'
+        run: |
+          cd operator
+          make setup-kind-cluster
       # Run test suite
       - name: Run ${{ matrix.test-suite }} tests
         run: |

--- a/.github/workflows/operator-ci.yaml
+++ b/.github/workflows/operator-ci.yaml
@@ -87,6 +87,9 @@ jobs:
           - k8s-version: "1.35.0"
             test-suite: unit-tests
             make-targets: "vet lint unit-tests"
+          - k8s-version: "1.35.0"
+            test-suite: helm-tests
+            make-targets: "helm-tests"
       fail-fast: false  # Continue testing other versions if one fails
     name: ${{ matrix.test-suite }} (k8s-${{ matrix.k8s-version }})
     steps:
@@ -107,7 +110,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Create Kubernetes KinD Cluster v${{ matrix.k8s-version }}
-        if: matrix.test-suite != 'unit-tests' # unit tests don't need a kind cluster
+        if: matrix.test-suite != 'unit-tests' && matrix.test-suite != 'helm-tests' # unit tests don't need a cluster; helm-tests uses ctlptl
         id: kind
         uses: helm/kind-action@v1
         with:
@@ -115,6 +118,25 @@ jobs:
           node_image: kindest/node:v${{ matrix.k8s-version }}
           config: ${{ matrix.kind-config || 'operator/config/local-dev/kind-config.yaml' }}
           cluster_name: kind
+      - name: Install ctlptl
+        if: matrix.test-suite == 'helm-tests'
+        # ctlptl v0.9.3 does not publish checksum assets; keep the release URL pinned.
+        run: curl -fsSL https://github.com/tilt-dev/ctlptl/releases/download/v0.9.3/ctlptl.0.9.3.linux.x86_64.tar.gz | sudo tar -xzv -C /usr/local/bin ctlptl
+      - name: Install kind
+        if: matrix.test-suite == 'helm-tests'
+        run: |
+          curl -fsSL -o /tmp/kind-linux-amd64 https://kind.sigs.k8s.io/dl/v0.31.0/kind-linux-amd64
+          curl -fsSL -o /tmp/kind-linux-amd64.sha256sum https://kind.sigs.k8s.io/dl/v0.31.0/kind-linux-amd64.sha256sum
+          cd /tmp && sha256sum -c kind-linux-amd64.sha256sum
+          sudo install /tmp/kind-linux-amd64 /usr/local/bin/kind
+      - name: Create ctlptl KinD Cluster
+        if: matrix.test-suite == 'helm-tests'
+        run: ctlptl apply -f operator/config/local-dev/ctlptl-config.yaml
+      - name: Set up ctlptl KinD Cluster
+        if: matrix.test-suite == 'helm-tests'
+        run: |
+          cd operator
+          make setup-kind-cluster
       # Cache build tools and dependencies for faster builds
       - name: Restore cached Binaries
         id: cached-binaries

--- a/chart/templates/skyhook-crd.yaml
+++ b/chart/templates/skyhook-crd.yaml
@@ -480,6 +480,28 @@ spec:
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
                       type: object
+                    uninstall:
+                      description: Uninstall configures explicit uninstall support
+                        for this package.
+                      properties:
+                        apply:
+                          default: false
+                          description: |-
+                            Apply triggers the uninstall workflow on all target nodes.
+                            Only valid when Enabled is true (webhook rejects apply=true with enabled=false).
+                            Set to false (or remove) to cancel a pending uninstall.
+                          type: boolean
+                        enabled:
+                          default: false
+                          description: |-
+                            Enabled declares this package supports uninstall (has uninstall.sh/uninstall_check.sh).
+                            When true, the operator will run uninstall pods before allowing package removal
+                            and during CR deletion cleanup.
+                          type: boolean
+                      required:
+                      - apply
+                      - enabled
+                      type: object
                     version:
                       description: Version is the version of the package
                       type: string

--- a/docs/development.md
+++ b/docs/development.md
@@ -27,7 +27,7 @@ cd operator
 make create-kind-cluster
 ```
 
-`make create-kind-cluster` applies `operator/config/local-dev/ctlptl-config.yaml`, which creates the kind cluster and a local registry at `localhost:5005`. It also runs `make setup-kind-cluster`, which is idempotent and labels the test node and creates the `skyhook` namespace pull secret.
+`make create-kind-cluster` applies `config/local-dev/ctlptl-config.yaml`, which creates the kind cluster and a local registry at `localhost:5005`. It also runs `make setup-kind-cluster`, which is idempotent and labels the test node and creates the `skyhook` namespace pull secret.
 
 ## Webhook Iteration
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -34,11 +34,7 @@ Webhook development uses the operator pod, so rebuilding and restarting the depl
 
 ```bash
 cd operator
-export LOCAL_OPERATOR_IMG=localhost:5005/skyhook-operator:testing
-make docker-build
-docker tag ghcr.io/nvidia/skyhook/operator:testing $LOCAL_OPERATOR_IMG
-docker push $LOCAL_OPERATOR_IMG
-kubectl rollout restart deploy/skyhook-operator -n skyhook
+make rollout-local
 ```
 
 The local registry removes the need for `kind load docker-image` or registry-pinned chart value edits while iterating on operator or webhook code.
@@ -48,5 +44,6 @@ The local registry removes the need for `kind load docker-image` or registry-pin
 Delete the cluster and registry with the same ctlptl config:
 
 ```bash
-ctlptl delete -f operator/config/local-dev/ctlptl-config.yaml
+cd operator
+make delete-kind-cluster
 ```

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,52 @@
+# Local Development
+
+## ctlptl Setup
+
+Install ctlptl once before creating the local development cluster:
+
+```bash
+brew install tilt-dev/tap/ctlptl
+```
+
+The generic install path from ctlptl is:
+
+```bash
+go install github.com/tilt-dev/ctlptl/cmd/ctlptl@v0.9.3
+```
+
+Keep this version in sync with the `ctlptl` version pinned in CI.
+
+## Local Cluster
+
+Bring up the kind cluster and local registry:
+
+```bash
+cd operator
+make create-kind-cluster
+make setup-kind-cluster
+```
+
+`make create-kind-cluster` applies `operator/config/local-dev/ctlptl-config.yaml`, which creates the kind cluster and a local registry at `localhost:5005`. `make setup-kind-cluster` is idempotent and labels the test node and creates the `skyhook` namespace pull secret.
+
+## Webhook Iteration
+
+Webhook development uses the operator pod, so rebuilding and restarting the deployment is the main iteration loop:
+
+```bash
+cd operator
+export LOCAL_OPERATOR_IMG=localhost:5005/skyhook-operator:testing
+make docker-build
+docker tag ghcr.io/nvidia/skyhook/operator:testing $LOCAL_OPERATOR_IMG
+docker push $LOCAL_OPERATOR_IMG
+kubectl rollout restart deploy/skyhook-operator -n skyhook
+```
+
+The local registry removes the need for `kind load docker-image` or registry-pinned chart value edits while iterating on operator or webhook code.
+
+## Teardown
+
+Delete the cluster and registry with the same ctlptl config:
+
+```bash
+ctlptl delete -f operator/config/local-dev/ctlptl-config.yaml
+```

--- a/docs/development.md
+++ b/docs/development.md
@@ -2,19 +2,21 @@
 
 ## ctlptl Setup
 
-Install ctlptl once before creating the local development cluster:
+The local development targets install the pinned `ctlptl` binary through `operator/deps.mk` into `operator/bin`. No global install is required when using the Makefile.
 
-```bash
-brew install tilt-dev/tap/ctlptl
-```
-
-The generic install path from ctlptl is:
+If you want a standalone `ctlptl` on your `PATH`, install the same version pinned in `operator/deps.mk`:
 
 ```bash
 go install github.com/tilt-dev/ctlptl/cmd/ctlptl@v0.9.3
 ```
 
-Keep this version in sync with the `ctlptl` version pinned in CI.
+Homebrew is also available for manual use:
+
+```bash
+brew install tilt-dev/tap/ctlptl
+```
+
+Keep manual installs in sync with `CTLPTL_VERSION` in `operator/deps.mk`.
 
 ## Local Cluster
 
@@ -23,10 +25,9 @@ Bring up the kind cluster and local registry:
 ```bash
 cd operator
 make create-kind-cluster
-make setup-kind-cluster
 ```
 
-`make create-kind-cluster` applies `operator/config/local-dev/ctlptl-config.yaml`, which creates the kind cluster and a local registry at `localhost:5005`. `make setup-kind-cluster` is idempotent and labels the test node and creates the `skyhook` namespace pull secret.
+`make create-kind-cluster` applies `operator/config/local-dev/ctlptl-config.yaml`, which creates the kind cluster and a local registry at `localhost:5005`. It also runs `make setup-kind-cluster`, which is idempotent and labels the test node and creates the `skyhook` namespace pull secret.
 
 ## Webhook Iteration
 

--- a/k8s-tests/chainsaw/helm/helm-chart-test/assert-no-schedule.yaml
+++ b/k8s-tests/chainsaw/helm/helm-chart-test/assert-no-schedule.yaml
@@ -49,7 +49,7 @@ spec:
   - command:
     - /manager
     ((env[?name == 'RUNTIME_REQUIRED_TAINT'].value)[0] == 'skyhook.nvidia.com=runtime-required:NoSchedule'): true 
-    image: ghcr.io/nvidia/skyhook/operator:latest ## THIS should change to be like a tag so it can point at a specific commit
+    (image == 'ghcr.io/nvidia/skyhook/operator:latest' || contains(image, 'localhost:5005/skyhook-operator')): true
     livenessProbe:
       failureThreshold: 3
       httpGet:

--- a/k8s-tests/chainsaw/helm/helm-chart-test/assert-scheduled.yaml
+++ b/k8s-tests/chainsaw/helm/helm-chart-test/assert-scheduled.yaml
@@ -49,7 +49,7 @@ spec:
   - command:
     - /manager
     ((env[?name == 'RUNTIME_REQUIRED_TAINT'].value)[0] == 'skyhook.nvidia.com=runtime-required:NoSchedule'): true
-    image: ghcr.io/nvidia/skyhook/operator:latest
+    (image == 'ghcr.io/nvidia/skyhook/operator:latest' || contains(image, 'localhost:5005/skyhook-operator')): true
     livenessProbe:
       failureThreshold: 3
       httpGet:

--- a/k8s-tests/chainsaw/helm/helm-chart-test/assert-scheduled.yaml
+++ b/k8s-tests/chainsaw/helm/helm-chart-test/assert-scheduled.yaml
@@ -49,7 +49,7 @@ spec:
   - command:
     - /manager
     ((env[?name == 'RUNTIME_REQUIRED_TAINT'].value)[0] == 'skyhook.nvidia.com=runtime-required:NoSchedule'): true
-    (image == 'ghcr.io/nvidia/skyhook/operator:latest' || contains(image, 'localhost:5005/skyhook-operator')): true
+    (image == 'ghcr.io/nvidia/skyhook/operator:latest' || contains(image, 'localhost:5005/skyhook-operator:')): true
     livenessProbe:
       failureThreshold: 3
       httpGet:

--- a/k8s-tests/chainsaw/helm/helm-webhook-test/skyhook-uninstall-valid.yaml
+++ b/k8s-tests/chainsaw/helm/helm-webhook-test/skyhook-uninstall-valid.yaml
@@ -27,8 +27,8 @@ spec:
     count: 1
   packages:
     mypkg:
-      version: "2.1.4"
-      image: ghcr.io/nvidia/skyhook/agentless
+      version: "1.0.0"
+      image: ghcr.io/nvidia/skyhook-packages/shellscript
       uninstall:
         enabled: true
         apply: false

--- a/k8s-tests/chainsaw/helm/helm-webhook-test/update-downgrade-enabled-pkg.yaml
+++ b/k8s-tests/chainsaw/helm/helm-webhook-test/update-downgrade-enabled-pkg.yaml
@@ -27,8 +27,8 @@ spec:
     count: 1
   packages:
     mypkg:
-      version: "1.0.0"
-      image: ghcr.io/nvidia/skyhook/agentless
+      version: "0.9.0"
+      image: ghcr.io/nvidia/skyhook-packages/shellscript
       uninstall:
         enabled: true
         apply: false

--- a/k8s-tests/chainsaw/helm/install-helm-chart.sh
+++ b/k8s-tests/chainsaw/helm/install-helm-chart.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -xe
 
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 #
@@ -28,5 +28,28 @@ else
     HELM=$(which helm)
 fi
 
+LOCAL_OPERATOR_IMG_ARGS=()
+if [ -n "${LOCAL_OPERATOR_IMG:-}" ]; then
+    LOCAL_OPERATOR_IMG_WITHOUT_DIGEST=${LOCAL_OPERATOR_IMG%%@*}
+    LOCAL_OPERATOR_IMG_DIGEST=""
+    if [[ "${LOCAL_OPERATOR_IMG}" == *@* ]]; then
+        LOCAL_OPERATOR_IMG_DIGEST=${LOCAL_OPERATOR_IMG#*@}
+    fi
+
+    LOCAL_OPERATOR_IMG_REPOSITORY=${LOCAL_OPERATOR_IMG_WITHOUT_DIGEST}
+    LOCAL_OPERATOR_IMG_TAG=""
+    LOCAL_OPERATOR_IMG_LAST_PART=${LOCAL_OPERATOR_IMG_WITHOUT_DIGEST##*/}
+    if [[ "${LOCAL_OPERATOR_IMG_LAST_PART}" == *:* ]]; then
+        LOCAL_OPERATOR_IMG_TAG=${LOCAL_OPERATOR_IMG_LAST_PART##*:}
+        LOCAL_OPERATOR_IMG_REPOSITORY=${LOCAL_OPERATOR_IMG_WITHOUT_DIGEST%:*}
+    fi
+
+    LOCAL_OPERATOR_IMG_ARGS=(
+        --set "controllerManager.manager.image.repository=${LOCAL_OPERATOR_IMG_REPOSITORY}"
+        --set "controllerManager.manager.image.tag=${LOCAL_OPERATOR_IMG_TAG}"
+        --set "controllerManager.manager.image.digest=${LOCAL_OPERATOR_IMG_DIGEST}"
+    )
+fi
+
 ## install operator
-${HELM} upgrade --install ${OPERATOR_NAME} ../../../../chart -n skyhook -f ${VALUES_FILE_NAME}
+${HELM} upgrade --install ${OPERATOR_NAME} ../../../../chart -n skyhook -f ${VALUES_FILE_NAME} "${LOCAL_OPERATOR_IMG_ARGS[@]}"

--- a/k8s-tests/chainsaw/skyhook/config-skyhook/assert-update-glob.yaml
+++ b/k8s-tests/chainsaw/skyhook/config-skyhook/assert-update-glob.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 #
@@ -47,6 +47,7 @@ spec:
 apiVersion: v1
 kind: Node
 metadata:
+  name: kind-worker
   labels:
     skyhook.nvidia.com/test-node: skyhooke2e
     skyhook.nvidia.com/status_config-skyhook: complete

--- a/k8s-tests/chainsaw/skyhook/config-skyhook/chainsaw-test.yaml
+++ b/k8s-tests/chainsaw/skyhook/config-skyhook/chainsaw-test.yaml
@@ -50,6 +50,7 @@ spec:
           apiVersion: v1
           kind: Node
           metadata:
+            name: kind-worker
             labels:
               skyhook.nvidia.com/test-node: skyhooke2e
               skyhook.nvidia.com/status_config-skyhook: in_progress
@@ -132,11 +133,13 @@ spec:
         file: update-while-running.yaml
     ## sequential: node/skyhook transition through lifecycle stages
     - assert:
+        timeout: 360s
         ## node complete with all packages at post-interrupt
         resource:
           apiVersion: v1
           kind: Node
           metadata:
+            name: kind-worker
             labels:
               skyhook.nvidia.com/test-node: skyhooke2e
               skyhook.nvidia.com/status_config-skyhook: complete
@@ -221,6 +224,7 @@ spec:
           apiVersion: v1
           kind: Node
           metadata:
+            name: kind-worker
             labels:
               skyhook.nvidia.com/test-node: skyhooke2e
               skyhook.nvidia.com/status_config-skyhook: complete
@@ -305,6 +309,7 @@ spec:
           apiVersion: v1
           kind: Node
           metadata:
+            name: kind-worker
             labels:
               skyhook.nvidia.com/test-node: skyhooke2e
               skyhook.nvidia.com/status_config-skyhook: complete

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -222,9 +222,8 @@ cli-e2e-tests: chainsaw install run build-cli-with-coverage ensure-test-symlinks
 		echo "ℹ️  No CLI coverage data (this is OK - CLI is covered by unit tests)"; \
 	fi
 
-helm-tests: helm chainsaw ensure-test-symlinks docker-build
-	$(DOCKER_CMD) tag $(IMG):testing $(LOCAL_OPERATOR_IMG)
-	$(DOCKER_CMD) push $(LOCAL_OPERATOR_IMG)
+
+helm-tests: helm chainsaw ctlptl ensure-test-symlinks push-local-image
 	## Here we need to run the operator so that the old CRD can deleted along with
 	## any leftover SCRs. Without this the SCRs may have finalizers which rely on
 	## the operator and will cause the deletion and tests to hang.
@@ -232,6 +231,24 @@ helm-tests: helm chainsaw ensure-test-symlinks docker-build
 	$(MAKE) uninstall ignore-not-found=true
 	$(MAKE) kill
 	LOCAL_OPERATOR_IMG=$(LOCAL_OPERATOR_IMG) $(CHAINSAW) test --test-dir ../k8s-tests/chainsaw/helm $(CHAINSAW_ARGS)
+
+
+
+.PHONY: push-local-image
+push-local-image: docker-build ## Tag and push the locally-built operator image to the local ctlptl registry
+	$(DOCKER_CMD) tag $(IMG):testing $(LOCAL_OPERATOR_IMG)
+	$(DOCKER_CMD) push $(LOCAL_OPERATOR_IMG)
+
+
+
+.PHONY: rollout-local
+rollout-local: push-local-image ## push locally-built operator and restart the deployment
+	$(KUBECTL) -n $(SKYHOOK_NAMESPACE) rollout restart deploy/skyhook-operator
+
+
+.PHONY: delete-kind-cluster
+delete-kind-cluster: ctlptl ## delete the local ctlptl kind cluster and registry
+	$(CTLPTL) delete -f config/local-dev/ctlptl-config.yaml
 
 operator-agent-tests: chainsaw install ## Run operator agent tests.
 	@if [ -z "$(AGENT_IMAGE)" ]; then \
@@ -289,8 +306,9 @@ setup-kind-cluster: ## setup kind cluster with local docker creds and skyhook na
 	$(KUBECTL) create secret generic node-init-secret --type=kubernetes.io/dockerconfigjson -n $(SKYHOOK_NAMESPACE) \
 		--from-file=.dockerconfigjson=$(DOCKER_AUTH_FILE) --dry-run=client -o yaml | $(KUBECTL) apply -f -
 
-create-kind-cluster: ## creates or updates a kind cluster.
-	ctlptl apply -f config/local-dev/ctlptl-config.yaml
+
+create-kind-cluster: ctlptl ## creates or updates a kind cluster.
+	$(CTLPTL) apply -f config/local-dev/ctlptl-config.yaml
 	$(MAKE) setup-kind-cluster
 
 podman-create-machine: ## creates a podman machine

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -24,6 +24,8 @@ DISTROLESS_VERSION ?= 4.0.2
 ## TODO: update this to the correct image location
 IMG_REPO ?= ghcr.io/nvidia/skyhook
 IMG ?= $(IMG_REPO)/operator
+LOCAL_REGISTRY ?= localhost:5005
+LOCAL_OPERATOR_IMG ?= $(LOCAL_REGISTRY)/skyhook-operator:testing
 
 ## default version of kind to use
 KIND_VERSION?=1.35.0
@@ -220,14 +222,16 @@ cli-e2e-tests: chainsaw install run build-cli-with-coverage ensure-test-symlinks
 		echo "ℹ️  No CLI coverage data (this is OK - CLI is covered by unit tests)"; \
 	fi
 
-helm-tests: helm chainsaw ensure-test-symlinks
+helm-tests: helm chainsaw ensure-test-symlinks docker-build
+	$(DOCKER_CMD) tag $(IMG):testing $(LOCAL_OPERATOR_IMG)
+	$(DOCKER_CMD) push $(LOCAL_OPERATOR_IMG)
 	## Here we need to run the operator so that the old CRD can deleted along with
 	## any leftover SCRs. Without this the SCRs may have finalizers which rely on
 	## the operator and will cause the deletion and tests to hang.
 	$(MAKE) run
 	$(MAKE) uninstall ignore-not-found=true
 	$(MAKE) kill
-	$(CHAINSAW) test --test-dir ../k8s-tests/chainsaw/helm $(CHAINSAW_ARGS)
+	LOCAL_OPERATOR_IMG=$(LOCAL_OPERATOR_IMG) $(CHAINSAW) test --test-dir ../k8s-tests/chainsaw/helm $(CHAINSAW_ARGS)
 
 operator-agent-tests: chainsaw install ## Run operator agent tests.
 	@if [ -z "$(AGENT_IMAGE)" ]; then \
@@ -283,10 +287,10 @@ setup-kind-cluster: ## setup kind cluster with local docker creds and skyhook na
 	$(KUBECTL) label node/kind-worker skyhook.nvidia.com/test-node=skyhooke2e --overwrite
 	$(KUBECTL) create namespace $(SKYHOOK_NAMESPACE) --dry-run=client -o yaml | kubectl apply -f -
 	$(KUBECTL) create secret generic node-init-secret --type=kubernetes.io/dockerconfigjson -n $(SKYHOOK_NAMESPACE) \
-		--from-file=.dockerconfigjson=$(DOCKER_AUTH_FILE)
+		--from-file=.dockerconfigjson=$(DOCKER_AUTH_FILE) --dry-run=client -o yaml | $(KUBECTL) apply -f -
 
-create-kind-cluster: ## deletes and creates a new kind cluster. versions is set via KIND_VERSION
-	kind delete cluster && kind create cluster --image=kindest/node:v$(KIND_VERSION) --config config/local-dev/kind-config.yaml
+create-kind-cluster: ## creates or updates a kind cluster.
+	ctlptl apply -f config/local-dev/ctlptl-config.yaml
 	$(MAKE) setup-kind-cluster
 
 podman-create-machine: ## creates a podman machine

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -244,6 +244,7 @@ push-local-image: docker-build ## Tag and push the locally-built operator image 
 .PHONY: rollout-local
 rollout-local: push-local-image ## push locally-built operator and restart the deployment
 	$(KUBECTL) -n $(SKYHOOK_NAMESPACE) rollout restart deployment -l app.kubernetes.io/name=skyhook-operator,control-plane=controller-manager
+	$(KUBECTL) -n $(SKYHOOK_NAMESPACE) rollout status deployment -l app.kubernetes.io/name=skyhook-operator,control-plane=controller-manager --timeout=60s
 
 
 .PHONY: delete-kind-cluster
@@ -303,8 +304,12 @@ setup-kind-cluster: ## setup kind cluster with local docker creds and skyhook na
 	## sets you local $(DOCKER_CMD) creds into a secret in kind in the skyhook namespace
 	$(KUBECTL) label node/kind-worker skyhook.nvidia.com/test-node=skyhooke2e --overwrite
 	$(KUBECTL) create namespace $(SKYHOOK_NAMESPACE) --dry-run=client -o yaml | kubectl apply -f -
-	$(KUBECTL) create secret generic node-init-secret --type=kubernetes.io/dockerconfigjson -n $(SKYHOOK_NAMESPACE) \
-		--from-file=.dockerconfigjson=$(DOCKER_AUTH_FILE) --dry-run=client -o yaml | $(KUBECTL) apply -f -
+	@if [ -f "$(DOCKER_AUTH_FILE)" ]; then \
+		$(KUBECTL) create secret generic node-init-secret --type=kubernetes.io/dockerconfigjson -n $(SKYHOOK_NAMESPACE) \
+			--from-file=.dockerconfigjson=$(DOCKER_AUTH_FILE) --dry-run=client -o yaml | $(KUBECTL) apply -f -; \
+	else \
+		echo "Skipping node-init-secret creation; docker auth file $(DOCKER_AUTH_FILE) not found"; \
+	fi
 
 
 create-kind-cluster: ctlptl ## creates or updates a kind cluster.

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -27,8 +27,8 @@ IMG ?= $(IMG_REPO)/operator
 LOCAL_REGISTRY ?= localhost:5005
 LOCAL_OPERATOR_IMG ?= $(LOCAL_REGISTRY)/skyhook-operator:testing
 
-## default version of kind to use
-KIND_VERSION?=1.35.0
+## default Kubernetes version for kind-based development clusters
+KIND_VERSION ?= $(ENVTEST_K8S_VERSION)
 
 PLATFORM := $(shell uname -s 2>/dev/null || echo unknown)
 SKYHOOK_NAMESPACE ?= skyhook

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -243,7 +243,7 @@ push-local-image: docker-build ## Tag and push the locally-built operator image 
 
 .PHONY: rollout-local
 rollout-local: push-local-image ## push locally-built operator and restart the deployment
-	$(KUBECTL) -n $(SKYHOOK_NAMESPACE) rollout restart deploy/skyhook-operator
+	$(KUBECTL) -n $(SKYHOOK_NAMESPACE) rollout restart deployment -l app.kubernetes.io/name=skyhook-operator,control-plane=controller-manager
 
 
 .PHONY: delete-kind-cluster

--- a/operator/config/local-dev/ctlptl-config.yaml
+++ b/operator/config/local-dev/ctlptl-config.yaml
@@ -23,6 +23,8 @@ apiVersion: ctlptl.dev/v1alpha1
 kind: Cluster
 product: kind
 registry: ctlptl-registry
+# Keep this aligned with ENVTEST_K8S_VERSION in deps.mk and the helm-tests
+# Kubernetes version in operator-ci.yaml; ctlptl consumes this YAML directly.
 kubernetesVersion: v1.35.0
 kindV1Alpha4Cluster:
   nodes:

--- a/operator/config/local-dev/ctlptl-config.yaml
+++ b/operator/config/local-dev/ctlptl-config.yaml
@@ -14,11 +14,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# three node (two workers) local kind cluster config used by non-helm CI suites
-# and retained for comparing the ctlptl local development cluster shape.
+apiVersion: ctlptl.dev/v1alpha1
+kind: Registry
+name: ctlptl-registry
+port: 5005
+---
+apiVersion: ctlptl.dev/v1alpha1
 kind: Cluster
-apiVersion: kind.x-k8s.io/v1alpha4
-nodes:
-- role: control-plane
-- role: worker
-- role: worker
+product: kind
+registry: ctlptl-registry
+kubernetesVersion: v1.35.0
+kindV1Alpha4Cluster:
+  nodes:
+  - role: control-plane
+  - role: worker
+  - role: worker

--- a/operator/config/local-dev/kind-config.yaml
+++ b/operator/config/local-dev/kind-config.yaml
@@ -14,8 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# three node (two workers) local kind cluster config used by non-helm CI suites
-# and retained for comparing the ctlptl local development cluster shape.
+# kind cluster config used by the e2e, cli-e2e (operator-ci.yaml) and agent-ci.yaml
+# matrix entries via helm/kind-action. The local-dev path and the helm-tests CI
+# entry use ctlptl-config.yaml in this directory instead. Converging the
+# helm/kind-action paths onto ctlptl is tracked as a follow-up to #209.
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:

--- a/operator/deps.mk
+++ b/operator/deps.mk
@@ -48,9 +48,13 @@ HELM_VERSION ?= v3.18.5
 HELMIFY_VERSION ?= v0.4.12
 GO_LICENSES_VERSION ?= v1.6.0
 
+## ctlptl (local cluster + registry management)
+CTLPTL_VERSION ?= v0.9.3
+
+
 
 .PHONY: install-deps
-install-deps: golangci-lint kustomize controller-gen envtest gocover-cobertura ginkgo mockery chainsaw helm helmify go-licenses ## Install all dependencies
+install-deps: golangci-lint kustomize controller-gen envtest gocover-cobertura ginkgo mockery chainsaw helm helmify go-licenses ctlptl ## Install all dependencies
 
 ## Location to install dependencies to
 LOCALBIN ?= $(shell pwd)/bin
@@ -74,6 +78,10 @@ MOCKERY ?= $(LOCALBIN)/mockery
 CHAINSAW ?= $(LOCALBIN)/chainsaw
 HELMIFY ?= $(LOCALBIN)/helmify
 HELM ?= $(LOCALBIN)/helm
+CTLPTL ?= $(LOCALBIN)/ctlptl
+CTLPTL_OS = $(if $(filter darwin,$(OS)),mac,$(OS))
+CTLPTL_ARCH = $(if $(filter amd64,$(ARCH)),x86_64,$(ARCH))
+CTLPTL_VERSION_NO_V = $(patsubst v%,%,$(CTLPTL_VERSION))
 
 .PHONY: $(LOCALBIN) kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary. If wrong version is installed, it will be removed before downloading.
@@ -112,6 +120,12 @@ mockery: $(LOCALBIN)  ## Download mockery locally if necessary.
 chainsaw: $(LOCALBIN)  ## Download chainsaw binary if necessary.
 	test -s $(LOCALBIN)/chainsaw || curl -sSfL https://github.com/kyverno/chainsaw/releases/download/$(CHAINSAW_VERSION)/chainsaw_$(OS)_$(ARCH).tar.gz | \
 		tar --no-same-owner -zxv -C $(LOCALBIN) chainsaw
+
+.PHONY: ctlptl
+ctlptl: $(LOCALBIN) ## Download ctlptl binary if necessary.
+	test -s $(LOCALBIN)/ctlptl || curl -sSfL \
+	    https://github.com/tilt-dev/ctlptl/releases/download/$(CTLPTL_VERSION)/ctlptl.$(CTLPTL_VERSION_NO_V).$(CTLPTL_OS).$(CTLPTL_ARCH).tar.gz | \
+	    tar --no-same-owner -zxv -C $(LOCALBIN) ctlptl
 
 .PHONY: helm
 helm: $(LOCALBIN) ## Download helm locally if necessary.


### PR DESCRIPTION
## Summary
- Add a ctlptl local-dev config that creates a kind cluster with a `localhost:5005` registry.
- Update `make create-kind-cluster`, `make helm-tests`, and local rollout targets to use the local registry path.
- Add `helm-tests` to the operator CI matrix using the ctlptl-backed cluster.
- Document the local cluster, webhook iteration, and teardown workflow.

Fixes #209

## Notes
- `operator/config/local-dev/kind-config.yaml` is still used by non-Helm CI paths; the local-dev path and the `helm-tests` CI entry use `operator/config/local-dev/ctlptl-config.yaml`.
- `ctlptl` is pinned and installed through `operator/deps.mk`.
- `setup-kind-cluster` is idempotent and skips `node-init-secret` creation when the local Docker auth file is missing.
- `rollout-local` builds, tags, pushes, restarts the Helm-managed operator deployment, and waits for rollout completion.

## Validation
- `bash -n k8s-tests/chainsaw/helm/install-helm-chart.sh`
- `git diff --check`
- `make unit-tests` from `operator/`
- `make create-kind-cluster DOCKER_CMD=docker` from `operator/`
- `make setup-kind-cluster DOCKER_CMD=docker`
- `make setup-kind-cluster DOCKER_CMD=docker DOCKER_AUTH_FILE=/tmp/nodewright-missing-docker-auth.json`
- `kubectl -n skyhook rollout status deployment -l app.kubernetes.io/name=skyhook-operator,control-plane=controller-manager --timeout=60s`
- `make helm-tests DOCKER_CMD=docker` from `operator/`
- Webhook iteration check: temporarily added a log marker in `operator/internal/controller/webhook_controller.go`, ran `make rollout-local DOCKER_CMD=docker`, saw the operator deployment restart and complete, and found the marker in the restarted manager pod logs. The temporary marker was removed, then `make rollout-local DOCKER_CMD=docker` was run again.
