### PR TITLE
fix(chart): repair immutable Deployment selector on skyhook->nodewright upgrade

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -45,7 +45,7 @@ This cutover must complete before GA. Shipping v1 on the Python agent and swappi
 
 ### 3. Production Hardening
 
-**Replace unmaintained and unversioned dependencies.** Move operator metrics off kube-rbac-proxy to controller-runtime's built-in auth ([#206](https://github.com/NVIDIA/skyhook/issues/206)), which also resolves the TLS-handshake noise reports, and migrate the cleanup-job image off `bitnami/kubectl` to a maintained, versioned alternative ([#207](https://github.com/NVIDIA/skyhook/issues/207)).
+**Replace unmaintained and unversioned dependencies.** Move operator metrics off kube-rbac-proxy to controller-runtime's built-in auth ([#206](https://github.com/NVIDIA/skyhook/issues/206)), which also resolves the TLS-handshake noise reports.
 
 **Correctness under partial failure.** Stop the ConfigMap volume from clobbering files baked into the package image ([#208](https://github.com/NVIDIA/skyhook/issues/208)); fix the ConfigMap desync where a stale `Status.ConfigUpdates` entry drives a spurious interrupt ([#245](https://github.com/NVIDIA/skyhook/issues/245)); fix the taint-on-reboot case when `applyOnReboot`, `runtimeRequired`, and `autoTaintNewNodes` combine ([#180](https://github.com/NVIDIA/skyhook/issues/180)); and surface ImagePullBackOff / ErrImagePull as an explicit error state instead of a silent hang.
 

--- a/chart/RELEASE_NOTES.md
+++ b/chart/RELEASE_NOTES.md
@@ -1,0 +1,51 @@
+# Release Notes
+
+Human-authored highlights, behavior changes, and upgrade steps for the Helm chart.
+For the full commit-level log see CHANGELOG.md.
+
+## Unreleased
+
+### Bug Fixes
+
+- **Helm upgrade no longer fails on the immutable Deployment selector after the
+  skyhook -> nodewright rename.** A release first installed from a pre-rename
+  chart (chart name `skyhook-operator`) could not be upgraded, because the
+  rename changed `app.kubernetes.io/name` inside the controller-manager
+  Deployment's `spec.selector`, which Kubernetes forbids mutating
+  (`spec.selector: field is immutable`). The chart now sources the selector from
+  a single shared helper (`chart.managerSelectorLabels`) and ships a
+  `pre-upgrade` hook (`selectorMigration.enabled`, default `true`) that inspects
+  the live Deployment and deletes it only when its selector does not match the
+  desired one, so Helm can recreate it. The hook is a no-op (no downtime) on
+  normal upgrades and is scoped to the controller-manager Deployment via its own
+  narrowly-permissioned ServiceAccount (#285).
+
+### Other Changes
+
+- **Maintenance jobs moved off `bitnami/kubectl` to `alpine/kubectl`.** The
+  webhook and skyhook cleanup pre-delete hooks and the new selector-migration
+  pre-upgrade hook now use a maintained, versioned, multi-arch `alpine/kubectl`
+  image, pinned by tag and digest. The previous image's free versioned tags were
+  withdrawn on 2025-08-28, leaving only an unversioned `:latest` with no
+  security maintenance. If you had overridden `webhook.removalImage` to point at
+  a private mirror, remirror from the new source (#207).
+
+### Upgrade notes
+
+- No action is required: the selector-migration hook runs automatically on
+  `helm upgrade` and only recreates the Deployment when its selector is stale.
+  To perform the recreate manually instead, set `selectorMigration.enabled=false`
+  and, before upgrading, delete the Deployment so the upgrade recreates it:
+
+  ```bash
+  # Simplest: brief control-plane gap, but clean (the pod is removed too).
+  kubectl delete deployment <release>-controller-manager -n <namespace>
+  ```
+
+  For no control-plane gap, orphan the pod instead, then remove the leftover
+  old pod once the new one is Ready (two managers run briefly; leader election
+  keeps only one active):
+
+  ```bash
+  kubectl delete deployment <release>-controller-manager -n <namespace> --cascade=orphan
+  ```

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -52,6 +52,20 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
+Selector for the controller-manager Deployment.
+
+Shared by the Deployment's spec.selector and the selector-migration pre-upgrade
+hook so both reason about the identical label set. spec.selector is immutable,
+so when the chart name or release name changes these labels (e.g. the
+skyhook-operator -> nodewright rename), the hook deletes the stale Deployment
+and lets helm recreate it rather than failing the upgrade.
+*/}}
+{{- define "chart.managerSelectorLabels" -}}
+control-plane: controller-manager
+{{ include "chart.selectorLabels" . }}
+{{- end }}
+
+{{/*
 Create the name of the service account to use
 */}}
 {{- define "chart.serviceAccountName" -}}

--- a/chart/templates/cleanup-skyhooks-job.yaml
+++ b/chart/templates/cleanup-skyhooks-job.yaml
@@ -64,10 +64,17 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.namespace
                 path: namespace
+      # kubectl writes its discovery/http cache under KUBECACHEDIR; with a
+      # read-only root filesystem it needs a writable mount.
+      - name: kube-cache
+        emptyDir: {}
       containers:
       - name: cleanup
-        image: {{ .Values.webhook.removalImage | default "bitnami/kubectl" }}{{- if .Values.webhook.removalDigest }}{{- if .Values.webhook.removalTag }}:{{ .Values.webhook.removalTag | default "latest" }}@{{ .Values.webhook.removalDigest }}{{- else }}@{{ .Values.webhook.removalDigest }}{{- end }}{{- else }}:{{ .Values.webhook.removalTag | default "latest" }}{{- end }}
+        image: {{ .Values.webhook.removalImage | default "alpine/kubectl" }}{{- if .Values.webhook.removalDigest }}{{- if .Values.webhook.removalTag }}:{{ .Values.webhook.removalTag | default "latest" }}@{{ .Values.webhook.removalDigest }}{{- else }}@{{ .Values.webhook.removalDigest }}{{- end }}{{- else }}:{{ .Values.webhook.removalTag | default "latest" }}{{- end }}
         imagePullPolicy: Always
+        env:
+        - name: KUBECACHEDIR
+          value: /tmp/kubecache
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
@@ -80,6 +87,8 @@ spec:
         - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
           name: kube-api-access
           readOnly: true
+        - mountPath: /tmp/kubecache
+          name: kube-cache
         # Guard against limitRange being disabled (set to null/false) with fallback defaults
         resources:
         {{- if .Values.limitRange }}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -15,15 +15,22 @@ metadata:
 spec:
   replicas: {{ .Values.controllerManager.replicas }}
   selector:
+    # Deployment.spec.selector is immutable. These labels are sourced from the
+    # shared chart.managerSelectorLabels helper so the selector-migration
+    # pre-upgrade hook compares against the exact same set; if the chart name or
+    # release name ever changes the selector, that hook deletes the stale
+    # Deployment so `helm upgrade` can recreate it.
     matchLabels:
-      control-plane: controller-manager
-    {{- include "chart.selectorLabels" . | nindent 6 }}
+      {{- include "chart.managerSelectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
         app: {{ include "chart.fullname" . }}-controller-manager
-        control-plane: controller-manager
-      {{- include "chart.selectorLabels" . | nindent 8 }}
+      {{- /* Sourced from the same helper as spec.selector above so the pod
+             labels always stay a superset of the immutable selector; if they
+             were built separately they could drift and the Deployment would
+             stop matching its own pods. */}}
+      {{- include "chart.managerSelectorLabels" . | nindent 8 }}
       annotations:
         kubectl.kubernetes.io/default-container: manager
     spec:

--- a/chart/templates/selector-migration-job.yaml
+++ b/chart/templates/selector-migration-job.yaml
@@ -1,19 +1,32 @@
-{{- if .Values.webhook.enable }}
+{{- if .Values.selectorMigration.enabled }}
+{{/*
+Deployment.spec.selector is immutable. When an existing release was first
+installed from a chart whose name produced a different selector (e.g. the
+skyhook-operator -> nodewright rename changed app.kubernetes.io/name), helm
+upgrade fails because it cannot patch the selector. This pre-upgrade hook
+inspects the live Deployment and deletes it ONLY when its selector does not
+match the desired chart.managerSelectorLabels, so helm can recreate it. It is a
+no-op (no downtime) on normal upgrades. The hook gets its own ServiceAccount and
+Role (selector-migration-{serviceaccount,role,rolebinding}.yaml) because, during
+pre-upgrade, the release's manager RBAC has not been applied yet, so it cannot be
+relied upon here.
+*/}}
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "{{ include "chart.fullname" . }}-webhook-cleanup"
+  name: "{{ include "chart.fullname" . }}-selector-migration"
   namespace: "{{ .Release.Namespace }}"
   annotations:
-    "helm.sh/hook": pre-delete
+    "helm.sh/hook": pre-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "-5"
 spec:
-  activeDeadlineSeconds: {{ .Values.cleanup.jobTimeoutSeconds }}
+  activeDeadlineSeconds: {{ .Values.selectorMigration.jobTimeoutSeconds }}
   template:
     spec:
       restartPolicy: Never
       automountServiceAccountToken: false
-      serviceAccountName: {{ include "chart.fullname" . }}-controller-manager
+      serviceAccountName: "{{ include "chart.fullname" . }}-selector-migration"
       {{- with .Values.controllerManager.tolerations }}
       tolerations:
         {{- toYaml . | nindent 6 }}
@@ -64,11 +77,12 @@ spec:
                   fieldPath: metadata.namespace
                 path: namespace
       # kubectl writes its discovery/http cache under KUBECACHEDIR; with a
-      # read-only root filesystem it needs a writable mount.
+      # read-only root filesystem it needs a writable mount, else it re-discovers
+      # the API on every call.
       - name: kube-cache
         emptyDir: {}
       containers:
-      - name: cleanup
+      - name: selector-migration
         image: {{ .Values.webhook.removalImage | default "alpine/kubectl" }}{{- if .Values.webhook.removalDigest }}{{- if .Values.webhook.removalTag }}:{{ .Values.webhook.removalTag | default "latest" }}@{{ .Values.webhook.removalDigest }}{{- else }}@{{ .Values.webhook.removalDigest }}{{- end }}{{- else }}:{{ .Values.webhook.removalTag | default "latest" }}{{- end }}
         imagePullPolicy: Always
         env:
@@ -109,10 +123,36 @@ spec:
         - /bin/sh
         - -c
         - |
-          NAMESPACE="{{ .Release.Namespace }}"
-          VALIDATING_WEBHOOK_CONFIGURATION_NAME="skyhook-operator-validating-webhook"
-          MUTATING_WEBHOOK_CONFIGURATION_NAME="skyhook-operator-mutating-webhook"
-          kubectl delete secret -n $NAMESPACE "{{ .Values.webhook.secretName | default "webhook-cert" }}" || true
-          kubectl delete validatingwebhookconfiguration $VALIDATING_WEBHOOK_CONFIGURATION_NAME || true
-          kubectl delete mutatingwebhookconfiguration $MUTATING_WEBHOOK_CONFIGURATION_NAME || true
-{{- end }} 
+          NS="{{ .Release.Namespace }}"
+          DEPLOY="{{ include "chart.fullname" . }}-controller-manager"
+
+          if ! kubectl get deployment "$DEPLOY" -n "$NS" >/dev/null 2>&1; then
+            echo "Deployment $DEPLOY not found; nothing to migrate"
+            exit 0
+          fi
+
+          echo "live selector: $(kubectl get deployment "$DEPLOY" -n "$NS" -o jsonpath='{.spec.selector.matchLabels}')"
+
+          mismatch=0
+          {{/* Compares each DESIRED label value against the live selector. This
+               catches a changed value (the skyhook-operator -> nodewright rename)
+               or a missing label, which covers every selector change in this
+               chart's history (the key set has always been control-plane + name
+               + instance). It does NOT detect a live selector with EXTRA keys
+               beyond the desired set; if a future change ever narrows the
+               selector, that case needs its own handling here. */}}
+          {{- range $k, $v := (include "chart.managerSelectorLabels" . | fromYaml) }}
+          live="$(kubectl get deployment "$DEPLOY" -n "$NS" -o jsonpath='{.spec.selector.matchLabels.{{ $k | replace "." "\\." }}}' 2>/dev/null || true)"
+          if [ "$live" != "{{ $v }}" ]; then
+            echo "selector label {{ $k }} differs: live='$live' want='{{ $v }}'"
+            mismatch=1
+          fi
+          {{- end }}
+
+          if [ "$mismatch" -eq 1 ]; then
+            echo "Deployment selector does not match desired; deleting so helm upgrade can recreate it"
+            kubectl delete deployment "$DEPLOY" -n "$NS" --ignore-not-found
+          else
+            echo "Deployment selector already matches desired; nothing to do"
+          fi
+{{- end }}

--- a/chart/templates/selector-migration-role.yaml
+++ b/chart/templates/selector-migration-role.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.selectorMigration.enabled }}
+{{/* Least-privilege RBAC for the selector-migration pre-upgrade hook: it only
+     needs to read and delete the one controller-manager Deployment by name, so
+     get/delete are scoped via resourceNames and list is not granted. */}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: "{{ include "chart.fullname" . }}-selector-migration"
+  namespace: "{{ .Release.Namespace }}"
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "-10"
+rules:
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  resourceNames:
+  - "{{ include "chart.fullname" . }}-controller-manager"
+  verbs:
+  - get
+  - delete
+{{- end }}

--- a/chart/templates/selector-migration-rolebinding.yaml
+++ b/chart/templates/selector-migration-rolebinding.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.selectorMigration.enabled }}
+{{/* Binds the selector-migration hook ServiceAccount to its Role.
+     See selector-migration-job.yaml for the hook rationale. */}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: "{{ include "chart.fullname" . }}-selector-migration"
+  namespace: "{{ .Release.Namespace }}"
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "-10"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: "{{ include "chart.fullname" . }}-selector-migration"
+subjects:
+- kind: ServiceAccount
+  name: "{{ include "chart.fullname" . }}-selector-migration"
+  namespace: "{{ .Release.Namespace }}"
+{{- end }}

--- a/chart/templates/selector-migration-serviceaccount.yaml
+++ b/chart/templates/selector-migration-serviceaccount.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.selectorMigration.enabled }}
+{{/* Dedicated ServiceAccount for the selector-migration pre-upgrade hook.
+     See selector-migration-job.yaml for why the hook exists and why it needs
+     its own RBAC rather than the controller-manager's. */}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: "{{ include "chart.fullname" . }}-selector-migration"
+  namespace: "{{ .Release.Namespace }}"
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "-10"
+{{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -156,10 +156,13 @@ webhook:
   ## Default is "true" and is required for production.
   enable: true
 
-  ## uninstall image for cleaning up webhook resources
-  removalImage: bitnami/kubectl
-  removalTag: latest
-  removalDigest: "sha256:1bc359beb3ae3982591349df11db50b0917b0596e8bed8ab9cf0c8a84a3502d1"
+  ## kubectl image used by the maintenance jobs (webhook + skyhook cleanup
+  ## pre-delete hooks and the selector-migration pre-upgrade hook). Pinned to a
+  ## maintained, versioned, multi-arch alpine/kubectl release; keep the tag in
+  ## skew with the supported Kubernetes range and bump per docs/release-process.md.
+  removalImage: alpine/kubectl
+  removalTag: 1.36.2
+  removalDigest: "sha256:01d138ce994b684abc62d9cfdff44de42a4c8996dcc12626dd0193afc3fb5a95"
 
 ## cleanup: Configuration for pre-delete cleanup jobs
 cleanup:
@@ -168,6 +171,18 @@ cleanup:
   enabled: true
   ## jobTimeoutSeconds: Hard deadline for the entire cleanup job.
   ## The job will be killed if it exceeds this time.
+  jobTimeoutSeconds: 120
+
+## selectorMigration: pre-upgrade hook that repairs an immutable Deployment
+## selector left over from an older chart (e.g. the skyhook-operator ->
+## nodewright rename). It deletes the controller-manager Deployment ONLY when
+## its live selector does not match the chart's desired selector, so helm can
+## recreate it. It is a no-op on normal upgrades.
+selectorMigration:
+  ## enabled: When true, run the selector-migration pre-upgrade hook. Safe to
+  ## leave on; disable if your GitOps tooling manages the Deployment directly.
+  enabled: true
+  ## jobTimeoutSeconds: Hard deadline for the migration job.
   jobTimeoutSeconds: 120
 
 metrics:

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -278,36 +278,31 @@ Starting with digest pinning, the chart references images using tag@digest (or d
 
 Prerequisites:
 
-- Docker buildx (`docker-buildx version`)
+- skopeo (`skopeo --version`)
+- jq (`jq --version`)
 
-Fetch a multi-arch digest (example for bitnami/kubectl used by the webhook cleanup job):
+Fetch the multi-arch (manifest list) digest (example for alpine/kubectl, used by the cleanup pre-delete jobs and the selector-migration pre-upgrade hook). The digest to pin is the sha256 of the raw manifest list:
 
 ```bash
-docker-buildx imagetools inspect bitnami/kubectl:1.33.1
+skopeo inspect --raw docker://docker.io/alpine/kubectl:1.36.2 | skopeo manifest-digest /dev/stdin
+# sha256:01d138ce994b684abc62d9cfdff44de42a4c8996dcc12626dd0193afc3fb5a95
+# pin that value (including the sha256: prefix) in chart/values.yaml
 ```
 
-Example output (look for the top-level Digest):
+Confirm it is a manifest list covering the platforms we ship (at least amd64 + arm64):
 
-```
-Name:      docker.io/bitnami/kubectl:1.33.1
-MediaType: application/vnd.docker.distribution.manifest.list.v2+json
-Digest:    sha256:9081a6f83f4febf47369fc46b6f0f7683c7db243df5b43fc9defe51b0471a950
-
-Manifests:
-  Name:      docker.io/bitnami/kubectl:1.33.1@sha256:c8efec87588c7a2d84c760d54446b2e081e607a709f16f19283774d5612191b7
-  MediaType: application/vnd.docker.distribution.manifest.v2+json
-  Platform:  linux/amd64
-
-  Name:      docker.io/bitnami/kubectl:1.33.1@sha256:2af8ed9feaeada845f4d60f1fe4db951df2e5334ea01bec4b5ef4f191ad20d65
-  MediaType: application/vnd.docker.distribution.manifest.v2+json
-  Platform:  linux/arm64
+```bash
+skopeo inspect --raw docker://docker.io/alpine/kubectl:1.36.2 \
+  | jq -r '.manifests[].platform | "\(.os)/\(.architecture)"'
 ```
 
-Update the digest in `chart/values.yaml` for kube-rbac-proxy, operator, and agent images:
+`alpine/kubectl` is a maintained, versioned, multi-arch image. These short-lived maintenance jobs only run `kubectl get`/`delete` on stable core/apps resources, where kubectl's version skew is a cosmetic warning rather than a functional break, so the tag tracks a recent maintained release for current base-image fixes. Bump it as the image is maintained.
+
+Update the digest in `chart/values.yaml` for the kube-rbac-proxy, operator, agent, and maintenance-job kubectl (`webhook.removalImage`/`removalTag`/`removalDigest`) images:
 
 Note:
 
-- Always use the multi-arch manifest digest (top-level Digest from imagetools), not a single-arch child manifest digest.
+- Always pin the manifest-list digest (`skopeo inspect --raw` returns the list itself, so `manifest-digest` of that output is the list digest), not a single-arch child manifest digest.
 
 **After tagging:**
 

--- a/k8s-tests/chainsaw/helm/helm-template-test/chainsaw-test.yaml
+++ b/k8s-tests/chainsaw/helm/helm-template-test/chainsaw-test.yaml
@@ -116,6 +116,252 @@ spec:
                       memory: 256Mi
           EXPECTED
 
+  - name: deployment-selector-pinned-labels
+    try:
+    - script:
+        env:
+        - name: CHART
+          value: ($CHART)
+        - name: CHAINSAW_BIN
+          value: ($CHAINSAW_BIN)
+        content: |
+          ## The controller-manager Deployment selector must carry the full,
+          ## specific managerSelectorLabels set (not a single vague label), so
+          ## it stays stable and the selector-migration hook can match it.
+          helm template test-release ${CHART} -n skyhook \
+            -s templates/deployment.yaml > /tmp/rendered.yaml
+          cat <<'EXPECTED' | ${CHAINSAW_BIN} assert \
+            --resource /tmp/rendered.yaml --file - --no-color --timeout 5s
+          apiVersion: apps/v1
+          kind: Deployment
+          spec:
+            selector:
+              matchLabels:
+                control-plane: controller-manager
+                app.kubernetes.io/name: nodewright
+                app.kubernetes.io/instance: test-release
+          EXPECTED
+
+  - name: override-keeps-name-and-aligns-hook
+    try:
+    - script:
+        env:
+        - name: CHART
+          value: ($CHART)
+        - name: CHAINSAW_BIN
+          value: ($CHAINSAW_BIN)
+        content: |
+          ## The bug only triggers when fullnameOverride preserves the
+          ## controller-manager Deployment NAME across the rename while the
+          ## selector (from chart name) is what changes. Under an override, the
+          ## immutable selector still renders the current chart identity
+          ## (name=nodewright), not the overridden name. (Asserted by kind, since
+          ## deployment.yaml also renders the PDB; the preserved Deployment name
+          ## is covered by the Role/hook assertions below.)
+          helm template skyhook-operator ${CHART} -n skyhook \
+            --set fullnameOverride=skyhook-operator \
+            -s templates/deployment.yaml > /tmp/rendered.yaml
+          cat <<'EXPECTED' | ${CHAINSAW_BIN} assert \
+            --resource /tmp/rendered.yaml --file - --no-color --timeout 5s
+          apiVersion: apps/v1
+          kind: Deployment
+          spec:
+            selector:
+              matchLabels:
+                control-plane: controller-manager
+                app.kubernetes.io/name: nodewright
+                app.kubernetes.io/instance: skyhook-operator
+          EXPECTED
+    - script:
+        env:
+        - name: CHART
+          value: ($CHART)
+        - name: CHAINSAW_BIN
+          value: ($CHAINSAW_BIN)
+        content: |
+          ## The hook's RBAC must follow the overridden name so it can delete the
+          ## right Deployment.
+          helm template skyhook-operator ${CHART} -n skyhook \
+            --set fullnameOverride=skyhook-operator \
+            -s templates/selector-migration-role.yaml > /tmp/rendered.yaml
+          cat <<'EXPECTED' | ${CHAINSAW_BIN} assert \
+            --resource /tmp/rendered.yaml --file - --no-color --timeout 5s
+          apiVersion: rbac.authorization.k8s.io/v1
+          kind: Role
+          metadata:
+            name: skyhook-operator-selector-migration
+          rules:
+          - resourceNames:
+            - skyhook-operator-controller-manager
+          EXPECTED
+    - script:
+        env:
+        - name: CHART
+          value: ($CHART)
+        content: |
+          ## The hook command targets the overridden Deployment name.
+          helm template skyhook-operator ${CHART} -n skyhook \
+            --set fullnameOverride=skyhook-operator \
+            -s templates/selector-migration-job.yaml
+        check:
+          "(contains($stdout, 'DEPLOY=\"skyhook-operator-controller-manager\"'))": true
+
+  - name: selector-migration-job-renders
+    try:
+    - script:
+        env:
+        - name: CHART
+          value: ($CHART)
+        - name: CHAINSAW_BIN
+          value: ($CHAINSAW_BIN)
+        content: |
+          ## The pre-upgrade hook Job is wired as a pre-upgrade hook, runs under
+          ## its dedicated ServiceAccount, and has a single migration container.
+          helm template test-release ${CHART} -n skyhook \
+            -s templates/selector-migration-job.yaml > /tmp/rendered.yaml
+          cat <<'EXPECTED' | ${CHAINSAW_BIN} assert \
+            --resource /tmp/rendered.yaml --file - --no-color --timeout 5s
+          apiVersion: batch/v1
+          kind: Job
+          metadata:
+            name: nodewright-selector-migration
+            annotations:
+              helm.sh/hook: pre-upgrade
+              helm.sh/hook-weight: "-5"
+          spec:
+            template:
+              spec:
+                restartPolicy: Never
+                serviceAccountName: nodewright-selector-migration
+                containers:
+                - name: selector-migration
+                  ## writable kubectl cache, required under readOnlyRootFilesystem
+                  env:
+                  - name: KUBECACHEDIR
+                    value: /tmp/kubecache
+          EXPECTED
+    - script:
+        env:
+        - name: CHART
+          value: ($CHART)
+        content: |
+          ## Image is the maintained kubectl image, not bitnami. (Checked as a
+          ## substring because the value carries a pinned, version-specific digest.)
+          ## Also assert the hook compares the FULL managerSelectorLabels set, not
+          ## just control-plane: a regression to a single label would reintroduce
+          ## the upgrade failure for rename/fullnameOverride installs.
+          helm template test-release ${CHART} -n skyhook \
+            -s templates/selector-migration-job.yaml
+        check:
+          "(contains($stdout, 'image: alpine/kubectl'))": true
+          ## must stay digest-pinned, not a floating tag
+          "(contains($stdout, '@sha256:'))": true
+          "(contains($stdout, 'bitnami'))": false
+          ## the migration must reason over all three desired selector labels
+          "(contains($stdout, 'selector label control-plane differs'))": true
+          "(contains($stdout, 'selector label app.kubernetes.io/name differs'))": true
+          "(contains($stdout, 'selector label app.kubernetes.io/instance differs'))": true
+          ## writable kubectl cache volume + mount (env asserted structurally above)
+          "(contains($stdout, 'name: kube-cache'))": true
+          "(contains($stdout, 'mountPath: /tmp/kubecache'))": true
+
+  - name: selector-migration-serviceaccount-renders
+    try:
+    - script:
+        env:
+        - name: CHART
+          value: ($CHART)
+        - name: CHAINSAW_BIN
+          value: ($CHAINSAW_BIN)
+        content: |
+          helm template test-release ${CHART} -n skyhook \
+            -s templates/selector-migration-serviceaccount.yaml > /tmp/rendered.yaml
+          cat <<'EXPECTED' | ${CHAINSAW_BIN} assert \
+            --resource /tmp/rendered.yaml --file - --no-color --timeout 5s
+          apiVersion: v1
+          kind: ServiceAccount
+          metadata:
+            name: nodewright-selector-migration
+            annotations:
+              helm.sh/hook: pre-upgrade
+              helm.sh/hook-weight: "-10"
+          EXPECTED
+
+  - name: selector-migration-role-renders
+    try:
+    - script:
+        env:
+        - name: CHART
+          value: ($CHART)
+        - name: CHAINSAW_BIN
+          value: ($CHAINSAW_BIN)
+        content: |
+          ## Least-privilege: get/delete on the controller-manager deployment only.
+          helm template test-release ${CHART} -n skyhook \
+            -s templates/selector-migration-role.yaml > /tmp/rendered.yaml
+          cat <<'EXPECTED' | ${CHAINSAW_BIN} assert \
+            --resource /tmp/rendered.yaml --file - --no-color --timeout 5s
+          apiVersion: rbac.authorization.k8s.io/v1
+          kind: Role
+          metadata:
+            name: nodewright-selector-migration
+          rules:
+          - apiGroups:
+            - apps
+            resources:
+            - deployments
+            resourceNames:
+            - nodewright-controller-manager
+            verbs:
+            - get
+            - delete
+          EXPECTED
+
+  - name: selector-migration-rolebinding-renders
+    try:
+    - script:
+        env:
+        - name: CHART
+          value: ($CHART)
+        - name: CHAINSAW_BIN
+          value: ($CHAINSAW_BIN)
+        content: |
+          helm template test-release ${CHART} -n skyhook \
+            -s templates/selector-migration-rolebinding.yaml > /tmp/rendered.yaml
+          cat <<'EXPECTED' | ${CHAINSAW_BIN} assert \
+            --resource /tmp/rendered.yaml --file - --no-color --timeout 5s
+          apiVersion: rbac.authorization.k8s.io/v1
+          kind: RoleBinding
+          metadata:
+            name: nodewright-selector-migration
+          roleRef:
+            apiGroup: rbac.authorization.k8s.io
+            kind: Role
+            name: nodewright-selector-migration
+          subjects:
+          - kind: ServiceAccount
+            name: nodewright-selector-migration
+          EXPECTED
+
+  - name: selector-migration-disabled-no-hook
+    try:
+    - script:
+        env:
+        - name: CHART
+          value: ($CHART)
+        content: |
+          ## With the hook disabled, none of the selector-migration templates
+          ## should render (-s exits non-zero when a gated template is empty).
+          for f in serviceaccount role rolebinding job; do
+            if helm template test-release ${CHART} -n skyhook \
+                 --set 'selectorMigration.enabled=false' \
+                 -s templates/selector-migration-$f.yaml 2>/dev/null; then
+              echo "ERROR: selector-migration-$f.yaml rendered while disabled"
+              exit 1
+            fi
+          done
+          echo "all selector-migration templates omitted when disabled"
+
   - name: limitrange-disabled-null-fallback-resources
     try:
     - script:


### PR DESCRIPTION
## What

Fixes the `helm upgrade` failure where Kubernetes rejects an immutable
`spec.selector` change introduced by the skyhook-operator -> nodewright chart
rename, and migrates the maintenance-job image off the now-paywalled
`bitnami/kubectl`.

Fixes #285. Closes #207. (Reported downstream in NVIDIA/aicr#1382.)

## Why it fails (and when)

`chart/templates/deployment.yaml` sourced the controller-manager selector's
`app.kubernetes.io/name` from the **chart name**, which changed at v0.16.0
(`skyhook-operator` -> `nodewright`). `Deployment.spec.selector` is immutable.

The failure only triggers when the controller-manager **Deployment name is
preserved** across the rename, forcing Helm to patch in place. That happens when
a release pins the name via `fullnameOverride`/`nameOverride` (e.g. AICR sets
`fullnameOverride: skyhook-operator`). Without a pinned name, Helm renders a
differently named Deployment and simply create+deletes it, so the upgrade
succeeds (silently replacing the operator) rather than erroring.

## Changes

- **Shared selector helper.** New `chart.managerSelectorLabels` in `_helpers.tpl`,
  used by both the Deployment selector and the migration hook so they reason
  about the identical label set. This does **not** change the selector's rendered
  value; it keeps the chart's existing three-label selector.
- **Smart pre-upgrade hook.** New `selector-migration-{job,serviceaccount,role,
  rolebinding}.yaml` (gated by `selectorMigration.enabled`, default `true`). The
  Job reads the live Deployment selector and deletes it **only when it does not
  match** the desired selector (per-label `jsonpath` compare), letting Helm
  recreate it. It is a no-op (no downtime) on normal upgrades. It runs under its
  own least-privilege ServiceAccount/Role (get/list/delete on deployments),
  because during `pre-upgrade` the release's manager RBAC is not applied yet.
- **Image migration (#207).** `webhook.removalImage/Tag/Digest` and the three
  maintenance Jobs move from `bitnami/kubectl` to
  `alpine/kubectl:1.36.2` pinned by multi-arch digest.
- **Tests.** `helm-template-test` gains structural chainsaw asserts for the
  selector pin and each hook resource (single-doc templates so `assert` can match
  by kind), plus a disabled-gate check.
- **Docs.** New `chart/RELEASE_NOTES.md` (upgrade notes), updated
  `docs/release-process.md` image example, and `ROADMAP.md`.

## New pattern (flagged per CONTRIBUTING)

This introduces the chart's first **`pre-upgrade`** hook with its own dedicated
hook RBAC (the existing hooks are `pre-delete` and reuse the controller-manager
SA). A dedicated SA is required because the new manager RBAC is not yet applied
during `pre-upgrade`, and the manager SA lacks deployment-delete permission. The
hook is modeled on the existing `cleanup-*-job.yaml` hooks otherwise.

## chart/ vs operator/config

This pins the chart's existing three-label selector; it does **not** re-align to
`operator/config/manager/manager.yaml`, which intentionally stays narrower
(`control-plane` only). No kustomize mirror is needed (this is a Helm-only
install-time concern). Other selector-bearing resources were audited: the PDB
keys on `chart.fullname` (moves with its own name, not affected); Service /
NetworkPolicy selectors are mutable; CRD `matchLabels` are schema fields. The
Deployment selector was the only immutable-field instance.

## Testing

- **Live e2e on kind** (published `skyhook-public/skyhook-operator` v0.15.1 ->
  this chart, with `fullnameOverride: skyhook-operator`):
  - control (hook disabled) reproduces `spec.selector ... field is immutable`
  - hook enabled: upgrade succeeds, selector flips to `nodewright`, Deployment
    recreated
  - second upgrade: Deployment UID unchanged -> genuine no-op, no downtime
- **helm-template-test**: passes (selector pin + all four hook resources asserted
  + disabled gate)
- `helm lint`: clean
