### PR TITLE
fix(controller): preserve shared Skyhook cordons

### DIFF
--- a/docs/interrupt_flow.md
+++ b/docs/interrupt_flow.md
@@ -81,6 +81,20 @@ The interrupt flow is managed by the `ProcessInterrupt` and `EnsureNodeIsReadyFo
 - Ensure the node is ready before proceeding with package operations
 - Handle the timing and sequencing of all stages
 
+### Shared Cordon Ownership
+
+Each Skyhook that cordons a node records ownership with a `skyhook.nvidia.com/cordon_<skyhook-name>` annotation. When that Skyhook completes, it removes only its own cordon annotation. The node is marked schedulable only after no `skyhook.nvidia.com/cordon_*` annotations remain, so one Skyhook cannot uncordon a node that another Skyhook is still preparing for interrupt work.
+
+Other Skyhook annotations, such as `status_*`, `nodeState_*`, and `version_*`, do not keep a node cordoned. Only the `cordon_*` annotation family participates in shared cordon ownership.
+
+### Orphaned Cordon Recovery
+
+If a Skyhook is force-deleted in a way that bypasses finalizer cleanup, or cleanup fails after the node was cordoned, its `cordon_<skyhook-name>` annotation can be left behind. That stale annotation will keep the node unschedulable from the operator's point of view until it is removed.
+
+Use `kubectl skyhook reset <skyhook-name> --confirm` to clear Skyhook metadata for affected nodes that still have `nodeState_<skyhook-name>` annotations, or `kubectl skyhook node reset <node-name> --skyhook <skyhook-name> --confirm` for a specific node. These reset commands remove the matching `cordon_<skyhook-name>` annotation, but they do not clear `spec.unschedulable`. After the stale cordon annotation is removed, if no other `skyhook.nvidia.com/cordon_*` annotations remain and no live Skyhook is expected to uncordon the node, run `kubectl uncordon <node-name>` to make it schedulable again.
+
+If the node only has a stale `cordon_<skyhook-name>` annotation and its `nodeState_<skyhook-name>` annotation has already been removed, `kubectl skyhook reset` will not discover the node. In that case, remove the orphaned annotation manually, then uncordon the node as above if no other Skyhook still owns a cordon.
+
 ## Drain Configuration
 
 Interrupt-enabled Skyhooks can tune drain behavior with `spec.drainConfig`.

--- a/k8s-tests/chainsaw/skyhook/shared-cordon-ownership/README.md
+++ b/k8s-tests/chainsaw/skyhook/shared-cordon-ownership/README.md
@@ -1,0 +1,30 @@
+# Shared Cordon Ownership
+
+## Purpose
+
+Verify that a node selected by two interrupt-enabled Skyhooks stays cordoned while either Skyhook still owns a cordon annotation.
+
+## Test Scenario
+
+1. Label the e2e test node with a test-specific selector and start a non-evictable blocker pod on it.
+2. Create `shared-cordon-slow`, which cordons the node and waits because its `podNonInterruptLabels` match the blocker pod.
+3. Create `shared-cordon-fast`, which also requires an interrupt and completes while `shared-cordon-slow` still owns the cordon.
+4. Assert that the fast Skyhook removed only its own cordon annotation and the node remains unschedulable.
+5. Delete the blocker pod, wait for the slow Skyhook to complete, and assert the node is schedulable with no `cordon_*` annotations.
+
+## Key Features Tested
+
+- Shared node cordon ownership across multiple Skyhooks
+- Cordon annotation cleanup for the completing Skyhook only
+- Final uncordon after all Skyhook-owned cordons are released
+
+## Files
+
+- `chainsaw-test.yaml` - Main test configuration
+- `blocker-pod.yaml` - Pod that holds the slow Skyhook at the pre-interrupt wait
+- `skyhook-fast.yaml` - Fast interrupt-enabled Skyhook
+- `skyhook-slow.yaml` - Slow interrupt-enabled Skyhook blocked by `podNonInterruptLabels`
+
+## Notes
+
+- The blocker pod tolerates `node.kubernetes.io/unschedulable`, so the fast Skyhook's drain ignores it while the slow Skyhook still treats it as non-interrupt work.

--- a/k8s-tests/chainsaw/skyhook/shared-cordon-ownership/blocker-pod.yaml
+++ b/k8s-tests/chainsaw/skyhook/shared-cordon-ownership/blocker-pod.yaml
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: shared-cordon-blocker
+  labels:
+    skyhook.nvidia.com/shared-cordon-blocker: "true"
+spec:
+  terminationGracePeriodSeconds: 5
+  restartPolicy: OnFailure
+  nodeSelector:
+    skyhook.nvidia.com/shared-cordon-ownership: "true"
+  tolerations:
+  - key: node.kubernetes.io/unschedulable
+    operator: Exists
+  containers:
+  - name: workload
+    image: busybox:1.38.0
+    command: ["sh", "-c", "sleep 1000 && exit"]

--- a/k8s-tests/chainsaw/skyhook/shared-cordon-ownership/chainsaw-test.yaml
+++ b/k8s-tests/chainsaw/skyhook/shared-cordon-ownership/chainsaw-test.yaml
@@ -1,0 +1,177 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: shared-cordon-ownership
+  labels:
+    pool: interrupt
+spec:
+  timeouts:
+    assert: 180s
+  catch:
+  - get:
+      apiVersion: v1
+      kind: Node
+      selector: skyhook.nvidia.com/shared-cordon-ownership=true
+      format: yaml
+  - get:
+      apiVersion: skyhook.nvidia.com/v1alpha1
+      kind: Skyhook
+      name: shared-cordon-fast
+      format: yaml
+  - get:
+      apiVersion: skyhook.nvidia.com/v1alpha1
+      kind: Skyhook
+      name: shared-cordon-slow
+      format: yaml
+  steps:
+  - name: shared-cordon-ownership
+    try:
+    - script:
+        timeout: 30s
+        content: |
+          set -eu
+
+          ../skyhook-cli reset shared-cordon-fast --confirm 2>/dev/null || true
+          ../skyhook-cli reset shared-cordon-slow --confirm 2>/dev/null || true
+
+          node=$(kubectl get nodes -l skyhook.nvidia.com/test-node=skyhooke2e -o jsonpath='{.items[0].metadata.name}')
+          if [ -z "$node" ]; then
+            echo "no skyhooke2e test node found"
+            exit 1
+          fi
+
+          kubectl label node "$node" skyhook.nvidia.com/shared-cordon-ownership=true --overwrite
+    - create:
+        file: blocker-pod.yaml
+    - wait:
+        apiVersion: v1
+        kind: Pod
+        name: shared-cordon-blocker
+        timeout: 30s
+        for:
+          condition:
+            name: Ready
+            value: 'true'
+    - create:
+        file: skyhook-slow.yaml
+    - script:
+        timeout: 90s
+        content: |
+          set -eu
+
+          node=$(kubectl get nodes -l skyhook.nvidia.com/shared-cordon-ownership=true -o jsonpath='{.items[0].metadata.name}')
+          for _ in $(seq 1 90); do
+            slow_cordon=$(kubectl get node "$node" -o jsonpath='{.metadata.annotations.skyhook\.nvidia\.com/cordon_shared-cordon-slow}' 2>/dev/null || true)
+            unschedulable=$(kubectl get node "$node" -o jsonpath='{.spec.unschedulable}' 2>/dev/null || true)
+
+            if [ "$slow_cordon" = "true" ] && [ "$unschedulable" = "true" ]; then
+              exit 0
+            fi
+
+            sleep 1
+          done
+
+          kubectl get node "$node" -o yaml
+          kubectl get skyhook shared-cordon-slow -o yaml
+          echo "timed out waiting for shared-cordon-slow to own the cordon"
+          exit 1
+    - create:
+        file: skyhook-fast.yaml
+    - assert:
+        timeout: 120s
+        resource:
+          apiVersion: skyhook.nvidia.com/v1alpha1
+          kind: Skyhook
+          metadata:
+            name: shared-cordon-fast
+          status:
+            status: complete
+    - script:
+        timeout: 30s
+        content: |
+          set -eu
+
+          node=$(kubectl get nodes -l skyhook.nvidia.com/shared-cordon-ownership=true -o jsonpath='{.items[0].metadata.name}')
+          unschedulable=$(kubectl get node "$node" -o jsonpath='{.spec.unschedulable}' 2>/dev/null || true)
+          fast_cordon=$(kubectl get node "$node" -o jsonpath='{.metadata.annotations.skyhook\.nvidia\.com/cordon_shared-cordon-fast}' 2>/dev/null || true)
+          slow_cordon=$(kubectl get node "$node" -o jsonpath='{.metadata.annotations.skyhook\.nvidia\.com/cordon_shared-cordon-slow}' 2>/dev/null || true)
+
+          if [ "$unschedulable" != "true" ]; then
+            kubectl get node "$node" -o yaml
+            echo "expected node to stay unschedulable while shared-cordon-slow still owns a cordon"
+            exit 1
+          fi
+
+          if [ -n "$fast_cordon" ]; then
+            kubectl get node "$node" -o yaml
+            echo "expected shared-cordon-fast cordon annotation to be removed after completion"
+            exit 1
+          fi
+
+          if [ "$slow_cordon" != "true" ]; then
+            kubectl get node "$node" -o yaml
+            echo "expected shared-cordon-slow cordon annotation to keep the node cordoned"
+            exit 1
+          fi
+    - delete:
+        file: blocker-pod.yaml
+    - assert:
+        timeout: 180s
+        resource:
+          apiVersion: skyhook.nvidia.com/v1alpha1
+          kind: Skyhook
+          metadata:
+            name: shared-cordon-slow
+          status:
+            status: complete
+    - script:
+        timeout: 30s
+        content: |
+          set -eu
+
+          node=$(kubectl get nodes -l skyhook.nvidia.com/shared-cordon-ownership=true -o jsonpath='{.items[0].metadata.name}')
+          unschedulable=$(kubectl get node "$node" -o jsonpath='{.spec.unschedulable}' 2>/dev/null || true)
+          cordons=$(kubectl get node "$node" -o json | jq -r '.metadata.annotations // {} | keys[] | select(startswith("skyhook.nvidia.com/cordon_"))')
+
+          if [ -n "$unschedulable" ] && [ "$unschedulable" != "false" ]; then
+            kubectl get node "$node" -o yaml
+            echo "expected node to become schedulable after both Skyhooks complete"
+            exit 1
+          fi
+
+          if [ -n "$cordons" ]; then
+            kubectl get node "$node" -o yaml
+            echo "expected no Skyhook cordon annotations after both Skyhooks complete"
+            exit 1
+          fi
+    finally:
+    - script:
+        timeout: 30s
+        content: |
+          set -eu
+
+          kubectl delete pod shared-cordon-blocker --ignore-not-found=true --wait=false 2>/dev/null || true
+          ../skyhook-cli reset shared-cordon-fast --confirm 2>/dev/null || true
+          ../skyhook-cli reset shared-cordon-slow --confirm 2>/dev/null || true
+
+          node=$(kubectl get nodes -l skyhook.nvidia.com/shared-cordon-ownership=true -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
+          if [ -n "$node" ]; then
+            kubectl label node "$node" skyhook.nvidia.com/shared-cordon-ownership- 2>/dev/null || true
+          fi

--- a/k8s-tests/chainsaw/skyhook/shared-cordon-ownership/skyhook-fast.yaml
+++ b/k8s-tests/chainsaw/skyhook/shared-cordon-ownership/skyhook-fast.yaml
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: skyhook.nvidia.com/v1alpha1
+kind: Skyhook
+metadata:
+  labels:
+    app.kubernetes.io/part-of: skyhook-operator
+    app.kubernetes.io/created-by: skyhook-operator
+  name: shared-cordon-fast
+spec:
+  nodeSelectors:
+    matchLabels:
+      skyhook.nvidia.com/shared-cordon-ownership: "true"
+  packages:
+    fastpkg:
+      version: "1.2.3"
+      image: ghcr.io/nvidia/skyhook/agentless
+      env:
+      - name: SLEEP_LEN
+        value: "1"
+      interrupt:
+        type: noop

--- a/k8s-tests/chainsaw/skyhook/shared-cordon-ownership/skyhook-slow.yaml
+++ b/k8s-tests/chainsaw/skyhook/shared-cordon-ownership/skyhook-slow.yaml
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: skyhook.nvidia.com/v1alpha1
+kind: Skyhook
+metadata:
+  labels:
+    app.kubernetes.io/part-of: skyhook-operator
+    app.kubernetes.io/created-by: skyhook-operator
+  name: shared-cordon-slow
+spec:
+  podNonInterruptLabels:
+    matchLabels:
+      skyhook.nvidia.com/shared-cordon-blocker: "true"
+  nodeSelectors:
+    matchLabels:
+      skyhook.nvidia.com/shared-cordon-ownership: "true"
+  packages:
+    slowpkg:
+      version: "1.2.3"
+      image: ghcr.io/nvidia/skyhook/agentless
+      env:
+      - name: SLEEP_LEN
+        value: "1"
+      interrupt:
+        type: noop

--- a/operator/internal/wrapper/node.go
+++ b/operator/internal/wrapper/node.go
@@ -115,6 +115,11 @@ type SkyhookNodeOnly interface {
 
 var _ SkyhookNode = &skyhookNode{}
 
+const (
+	cordonAnnotationPrefix = v1alpha1.METADATA_PREFIX + "/cordon_"
+	cordonAnnotationValue  = "true"
+)
+
 // NewSkyhookNodeOnly most of use cases for the wrapper just needs name, so this stub is for making helpers for those use cases,
 // should help reduce calls to api, and not leak stubbed skyhooks with just name set.
 //
@@ -478,13 +483,14 @@ func (node *skyhookNode) HasSkyhookAnnotations() bool {
 
 // Cordon marks the node unschedulable and records the cordon in annotations for this Skyhook.
 func (node *skyhookNode) Cordon() {
-	_, ok := node.Annotations[fmt.Sprintf("%s/cordon_%s", v1alpha1.METADATA_PREFIX, node.skyhookName)]
+	if node.Annotations == nil {
+		node.Annotations = make(map[string]string)
+	}
+
+	_, ok := node.Annotations[cordonAnnotationKey(node.skyhookName)]
 	if !node.Spec.Unschedulable || !ok {
-		if node.Annotations == nil {
-			node.Annotations = make(map[string]string)
-		}
 		node.Spec.Unschedulable = true
-		node.Annotations[fmt.Sprintf("%s/cordon_%s", v1alpha1.METADATA_PREFIX, node.skyhookName)] = "true"
+		node.Annotations[cordonAnnotationKey(node.skyhookName)] = cordonAnnotationValue
 		node.updated = true
 	}
 }
@@ -543,12 +549,29 @@ func (node *skyhookNode) ClearDrainStart() {
 func (node *skyhookNode) Uncordon() {
 
 	// if we hold a cordon remove it, also we dont want to remove a cordon if we dont have one...
-	_, ok := node.Annotations[fmt.Sprintf("%s/cordon_%s", v1alpha1.METADATA_PREFIX, node.skyhookName)]
+	_, ok := node.Annotations[cordonAnnotationKey(node.skyhookName)]
 	if ok {
-		node.Spec.Unschedulable = false
-		delete(node.Annotations, fmt.Sprintf("%s/cordon_%s", v1alpha1.METADATA_PREFIX, node.skyhookName))
+		delete(node.Annotations, cordonAnnotationKey(node.skyhookName))
+		// Multiple Skyhooks can cordon the same node; only mark it schedulable
+		// after every Skyhook-owned cordon has been released.
+		if !hasSkyhookCordon(node.Annotations) {
+			node.Spec.Unschedulable = false
+		}
 		node.updated = true
 	}
+}
+
+func cordonAnnotationKey(skyhookName string) string {
+	return cordonAnnotationPrefix + skyhookName
+}
+
+func hasSkyhookCordon(annotations map[string]string) bool {
+	for key := range annotations {
+		if strings.HasPrefix(key, cordonAnnotationPrefix) {
+			return true
+		}
+	}
+	return false
 }
 
 // Reset clears Skyhook-related state and annotations so the node can be reconfigured from scratch.
@@ -559,8 +582,8 @@ func (node *skyhookNode) Reset() {
 	node.skyhook.Status.Status = v1alpha1.StatusUnknown
 	node.skyhook.Updated = true
 
-	delete(node.Annotations, fmt.Sprintf("%s/cordon_%s", v1alpha1.METADATA_PREFIX, node.skyhookName))
-	delete(node.Annotations, fmt.Sprintf("%s/drainStart_%s", v1alpha1.METADATA_PREFIX, node.skyhookName))
+	delete(node.Annotations, cordonAnnotationKey(node.skyhookName))
+	delete(node.Annotations, node.drainStartAnnotationKey())
 	delete(node.Annotations, fmt.Sprintf("%s/nodeState_%s", v1alpha1.METADATA_PREFIX, node.skyhookName))
 	delete(node.Annotations, fmt.Sprintf("%s/status_%s", v1alpha1.METADATA_PREFIX, node.skyhookName))
 	delete(node.Annotations, fmt.Sprintf("%s/version_%s", v1alpha1.METADATA_PREFIX, node.skyhookName))

--- a/operator/internal/wrapper/node_test.go
+++ b/operator/internal/wrapper/node_test.go
@@ -180,6 +180,123 @@ var _ = Describe("SkyhookNode", func() {
 		})
 	})
 
+	Context("Cordon", func() {
+		It("should initialize annotations if the node has none", func() {
+			myCordonKey := cordonAnnotationKey("my-skyhook")
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-node",
+				},
+			}
+
+			sn, err := NewSkyhookNodeOnly(node, "my-skyhook")
+			Expect(err).ToNot(HaveOccurred())
+
+			sn.Cordon()
+
+			Expect(node.Spec.Unschedulable).To(BeTrue())
+			Expect(node.Annotations).To(HaveKeyWithValue(myCordonKey, cordonAnnotationValue))
+			Expect(sn.Changed()).To(BeTrue())
+		})
+	})
+
+	Context("Uncordon", func() {
+		myCordonKey := cordonAnnotationKey("my-skyhook")
+		otherCordonKey := cordonAnnotationKey("other-skyhook")
+
+		It("should make the node schedulable if this Skyhook owns the only cordon", func() {
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-node",
+					Annotations: map[string]string{
+						myCordonKey: cordonAnnotationValue,
+					},
+				},
+				Spec: corev1.NodeSpec{Unschedulable: true},
+			}
+
+			sn, err := NewSkyhookNodeOnly(node, "my-skyhook")
+			Expect(err).ToNot(HaveOccurred())
+
+			sn.Uncordon()
+
+			Expect(node.Spec.Unschedulable).To(BeFalse())
+			Expect(node.Annotations).ToNot(HaveKey(myCordonKey))
+			Expect(sn.Changed()).To(BeTrue())
+		})
+
+		It("should keep the node unschedulable if another Skyhook still owns a cordon", func() {
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-node",
+					Annotations: map[string]string{
+						myCordonKey:    cordonAnnotationValue,
+						otherCordonKey: cordonAnnotationValue,
+					},
+				},
+				Spec: corev1.NodeSpec{Unschedulable: true},
+			}
+
+			sn, err := NewSkyhookNodeOnly(node, "my-skyhook")
+			Expect(err).ToNot(HaveOccurred())
+
+			sn.Uncordon()
+
+			Expect(node.Spec.Unschedulable).To(BeTrue())
+			Expect(node.Annotations).ToNot(HaveKey(myCordonKey))
+			Expect(node.Annotations).To(HaveKeyWithValue(otherCordonKey, cordonAnnotationValue))
+			Expect(sn.Changed()).To(BeTrue())
+		})
+
+		It("should make the node schedulable if only unrelated Skyhook annotations remain", func() {
+			otherStatusKey := "skyhook.nvidia.com/status_other-skyhook"
+			otherNodeStateKey := "skyhook.nvidia.com/nodeState_other-skyhook"
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-node",
+					Annotations: map[string]string{
+						myCordonKey:       cordonAnnotationValue,
+						otherStatusKey:    string(v1alpha1.StatusInProgress),
+						otherNodeStateKey: "{}",
+					},
+				},
+				Spec: corev1.NodeSpec{Unschedulable: true},
+			}
+
+			sn, err := NewSkyhookNodeOnly(node, "my-skyhook")
+			Expect(err).ToNot(HaveOccurred())
+
+			sn.Uncordon()
+
+			Expect(node.Spec.Unschedulable).To(BeFalse())
+			Expect(node.Annotations).ToNot(HaveKey(myCordonKey))
+			Expect(node.Annotations).To(HaveKeyWithValue(otherStatusKey, string(v1alpha1.StatusInProgress)))
+			Expect(node.Annotations).To(HaveKeyWithValue(otherNodeStateKey, "{}"))
+			Expect(sn.Changed()).To(BeTrue())
+		})
+
+		It("should not change the node if this Skyhook does not own a cordon", func() {
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-node",
+					Annotations: map[string]string{
+						otherCordonKey: cordonAnnotationValue,
+					},
+				},
+				Spec: corev1.NodeSpec{Unschedulable: true},
+			}
+
+			sn, err := NewSkyhookNodeOnly(node, "my-skyhook")
+			Expect(err).ToNot(HaveOccurred())
+
+			sn.Uncordon()
+
+			Expect(node.Spec.Unschedulable).To(BeTrue())
+			Expect(node.Annotations).To(HaveKeyWithValue(otherCordonKey, cordonAnnotationValue))
+			Expect(sn.Changed()).To(BeFalse())
+		})
+	})
+
 	Context("DrainStart", func() {
 		It("should record, read, and clear the drain start annotation", func() {
 			node := &corev1.Node{


### PR DESCRIPTION
## Summary
- Remove only the current Skyhook cordon annotation before deciding whether to clear `spec.unschedulable`.
- Keep a node unschedulable while any `skyhook.nvidia.com/cordon_*` annotation remains.
- Initialize node annotations before recording cordon state.
- Add wrapper tests for cordon initialization plus sole-owner, shared-owner, and non-owner uncordon cases.

## Why
Previously, one Skyhook completing could clear `spec.unschedulable` even though another Skyhook still had a cordon annotation on the same node. While touching that path, `Cordon()` also needed to tolerate nodes without annotations so recording cordon ownership cannot panic.

## Validation
- `go test ./internal/wrapper`
- `go test ./...`
