### PR TITLE
feat(agent): embedded json schema and step validation for agent go re…

### DIFF
--- a/agent/go/cmd/agent/main.go
+++ b/agent/go/cmd/agent/main.go
@@ -19,8 +19,16 @@ package main
 
 import (
 	"fmt"
+	"log/slog"
+	"os"
 )
 
 func main() {
+	// Establish the agent's structured-logging seam. Packages (e.g.
+	// config.Loader.Load) log through *slog.Logger and fall back to
+	// slog.Default() when passed nil, so wiring it here once keeps that
+	// default sane for the whole process.
+	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, nil)))
+
 	fmt.Println("Hello, World!")
 }

--- a/agent/go/go.mod
+++ b/agent/go/go.mod
@@ -5,6 +5,7 @@ go 1.26.4
 require (
 	github.com/onsi/ginkgo/v2 v2.28.1
 	github.com/onsi/gomega v1.39.0
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 )
 
 require (

--- a/agent/go/go.sum
+++ b/agent/go/go.sum
@@ -2,6 +2,8 @@ github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
+github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/gkampitakis/ciinfo v0.3.2 h1:JcuOPk8ZU7nZQjdUhctuhQofk7BGHuIy0c9Ez8BNhXs=
 github.com/gkampitakis/ciinfo v0.3.2/go.mod h1:1NIwaOcFChN4fa/B0hEBdAb6npDlFL8Bwx4dfRLRqAo=
 github.com/gkampitakis/go-diff v1.3.2 h1:Qyn0J9XJSDTgnsgHRdz9Zp24RaJeKMUHg2+PDZZdC4M=
@@ -36,6 +38,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=
 github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/tidwall/gjson v1.18.0 h1:FIDeeyB800efLX89e5a8Y0BNH+LOngJyGrIWxG2FKQY=

--- a/agent/go/internal/config/config.go
+++ b/agent/go/internal/config/config.go
@@ -1,0 +1,225 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+
+	"github.com/NVIDIA/nodewright/agent/internal/schema"
+	"github.com/NVIDIA/nodewright/agent/internal/stage"
+	"github.com/NVIDIA/nodewright/agent/internal/step"
+)
+
+// Config is a parsed, validated skyhook package configuration.
+type Config struct {
+	SchemaVersion       schema.SchemaVersion
+	RootDir             string
+	ExpectedConfigFiles []string
+	PackageName         string
+	PackageVersion      string
+	Modes               map[stage.Stage][]step.Step
+}
+
+// configJSON is the wire form of a Config and the only thing that touches the
+// JSON tags. It exists because Config.Modes holds the step.Step interface,
+// which stdlib json can neither unmarshal into nor re-encode with each step's
+// own discriminator logic; (un)marshaling routes the modes through here and
+// step.Decode / step.Encode. Field order is the canonical serialization order.
+type configJSON struct {
+	SchemaVersion       string                       `json:"schema_version"`
+	RootDir             string                       `json:"root_dir"`
+	ExpectedConfigFiles []string                     `json:"expected_config_files"`
+	PackageName         string                       `json:"package_name"`
+	PackageVersion      string                       `json:"package_version"`
+	Modes               map[string][]json.RawMessage `json:"modes"`
+}
+
+// MarshalJSON encodes the config, deferring per-step encoding to step.Encode so
+// the step wire form (and its upgrade_step discriminator) stays owned by the
+// step type. expected_config_files is coerced to [] so it never serializes as
+// null, which the schema's array type would reject.
+func (c Config) MarshalJSON() ([]byte, error) {
+	modes := make(map[string][]json.RawMessage, len(c.Modes))
+	for st, steps := range c.Modes {
+		encoded := make([]json.RawMessage, 0, len(steps))
+		for i, s := range steps {
+			b, err := s.Encode()
+			if err != nil {
+				return nil, fmt.Errorf("encoding step %d in stage %q: %w", i, st, err)
+			}
+			encoded = append(encoded, b)
+		}
+		modes[string(st)] = encoded
+	}
+
+	expected := c.ExpectedConfigFiles
+	if expected == nil {
+		expected = []string{}
+	}
+
+	return json.Marshal(configJSON{
+		SchemaVersion:       string(c.SchemaVersion),
+		RootDir:             c.RootDir,
+		ExpectedConfigFiles: expected,
+		PackageName:         c.PackageName,
+		PackageVersion:      c.PackageVersion,
+		Modes:               modes,
+	})
+}
+
+// UnmarshalJSON decodes the wire form, mapping each mode key to a stage.Stage
+// (rejecting unknown stages) and decoding each step via step.Decode.
+func (c *Config) UnmarshalJSON(data []byte) error {
+	var w configJSON
+	if err := json.Unmarshal(data, &w); err != nil {
+		return err
+	}
+
+	modes := make(map[stage.Stage][]step.Step, len(w.Modes))
+	for rawStage, rawSteps := range w.Modes {
+		st, err := stage.ParseStage(rawStage)
+		if err != nil {
+			return fmt.Errorf("config modes: %w", err)
+		}
+		steps := make([]step.Step, 0, len(rawSteps))
+		for i, raw := range rawSteps {
+			s, err := step.Decode(raw)
+			if err != nil {
+				return fmt.Errorf("decoding step %d in stage %q: %w", i, st, err)
+			}
+			steps = append(steps, s)
+		}
+		modes[st] = steps
+	}
+
+	*c = Config{
+		SchemaVersion:       schema.SchemaVersion(w.SchemaVersion),
+		RootDir:             w.RootDir,
+		ExpectedConfigFiles: w.ExpectedConfigFiles,
+		PackageName:         w.PackageName,
+		PackageVersion:      w.PackageVersion,
+		Modes:               modes,
+	}
+	return nil
+}
+
+// Loader loads and dumps package configs. It holds the SchemaValidator the
+// document is checked against, so callers (and tests) can substitute the
+// validation backend without reaching through package state.
+type Loader struct {
+	validator SchemaValidator
+}
+
+// NewLoader returns a Loader that validates against the embedded JSON Schemas.
+func NewLoader() *Loader {
+	return &Loader{validator: newSchemaValidator()}
+}
+
+// Load parses and validates a package config: it reads the declared schema
+// version, validates the document against that schema (which also rejects
+// unrecognised versions), materializes the typed Config, then runs the
+// cross-step document rules. Warnings are emitted via logger (nil uses
+// slog.Default()).
+//
+// stepRootDir is the on-disk directory the step files must exist under; it is
+// intentionally distinct from Config.RootDir (the package-relative root
+// recorded in the config) and the two need not match.
+func (l *Loader) Load(data []byte, stepRootDir string, logger *slog.Logger) (*Config, error) {
+	version, err := schemaVersionOf(data)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := l.validator.Validate(data, version); err != nil {
+		return nil, err
+	}
+
+	var cfg Config
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("parsing config json: %w", err)
+	}
+	cfg.SchemaVersion = version
+
+	if err := validateModes(cfg.Modes, stepRootDir, logger); err != nil {
+		return nil, fmt.Errorf("validating steps: %w", err)
+	}
+
+	return &cfg, nil
+}
+
+// Dump serializes a package config at the latest schema version. Output is
+// deterministic (struct field order + stdlib-sorted map keys) and is validated
+// before returning so Dump never emits a document Load would reject for shape
+// or schema reasons. It does not check step files on disk — that is Load's job
+// against a real stepRootDir.
+func (l *Loader) Dump(packageName, packageVersion, rootDir string, modes map[stage.Stage][]step.Step, expectedConfigFiles []string) ([]byte, error) {
+	latest, err := schema.Highest()
+	if err != nil {
+		return nil, fmt.Errorf("resolving latest schema version: %w", err)
+	}
+
+	for st := range modes {
+		if _, err := stage.ParseStage(string(st)); err != nil {
+			return nil, fmt.Errorf("dumping config: %w", err)
+		}
+	}
+
+	// Run the same structural cross-step rules Load enforces so a dumped
+	// config can't serialize cleanly yet fail on reload. The on-disk step-file
+	// check is intentionally excluded — Dump records a package-relative root,
+	// not a path it can stat.
+	if err := checkModeRules(modes); err != nil {
+		return nil, fmt.Errorf("dumping config: %w", err)
+	}
+
+	data, err := json.Marshal(Config{
+		SchemaVersion:       latest,
+		RootDir:             rootDir,
+		ExpectedConfigFiles: expectedConfigFiles,
+		PackageName:         packageName,
+		PackageVersion:      packageVersion,
+		Modes:               modes,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshaling config: %w", err)
+	}
+
+	if err := l.validator.Validate(data, latest); err != nil {
+		return nil, fmt.Errorf("dump produced invalid config: %w", err)
+	}
+	return data, nil
+}
+
+// schemaVersionOf extracts the declared schema_version without validating the
+// rest of the document, so the loader can pick the right schema before
+// validating against it.
+func schemaVersionOf(data []byte) (schema.SchemaVersion, error) {
+	var head struct {
+		SchemaVersion string `json:"schema_version"`
+	}
+	if err := json.Unmarshal(data, &head); err != nil {
+		return "", fmt.Errorf("parsing config json: %w", err)
+	}
+	if head.SchemaVersion == "" {
+		return "", fmt.Errorf("config is missing required field schema_version")
+	}
+	return schema.SchemaVersion(head.SchemaVersion), nil
+}

--- a/agent/go/internal/config/config_test.go
+++ b/agent/go/internal/config/config_test.go
@@ -1,0 +1,205 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package config
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/NVIDIA/nodewright/agent/internal/schema"
+	"github.com/NVIDIA/nodewright/agent/internal/stage"
+	"github.com/NVIDIA/nodewright/agent/internal/step"
+)
+
+func TestConfig(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Config Suite")
+}
+
+const validConfigJSON = `{
+  "schema_version": "v1",
+  "root_dir": "/",
+  "expected_config_files": [],
+  "package_name": "test-package",
+  "package_version": "1.0.0",
+  "modes": {
+    "apply": [
+      {"name": "apply", "path": "apply.sh", "arguments": [], "returncodes": [0], "on_host": true, "idempotence": false, "upgrade_step": false}
+    ],
+    "apply-check": [
+      {"name": "apply-check", "path": "apply_check.sh", "arguments": [], "returncodes": [0], "on_host": true, "idempotence": false, "upgrade_step": false}
+    ]
+  }
+}`
+
+func writeStepFiles(dir string, names ...string) {
+	for _, n := range names {
+		Expect(os.WriteFile(filepath.Join(dir, n), []byte("#!/bin/sh\n"), 0o755)).To(Succeed())
+	}
+}
+
+var _ = Describe("schema compilation", func() {
+	It("compiles the embedded v1 schema", func() {
+		_, err := compileSchema(schema.V1)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("reports an unknown version", func() {
+		_, err := compileSchema(schema.SchemaVersion("v99"))
+		Expect(err).To(MatchError(ContainSubstring("unknown schema version")))
+	})
+})
+
+var _ = Describe("Load", func() {
+	var (
+		tmp    string
+		logger *slog.Logger
+		loader *Loader
+	)
+
+	BeforeEach(func() {
+		tmp = GinkgoT().TempDir()
+		logger = slog.New(slog.NewTextHandler(GinkgoWriter, nil))
+		loader = NewLoader()
+	})
+
+	It("loads a valid config", func() {
+		writeStepFiles(tmp, "apply.sh", "apply_check.sh")
+		cfg, err := loader.Load([]byte(validConfigJSON), tmp, logger)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(cfg.SchemaVersion).To(Equal(schema.V1))
+		Expect(cfg.PackageName).To(Equal("test-package"))
+		Expect(cfg.PackageVersion).To(Equal("1.0.0"))
+		Expect(cfg.Modes).To(HaveKey(stage.Apply))
+		Expect(cfg.Modes).To(HaveKey(stage.ApplyCheck))
+		Expect(cfg.Modes[stage.Apply]).To(HaveLen(1))
+	})
+
+	It("rejects a config missing a required field", func() {
+		data := `{"schema_version": "v1", "root_dir": "/", "expected_config_files": [], "package_version": "1.0.0", "modes": {}}`
+		_, err := loader.Load([]byte(data), tmp, logger)
+		Expect(err).To(MatchError(ContainSubstring("schema validation")))
+	})
+
+	It("rejects a step missing required on_host", func() {
+		data := `{
+  "schema_version": "v1", "root_dir": "/", "expected_config_files": [],
+  "package_name": "p", "package_version": "1.0.0",
+  "modes": {"apply": [{"name": "apply", "path": "apply.sh", "arguments": [], "returncodes": [0], "idempotence": false, "upgrade_step": false}]}
+}`
+		_, err := loader.Load([]byte(data), tmp, logger)
+		Expect(err).To(MatchError(ContainSubstring("schema validation")))
+	})
+
+	It("rejects an unknown schema version", func() {
+		data := `{"schema_version": "v99", "root_dir": "/", "expected_config_files": [], "package_name": "p", "package_version": "1.0.0", "modes": {}}`
+		_, err := loader.Load([]byte(data), tmp, logger)
+		Expect(err).To(MatchError(ContainSubstring("unknown schema version")))
+	})
+
+	It("rejects a non-semver package_version", func() {
+		writeStepFiles(tmp, "apply.sh", "apply_check.sh")
+		data := `{
+  "schema_version": "v1", "root_dir": "/", "expected_config_files": [],
+  "package_name": "p", "package_version": "1.0",
+  "modes": {"apply": [{"name": "apply", "path": "apply.sh", "arguments": [], "returncodes": [0], "on_host": true, "idempotence": false, "upgrade_step": false}]}
+}`
+		_, err := loader.Load([]byte(data), tmp, logger)
+		Expect(err).To(MatchError(ContainSubstring("schema validation")))
+	})
+
+	It("surfaces a missing schema_version distinctly", func() {
+		_, err := loader.Load([]byte(`{"root_dir": "/"}`), tmp, logger)
+		Expect(err).To(MatchError(ContainSubstring("missing required field schema_version")))
+	})
+})
+
+var _ = Describe("Dump", func() {
+	var (
+		tmp    string
+		logger *slog.Logger
+		loader *Loader
+	)
+
+	BeforeEach(func() {
+		tmp = GinkgoT().TempDir()
+		logger = slog.New(slog.NewTextHandler(GinkgoWriter, nil))
+		loader = NewLoader()
+	})
+
+	It("produces output Load accepts (round-trip)", func() {
+		writeStepFiles(tmp, "apply.sh", "apply_check.sh")
+		modes := map[stage.Stage][]step.Step{
+			stage.Apply:      {step.NewRegularStep("apply.sh")},
+			stage.ApplyCheck: {step.NewRegularStep("apply_check.sh")},
+		}
+
+		data, err := loader.Dump("pkg", "1.2.3", "/", modes, nil)
+		Expect(err).NotTo(HaveOccurred())
+
+		cfg, err := loader.Load(data, tmp, logger)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(cfg.PackageName).To(Equal("pkg"))
+		Expect(cfg.PackageVersion).To(Equal("1.2.3"))
+		Expect(cfg.SchemaVersion).To(Equal(schema.V1))
+		Expect(cfg.Modes[stage.Apply]).To(HaveLen(1))
+	})
+
+	It("always emits the latest schema version", func() {
+		modes := map[stage.Stage][]step.Step{
+			stage.Apply:      {step.NewRegularStep("apply.sh")},
+			stage.ApplyCheck: {step.NewRegularStep("apply_check.sh")},
+		}
+		data, err := loader.Dump("pkg", "1.0.0", "/", modes, nil)
+		Expect(err).NotTo(HaveOccurred())
+		latest, err := schema.Highest()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(data)).To(ContainSubstring(`"schema_version":"` + string(latest) + `"`))
+	})
+
+	It("rejects a non-semver package version up front", func() {
+		modes := map[stage.Stage][]step.Step{
+			stage.Apply:      {step.NewRegularStep("apply.sh")},
+			stage.ApplyCheck: {step.NewRegularStep("apply_check.sh")},
+		}
+		_, err := loader.Dump("pkg", "1.0", "/", modes, nil)
+		Expect(err).To(MatchError(ContainSubstring("invalid config")))
+	})
+
+	It("rejects modes that would fail Load's cross-step rules", func() {
+		// An apply stage with no apply-check would serialize fine but be
+		// rejected on reload; Dump must catch it up front.
+		modes := map[stage.Stage][]step.Step{
+			stage.Apply: {step.NewRegularStep("apply.sh")},
+		}
+		_, err := loader.Dump("pkg", "1.0.0", "/", modes, nil)
+		Expect(err).To(MatchError(ContainSubstring("no corresponding")))
+	})
+
+	It("rejects a bogus stage key up front", func() {
+		modes := map[stage.Stage][]step.Step{stage.Stage("bogus"): {step.NewRegularStep("x.sh")}}
+		_, err := loader.Dump("pkg", "1.0.0", "/", modes, nil)
+		Expect(err).To(MatchError(ContainSubstring("unknown stage")))
+	})
+})

--- a/agent/go/internal/config/schemas/v1/skyhook-agent-schema.json
+++ b/agent/go/internal/config/schemas/v1/skyhook-agent-schema.json
@@ -1,0 +1,114 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "v1/skyhook-agent-schema.json",
+  "title": "Skyhook-Agent",
+  "description": "Step Configuration for Skyhook-Agent",
+  "type": "object",
+  "properties": {
+    "schema_version": {
+      "description": "Version of the schema",
+      "type": "string"
+    },
+    "package_name": {
+      "description": "The name of the skyhook package",
+      "type": "string"
+    },
+    "package_version": {
+      "description": "The version of the skyhook package. Supports semver",
+      "type": "string",
+      "pattern": "^(0|[1-9][0-9]*)[.](0|[1-9][0-9]*)[.](0|[1-9][0-9]*)(?:-((?:0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(?:[.](?:0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:[+]([0-9a-zA-Z-]+(?:[.][0-9a-zA-Z-]+)*))?$"
+    },
+    "expected_config_files": {
+      "description": "List of expected config files. Files within SKYHOOK_DIR/configmaps",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 0
+    },
+    "modes": {
+      "description": "What steps to run for each mode",
+      "type": "object",
+      "properties": {
+        "apply": {
+          "description": "Steps to run for APPLY mode",
+          "type": "array",
+          "items": {
+            "$ref": "v1/step-schema.json"
+          }
+        },
+        "apply-check": {
+          "description": "Steps to run to check the work done by APPLY mode",
+          "type": "array",
+          "items": {
+            "$ref": "v1/step-schema.json"
+          }
+        },
+        "config": {
+          "description": "Steps to run for CONFIG mode",
+          "type": "array",
+          "items": {
+            "$ref": "v1/step-schema.json"
+          }
+        },
+        "config-check": {
+          "description": "Steps to run check the work done by CONFIG mode",
+          "type": "array",
+          "items": {
+            "$ref": "v1/step-schema.json"
+          }
+        },
+        "post-interrupt": {
+          "description": "Steps to run after interrupt has been done",
+          "type": "array",
+          "items": {
+            "$ref": "v1/step-schema.json"
+          }
+        },
+        "post-interrupt-check": {
+          "description": "Steps to run check the work done by POST-INTERRUPT mode",
+          "type": "array",
+          "items": {
+            "$ref": "v1/step-schema.json"
+          }
+        },
+        "uninstall": {
+          "description": "Steps to run to uninstall",
+          "type": "array",
+          "items": {
+            "$ref": "v1/step-schema.json"
+          }
+        },
+        "uninstall-check": {
+          "description": "Steps to run to check the work done by UNINSTALL mode",
+          "type": "array",
+          "items": {
+            "$ref": "v1/step-schema.json"
+          }
+        },
+        "upgrade": {
+          "description": "Steps to run to upgrade",
+          "type": "array",
+          "items": {
+            "$ref": "v1/step-schema.json"
+          }
+        },
+        "upgrade-check": {
+          "description": "Steps to run to check the work done by UPGRADE mode",
+          "type": "array",
+          "items": {
+            "$ref": "v1/step-schema.json"
+          }
+        }
+      }
+    }
+  },
+  "required": [
+    "schema_version",
+    "package_name",
+    "package_version",
+    "expected_config_files",
+    "modes"
+  ]
+}
+

--- a/agent/go/internal/config/schemas/v1/step-schema.json
+++ b/agent/go/internal/config/schemas/v1/step-schema.json
@@ -1,0 +1,62 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "v1/step-schema.json",
+    "title": "Step",
+    "description": "Definition of a step for skyhook-agent",
+    "type": "object",
+    "properties": {
+        "name": {
+            "description": "Name of the step",
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_\\-.]+$"
+        },
+        "path": {
+            "description": "Path to the step from within the root_dir as set in the main config",
+            "type": "string"
+        },
+        "arguments": {
+            "description": "Arguments to pass to the step",
+            "type": "array",
+            "items": {
+                "type": "string"
+            },
+            "minItems": 0
+        },
+        "returncodes": {
+            "description": "Return codes that are considered successful",
+            "type": "array",
+            "items": {
+                "type": "integer"
+            },
+            "minItems": 1
+        },
+        "on_host": {
+            "description": "Run the step on the host or inside the agent",
+            "type": "boolean"
+        },
+        "env": {
+            "description": "Environment variables to set for the step",
+            "type": "object",
+            "patternProperties": {
+                ".*": { "type": "string" }
+            }
+        },
+        "idempotence": {
+            "description": "Whether the step will manage its own idempotence",
+            "type": "boolean"
+        },
+        "upgrade_step": {
+            "description": "Whether the step is an upgrade step",
+            "type": "boolean"
+        }
+    },
+    "required": [
+        "name",
+        "path",
+        "arguments",
+        "returncodes",
+        "on_host",
+        "idempotence",
+        "upgrade_step"
+    ]
+}

--- a/agent/go/internal/config/validate.go
+++ b/agent/go/internal/config/validate.go
@@ -1,0 +1,325 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package config
+
+import (
+	"bytes"
+	"embed"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/santhosh-tekuri/jsonschema/v6"
+
+	"github.com/NVIDIA/nodewright/agent/internal/schema"
+	"github.com/NVIDIA/nodewright/agent/internal/stage"
+	"github.com/NVIDIA/nodewright/agent/internal/step"
+)
+
+// This file is the single home for config validation. It covers both layers a
+// loaded document must pass: the JSON Schema check (SchemaValidator, below) and
+// the cross-step document rules (validateModes, further down) that no single
+// step can enforce on its own.
+
+// schemaFS holds the authoritative JSON Schemas the agent validates package
+// configs against. They are copied byte-for-byte from the Python agent's
+// schemas/ tree and embedded so the binary stays a single static artifact.
+//
+//go:embed schemas/v1/*.json
+var schemaFS embed.FS
+
+// rootSchemaFile is the per-version entrypoint schema; the others it pulls in
+// via $ref are siblings in the same version directory.
+const rootSchemaFile = "skyhook-agent-schema.json"
+
+// schemaScheme is a synthetic URL scheme the compiler routes through
+// embeddedLoader. The v1 schemas use relative $id/$ref values whose URI
+// resolution would otherwise point at the filesystem; routing every load
+// through our loader keeps resolution entirely inside the embed FS.
+const schemaScheme = "skyhook"
+
+// SchemaValidator validates a raw config document against the JSON Schema for a
+// given version. Loader depends on this interface rather than a concrete
+// validator so the backend can be substituted (for example, faked in tests).
+type SchemaValidator interface {
+	Validate(data []byte, v schema.SchemaVersion) error
+}
+
+// embeddedValidator validates documents against the JSON Schemas embedded in
+// the binary. The schemas are tiny and single-version, so it compiles on
+// demand and holds no state — there is no package-global cache to share.
+type embeddedValidator struct{}
+
+func newSchemaValidator() embeddedValidator { return embeddedValidator{} }
+
+// Validate checks a raw config document against the embedded schema for v. An
+// unrecognised version is reported as such (rather than as a parse failure).
+func (embeddedValidator) Validate(data []byte, v schema.SchemaVersion) error {
+	compiled, err := compileSchema(v)
+	if err != nil {
+		return err
+	}
+	// jsonschema.UnmarshalJSON decodes numbers as json.Number, which the
+	// validator needs to honour the schema's integer/number distinctions
+	// (e.g. returncodes); a plain json.Unmarshal into any would yield
+	// float64 and weaken those checks.
+	doc, err := jsonschema.UnmarshalJSON(bytes.NewReader(data))
+	if err != nil {
+		return fmt.Errorf("parsing config json: %w", err)
+	}
+	if err := compiled.Validate(doc); err != nil {
+		return fmt.Errorf("config failed schema validation: %w", err)
+	}
+	return nil
+}
+
+// compileSchema compiles the version's root schema, resolving its cross-file
+// $ref through embeddedLoader so every referenced document is read from the
+// embed FS.
+func compileSchema(v schema.SchemaVersion) (*jsonschema.Schema, error) {
+	if _, err := schemaFS.ReadDir("schemas/" + string(v)); err != nil {
+		return nil, fmt.Errorf("unknown schema version %q", v)
+	}
+
+	c := jsonschema.NewCompiler()
+	c.UseLoader(jsonschema.SchemeURLLoader{schemaScheme: embeddedLoader{version: v}})
+
+	root := rootSchemaURL(v)
+	compiled, err := c.Compile(root)
+	if err != nil {
+		return nil, fmt.Errorf("compiling schema %q: %w", root, err)
+	}
+	return compiled, nil
+}
+
+// rootSchemaURL is the synthetic absolute URL the root schema compiles under.
+func rootSchemaURL(v schema.SchemaVersion) string {
+	return schemaScheme + "://schemas/" + string(v) + "/" + rootSchemaFile
+}
+
+// embeddedLoader serves schema documents out of schemaFS for a single
+// version. It keys off the URL's basename, so it is indifferent to whatever
+// base URI the compiler computes when resolving the relative $ref.
+type embeddedLoader struct{ version schema.SchemaVersion }
+
+func (l embeddedLoader) Load(rawURL string) (any, error) {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, fmt.Errorf("parsing schema url %q: %w", rawURL, err)
+	}
+	name := path.Base(u.Path)
+	raw, err := schemaFS.ReadFile("schemas/" + string(l.version) + "/" + name)
+	if err != nil {
+		return nil, fmt.Errorf("loading embedded schema %q: %w", name, err)
+	}
+	doc, err := jsonschema.UnmarshalJSON(bytes.NewReader(raw))
+	if err != nil {
+		return nil, fmt.Errorf("parsing embedded schema %q: %w", name, err)
+	}
+	return doc, nil
+}
+
+// modeRule is a single cross-step invariant over the assembled modes.
+type modeRule func(map[stage.Stage][]step.Step) error
+
+// modeRules are the fatal cross-step invariants, in the order validateModes
+// runs them. Order matters: placement is checked before pairing so a misplaced
+// UpgradeStep in an otherwise-unchecked stage reports the specific placement
+// error rather than the generic missing-checks one.
+var modeRules = []modeRule{
+	requireDefinedSteps,
+	requireNonCheckStage,
+	requireUpgradeStepPlacement,
+	requireApplyChecks,
+}
+
+// validateModes enforces the cross-step rules a single Step cannot check on its
+// own: that some work is defined, that every apply-style stage has matching
+// checks, that UpgradeSteps sit only in the upgrade stages, and that every
+// referenced step file exists under rootDir. A missing check counterpart for a
+// step is a non-fatal warning emitted via logger (nil uses slog.Default()).
+func validateModes(modes map[stage.Stage][]step.Step, rootDir string, logger *slog.Logger) error {
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	if err := checkModeRules(modes); err != nil {
+		return err
+	}
+
+	warnMissingCheckPairs(modes, logger)
+
+	return checkStepFilesExist(modes, rootDir)
+}
+
+// checkModeRules runs the fatal structural cross-step invariants — the ones
+// that don't touch disk. Both Load (via validateModes) and Dump use it so a
+// config can't serialize cleanly yet be rejected on reload.
+func checkModeRules(modes map[stage.Stage][]step.Step) error {
+	for _, rule := range modeRules {
+		if err := rule(modes); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func requireDefinedSteps(modes map[stage.Stage][]step.Step) error {
+	for _, list := range modes {
+		if len(list) > 0 {
+			return nil
+		}
+	}
+	return errors.New("there are no defined steps")
+}
+
+func requireNonCheckStage(modes map[stage.Stage][]step.Step) error {
+	for st := range stage.ApplyToCheck {
+		// A declared-but-empty stage (e.g. "apply": []) does not count: it
+		// carries no work, so it must not satisfy the "must define a
+		// non-check stage" rule.
+		if len(modes[st]) > 0 {
+			return nil
+		}
+	}
+	names := make([]string, 0, len(stage.ApplyToCheck))
+	for st := range stage.ApplyToCheck {
+		names = append(names, string(st))
+	}
+	sort.Strings(names)
+	return fmt.Errorf("there are only check stages defined; define at least one of: %s", strings.Join(names, ", "))
+}
+
+func requireApplyChecks(modes map[stage.Stage][]step.Step) error {
+	for applyStage, checkStage := range stage.ApplyToCheck {
+		if len(modes[applyStage]) > 0 && len(modes[checkStage]) == 0 {
+			return fmt.Errorf("stage %q has steps but no corresponding %q checks", applyStage, checkStage)
+		}
+	}
+	return nil
+}
+
+func requireUpgradeStepPlacement(modes map[stage.Stage][]step.Step) error {
+	for st, list := range modes {
+		for _, s := range list {
+			u, ok := s.(step.UpgradeStep)
+			if !ok {
+				continue
+			}
+			if st != stage.Upgrade && st != stage.UpgradeCheck {
+				return fmt.Errorf(
+					"UpgradeStep %q is defined in stage %q but may only appear in %q or %q",
+					u.Path(), st, stage.Upgrade, stage.UpgradeCheck,
+				)
+			}
+			if err := u.Validate(); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// warnMissingCheckPairs warns when a step has no counterpart in its own check
+// stage. The expected check name is the step path with "_check" inserted
+// before the extension (or appended when there is none), e.g.
+// foo.sh -> foo_check.sh. Each step is matched only against its paired check
+// stage (stage.ApplyToCheck[stage]) so an identically named file in an unrelated
+// check stage cannot mask a genuinely missing check.
+func warnMissingCheckPairs(modes map[stage.Stage][]step.Step, logger *slog.Logger) {
+	for st, list := range modes {
+		checkStage, ok := stage.ApplyToCheck[st]
+		if !ok {
+			// Check stages and non-step stages (Interrupt) have no
+			// apply->check pairing of their own.
+			continue
+		}
+
+		checkPaths := make(map[string]struct{}, len(modes[checkStage]))
+		for _, s := range modes[checkStage] {
+			checkPaths[s.Path()] = struct{}{}
+		}
+
+		for _, s := range list {
+			expected := expectedCheckName(s.Path())
+			if _, ok := checkPaths[expected]; !ok {
+				logger.Warn(
+					"step has no corresponding check; checks ensure all tasks in the step complete",
+					"step", s.Path(),
+					"stage", string(st),
+					"expectedCheck", expected,
+				)
+			}
+		}
+	}
+}
+
+func checkStepFilesExist(modes map[stage.Stage][]step.Step, rootDir string) error {
+	var missing []string
+	for _, list := range modes {
+		for _, s := range list {
+			rel := s.Path()
+			// Reject absolute paths and ones that climb outside rootDir (and
+			// the empty path): a step path must resolve inside the package
+			// root the agent unpacks to, never escape it.
+			if !filepath.IsLocal(rel) {
+				return fmt.Errorf("step path %q must be relative to and contained within the package root", rel)
+			}
+			switch _, err := os.Stat(filepath.Join(rootDir, rel)); {
+			case err == nil:
+				// file present
+			case os.IsNotExist(err):
+				missing = append(missing, rel)
+			default:
+				// A stat failure that isn't "not found" (permission, I/O) is a
+				// real error, not a missing step — surface it rather than
+				// mislabeling the path as absent.
+				return fmt.Errorf("checking step %q under %q: %w", rel, rootDir, err)
+			}
+		}
+	}
+	if len(missing) > 0 {
+		sort.Strings(missing)
+		return fmt.Errorf("the following steps do not exist: %s", strings.Join(missing, ", "))
+	}
+	return nil
+}
+
+// expectedCheckName derives a step's check counterpart by inserting "_check"
+// before the extension of the file's basename (appended when there is none),
+// e.g. foo.sh -> foo_check.sh. The directory is split off first so a dot in a
+// parent directory (dir.v1/foo) doesn't get mistaken for an extension.
+func expectedCheckName(p string) string {
+	dir, base := path.Split(p)
+	i := strings.LastIndex(base, ".")
+	if i < 0 {
+		return dir + base + "_check"
+	}
+	name, ext := base[:i], base[i+1:]
+	if ext == "" {
+		return dir + name + "_check"
+	}
+	return dir + name + "_check." + ext
+}

--- a/agent/go/internal/config/validate_test.go
+++ b/agent/go/internal/config/validate_test.go
@@ -1,0 +1,185 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package config
+
+import (
+	"bytes"
+	"errors"
+	"log/slog"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/NVIDIA/nodewright/agent/internal/schema"
+	"github.com/NVIDIA/nodewright/agent/internal/stage"
+	"github.com/NVIDIA/nodewright/agent/internal/step"
+)
+
+func mustUpgradeStep(path string, opts ...step.RegularStepOption) step.UpgradeStep {
+	u, err := step.NewUpgradeStep(path, opts...)
+	Expect(err).NotTo(HaveOccurred())
+	return u
+}
+
+var _ = Describe("expectedCheckName", func() {
+	DescribeTable("derives the check counterpart",
+		func(in, want string) { Expect(expectedCheckName(in)).To(Equal(want)) },
+		Entry("with extension", "foo.sh", "foo_check.sh"),
+		Entry("without extension", "foo", "foo_check"),
+		Entry("multi-dot keeps last as ext", "foo.tar.gz", "foo.tar_check.gz"),
+		Entry("trailing dot has empty ext", "foo.", "foo_check"),
+		Entry("dotted parent dir, no extension", "dir.v1/foo", "dir.v1/foo_check"),
+		Entry("dotted parent dir with extension", "dir.v1/foo.sh", "dir.v1/foo_check.sh"),
+	)
+})
+
+var _ = Describe("validateModes", func() {
+	var (
+		buf    *bytes.Buffer
+		logger *slog.Logger
+		tmp    string
+	)
+
+	BeforeEach(func() {
+		buf = &bytes.Buffer{}
+		logger = slog.New(slog.NewTextHandler(buf, nil))
+		tmp = GinkgoT().TempDir()
+	})
+
+	It("errors when no steps are defined", func() {
+		err := validateModes(map[stage.Stage][]step.Step{}, tmp, logger)
+		Expect(err).To(MatchError(ContainSubstring("no defined steps")))
+	})
+
+	It("errors when only check stages are defined", func() {
+		steps := map[stage.Stage][]step.Step{
+			stage.ApplyCheck: {step.NewRegularStep("apply_check.sh")},
+		}
+		err := validateModes(steps, tmp, logger)
+		Expect(err).To(MatchError(ContainSubstring("only check stages")))
+	})
+
+	It("treats a declared-but-empty non-check stage as absent", func() {
+		steps := map[stage.Stage][]step.Step{
+			stage.Apply:      {},
+			stage.ApplyCheck: {step.NewRegularStep("apply_check.sh")},
+		}
+		err := validateModes(steps, tmp, logger)
+		Expect(err).To(MatchError(ContainSubstring("only check stages")))
+	})
+
+	It("rejects a step path that escapes the package root", func() {
+		steps := map[stage.Stage][]step.Step{
+			stage.Apply:      {step.NewRegularStep("../escape.sh")},
+			stage.ApplyCheck: {step.NewRegularStep("../escape_check.sh")},
+		}
+		err := validateModes(steps, tmp, logger)
+		Expect(err).To(MatchError(ContainSubstring("must be relative to and contained within the package root")))
+	})
+
+	It("warns when only an unrelated check stage carries the check name", func() {
+		writeStepFiles(tmp, "foo.sh", "apply_check.sh", "foo_check.sh")
+		steps := map[stage.Stage][]step.Step{
+			stage.Apply:       {step.NewRegularStep("foo.sh")},
+			stage.ApplyCheck:  {step.NewRegularStep("apply_check.sh")},
+			stage.ConfigCheck: {step.NewRegularStep("foo_check.sh")},
+		}
+		Expect(validateModes(steps, tmp, logger)).To(Succeed())
+		// foo_check.sh lives in config-check, not apply-check, so foo.sh is
+		// still unpaired in its own stage.
+		Expect(buf.String()).To(ContainSubstring("no corresponding check"))
+		Expect(buf.String()).To(ContainSubstring("foo_check.sh"))
+	})
+
+	It("errors when an apply stage has no checks", func() {
+		steps := map[stage.Stage][]step.Step{
+			stage.Apply: {step.NewRegularStep("apply.sh")},
+		}
+		err := validateModes(steps, tmp, logger)
+		Expect(err).To(MatchError(ContainSubstring("no corresponding")))
+	})
+
+	It("errors when an UpgradeStep is placed outside the upgrade stages", func() {
+		steps := map[stage.Stage][]step.Step{
+			stage.Apply:      {mustUpgradeStep("up.sh")},
+			stage.ApplyCheck: {step.NewRegularStep("up_check.sh")},
+		}
+		err := validateModes(steps, tmp, logger)
+		Expect(err).To(MatchError(ContainSubstring("may only appear")))
+	})
+
+	It("errors listing every missing step file", func() {
+		steps := map[stage.Stage][]step.Step{
+			stage.Apply:      {step.NewRegularStep("apply.sh")},
+			stage.ApplyCheck: {step.NewRegularStep("apply_check.sh")},
+		}
+		err := validateModes(steps, tmp, logger)
+		Expect(err).To(MatchError(ContainSubstring("do not exist")))
+		Expect(err).To(MatchError(ContainSubstring("apply.sh")))
+		Expect(err).To(MatchError(ContainSubstring("apply_check.sh")))
+	})
+
+	It("passes a well-formed set with matching checks and no warnings", func() {
+		writeStepFiles(tmp, "apply.sh", "apply_check.sh")
+		steps := map[stage.Stage][]step.Step{
+			stage.Apply:      {step.NewRegularStep("apply.sh")},
+			stage.ApplyCheck: {step.NewRegularStep("apply_check.sh")},
+		}
+		Expect(validateModes(steps, tmp, logger)).To(Succeed())
+		Expect(buf.String()).NotTo(ContainSubstring("no corresponding check"))
+	})
+
+	It("warns (without failing) when a step has no matching check", func() {
+		writeStepFiles(tmp, "foo.sh", "bar.sh")
+		steps := map[stage.Stage][]step.Step{
+			stage.Apply:      {step.NewRegularStep("foo.sh")},
+			stage.ApplyCheck: {step.NewRegularStep("bar.sh")},
+		}
+		Expect(validateModes(steps, tmp, logger)).To(Succeed())
+		Expect(buf.String()).To(ContainSubstring("no corresponding check"))
+		Expect(buf.String()).To(ContainSubstring("foo_check.sh"))
+	})
+
+	It("accepts an UpgradeStep inside the upgrade stages", func() {
+		writeStepFiles(tmp, "up.sh", "up_check.sh")
+		steps := map[stage.Stage][]step.Step{
+			stage.Upgrade:      {mustUpgradeStep("up.sh")},
+			stage.UpgradeCheck: {step.NewRegularStep("up_check.sh")},
+		}
+		Expect(validateModes(steps, tmp, logger)).To(Succeed())
+	})
+})
+
+var _ = Describe("Loader schema-validation seam", func() {
+	It("surfaces the injected validator's error without parsing the document", func() {
+		sentinel := errors.New("boom from fake validator")
+		loader := &Loader{validator: fakeValidator{err: sentinel}}
+
+		_, err := loader.Load([]byte(validConfigJSON), GinkgoT().TempDir(), nil)
+		Expect(err).To(MatchError(sentinel))
+	})
+})
+
+// fakeValidator is a SchemaValidator stand-in that returns a fixed result,
+// proving Loader depends on the interface rather than the embedded schemas.
+type fakeValidator struct {
+	err error
+}
+
+func (f fakeValidator) Validate(_ []byte, _ schema.SchemaVersion) error { return f.err }

--- a/agent/go/internal/interrupts/interrupts.go
+++ b/agent/go/internal/interrupts/interrupts.go
@@ -23,9 +23,10 @@ import (
 	"fmt"
 )
 
-// invalidSerializedInterruptError mirrors the Python ValueError message so
-// callers comparing error text across language boundaries stay compatible.
-const invalidSerializedInterruptError = "serialized interrupt must be base64 encoded {'type': str, **kwargs: dict[str, any]}"
+// errInvalidSerializedInterrupt is returned when a serialized interrupt is not
+// a base64-encoded JSON object of the expected shape. It is a sentinel so
+// callers can branch on it with errors.Is.
+var errInvalidSerializedInterrupt = errors.New(`serialized interrupt must be base64-encoded JSON with a "type" field`)
 
 // Interrupt is the pure data contract for an interrupt type.
 type Interrupt interface {
@@ -51,25 +52,25 @@ func Encode(i Interrupt) (string, error) {
 
 // Decode parses a base64+JSON serialized interrupt produced by Encode
 // (or its Python counterpart skyhook_agent.interrupts.inflate).
-// Wire-shape errors return invalidSerializedInterruptError; unknown
-// type names return a descriptive error listing the supported types.
+// Wire-shape errors return errInvalidSerializedInterrupt; unknown type
+// names return a descriptive error listing the supported types.
 func Decode(serializedValue string) (Interrupt, error) {
 	data, err := base64.StdEncoding.DecodeString(serializedValue)
 	if err != nil {
-		return nil, errors.New(invalidSerializedInterruptError)
+		return nil, fmt.Errorf("%w: %v", errInvalidSerializedInterrupt, err)
 	}
 
-	// *string distinguishes "type field absent" (Python KeyError →
-	// wire-shape error) from "type field present but empty" (Python
-	// dispatch miss → unknown-type error).
+	// type is probed as *string to distinguish an absent field (a wire-shape
+	// error) from a present-but-empty value (an unknown-type error); the two
+	// take different branches below.
 	var head struct {
 		Type *string `json:"type"`
 	}
 	if err := json.Unmarshal(data, &head); err != nil {
-		return nil, errors.New(invalidSerializedInterruptError)
+		return nil, fmt.Errorf("%w: %v", errInvalidSerializedInterrupt, err)
 	}
 	if head.Type == nil {
-		return nil, errors.New(invalidSerializedInterruptError)
+		return nil, errInvalidSerializedInterrupt
 	}
 
 	switch *head.Type {
@@ -80,7 +81,7 @@ func Decode(serializedValue string) (Interrupt, error) {
 			Services []string `json:"services"`
 		}
 		if err := json.Unmarshal(data, &wire); err != nil {
-			return nil, errors.New(invalidSerializedInterruptError)
+			return nil, fmt.Errorf("%w: %v", errInvalidSerializedInterrupt, err)
 		}
 		return ServiceRestart{Services: wire.Services}, nil
 	case RestartAllServices{}.Type():

--- a/agent/go/internal/interrupts/interrupts_test.go
+++ b/agent/go/internal/interrupts/interrupts_test.go
@@ -19,6 +19,7 @@ package interrupts
 import (
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -63,19 +64,26 @@ var _ = Describe("Encode/Decode", func() {
 		}
 	})
 
-	It("returns python-compatible errors when input is not base64", func() {
+	It("returns the wire-shape error when input is not base64", func() {
 		_, err := Decode("not-base64")
-		Expect(err).To(MatchError(invalidSerializedInterruptError))
+		Expect(err).To(MatchError(errInvalidSerializedInterrupt))
+	})
+
+	It("wraps the underlying decode error while staying branchable on the sentinel", func() {
+		_, err := Decode("not-base64")
+		Expect(errors.Is(err, errInvalidSerializedInterrupt)).To(BeTrue())
+		// The original base64 failure is preserved for diagnostics, not dropped.
+		Expect(err.Error()).To(ContainSubstring("illegal base64"))
 	})
 
 	It("rejects payload without a type field", func() {
 		encoded := base64.StdEncoding.EncodeToString([]byte(`{"services":["kubelet"]}`))
 
 		_, err := Decode(encoded)
-		Expect(err).To(MatchError(invalidSerializedInterruptError))
+		Expect(err).To(MatchError(errInvalidSerializedInterrupt))
 	})
 
-	It("treats an empty type as unknown, matching python dispatch", func() {
+	It("treats an empty type as unknown", func() {
 		encoded := base64.StdEncoding.EncodeToString([]byte(`{"type":""}`))
 
 		_, err := Decode(encoded)
@@ -141,7 +149,7 @@ var _ = Describe("ServiceRestart", func() {
 		encoded := base64.StdEncoding.EncodeToString([]byte(`{"type":"service_restart","services":"kubelet"}`))
 
 		_, err := Decode(encoded)
-		Expect(err).To(MatchError(invalidSerializedInterruptError))
+		Expect(err).To(MatchError(errInvalidSerializedInterrupt))
 	})
 
 	It("emits an empty services array when Services is nil, not null", func() {

--- a/agent/go/internal/stage/stage.go
+++ b/agent/go/internal/stage/stage.go
@@ -1,0 +1,104 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package stage defines the agent lifecycle stages (the keys of a package
+// config's "modes" object) and the relationships between them. It is the
+// vocabulary half of the package-config domain; the step package owns the
+// other half (the steps that run within a stage).
+package stage
+
+import (
+	"fmt"
+	"slices"
+)
+
+// Stage identifies an agent lifecycle stage.
+type Stage string
+
+const (
+	Uninstall          Stage = "uninstall"
+	UninstallCheck     Stage = "uninstall-check"
+	Upgrade            Stage = "upgrade"
+	UpgradeCheck       Stage = "upgrade-check"
+	Apply              Stage = "apply"
+	ApplyCheck         Stage = "apply-check"
+	Config             Stage = "config"
+	ConfigCheck        Stage = "config-check"
+	Interrupt          Stage = "interrupt"
+	PostInterrupt      Stage = "post-interrupt"
+	PostInterruptCheck Stage = "post-interrupt-check"
+)
+
+// All is every recognised stage. ParseStage validates wire mode keys against it
+// (the JSON schema does not forbid extra keys, so this is the gate). Keep it in
+// sync with the consts above when adding a stage.
+var All = []Stage{
+	Uninstall,
+	UninstallCheck,
+	Upgrade,
+	UpgradeCheck,
+	Apply,
+	ApplyCheck,
+	Config,
+	ConfigCheck,
+	Interrupt,
+	PostInterrupt,
+	PostInterruptCheck,
+}
+
+// ApplyToCheck maps each non-check stage to its check counterpart.
+var ApplyToCheck = map[Stage]Stage{
+	Uninstall:     UninstallCheck,
+	Upgrade:       UpgradeCheck,
+	Apply:         ApplyCheck,
+	Config:        ConfigCheck,
+	PostInterrupt: PostInterruptCheck,
+}
+
+// CheckToApply maps each check stage to its non-check counterpart.
+var CheckToApply = map[Stage]Stage{
+	UninstallCheck:     Uninstall,
+	UpgradeCheck:       Upgrade,
+	ApplyCheck:         Apply,
+	ConfigCheck:        Config,
+	PostInterruptCheck: PostInterrupt,
+}
+
+// nonStepStages is the Go counterpart to Python's NON_STEP_MODES list.
+// A "non-step" stage is one the agent dispatches without an apply/check
+// companion: Interrupt today, possibly more in the future. Adding a
+// stage here is enough to exclude it from IsStepStage.
+var nonStepStages = map[Stage]struct{}{
+	Interrupt: {},
+}
+
+// IsStepStage reports whether s carries normal step/check pairs.
+// Non-step stages (see nonStepStages) are dispatched on their own.
+func IsStepStage(s Stage) bool {
+	_, isNonStep := nonStepStages[s]
+	return !isNonStep
+}
+
+// ParseStage converts a wire mode key into a Stage, rejecting unknown values.
+func ParseStage(s string) (Stage, error) {
+	stage := Stage(s)
+	if slices.Contains(All, stage) {
+		return stage, nil
+	}
+	return "", fmt.Errorf("unknown stage %q", s)
+}

--- a/agent/go/internal/stage/stage_test.go
+++ b/agent/go/internal/stage/stage_test.go
@@ -1,0 +1,73 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package stage
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestStage(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Stage Suite")
+}
+
+var _ = Describe("Stage", func() {
+	It("treats Interrupt as a non-step stage", func() {
+		Expect(IsStepStage(Interrupt)).To(BeFalse())
+	})
+
+	It("treats every apply/check pair as a step stage", func() {
+		for apply, check := range ApplyToCheck {
+			Expect(IsStepStage(apply)).To(BeTrue(), "expected %s to be a step stage", apply)
+			Expect(IsStepStage(check)).To(BeTrue(), "expected %s to be a step stage", check)
+		}
+	})
+
+	It("locks Interrupt as the only known non-step stage", func() {
+		Expect(nonStepStages).To(HaveLen(1))
+		Expect(nonStepStages).To(HaveKey(Interrupt))
+	})
+})
+
+var _ = Describe("ParseStage", func() {
+	It("accepts every known stage", func() {
+		// An explicit list (not the All registry) so a stage const that is
+		// added but never registered with ParseStage is caught as drift.
+		for _, s := range []Stage{
+			Uninstall, UninstallCheck,
+			Upgrade, UpgradeCheck,
+			Apply, ApplyCheck,
+			Config, ConfigCheck,
+			Interrupt,
+			PostInterrupt, PostInterruptCheck,
+		} {
+			got, err := ParseStage(string(s))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(got).To(Equal(s))
+		}
+	})
+
+	It("rejects an unknown stage", func() {
+		_, err := ParseStage("not-a-stage")
+		Expect(err).To(MatchError(ContainSubstring("unknown stage")))
+	})
+})

--- a/agent/go/internal/step/regular_step.go
+++ b/agent/go/internal/step/regular_step.go
@@ -23,17 +23,20 @@ import (
 	"fmt"
 )
 
-// RegularStep is the default Step implementation (Python's plain Step).
-// Its fields are exported with JSON tags so stdlib json.Marshal /
-// json.Unmarshal operate on it directly; Idempotence carries its own
-// enum<->bool codec, so no custom marshaler is needed here.
+// RegularStep is the default Step implementation. Its fields are
+// exported with JSON tags so stdlib json.Marshal / json.Unmarshal
+// operate on it directly; Idempotence carries its own enum<->bool
+// codec, so no custom marshaler is needed here.
 //
-// Defaults: Name falls back to Path, Arguments to []string{},
-// Returncodes to []int{0}, Env to map[string]string{}, OnHost to true,
-// and Idempotence to Auto. applyDefaults centralizes these.
+// applyDefaults makes Name fall back to ScriptPath, Arguments to []string{},
+// Returncodes to []int{0}, Env to map[string]string{}, and Idempotence to Auto.
+// NewRegularStep additionally defaults OnHost to true.
+//
+// ScriptPath carries the json:"path" wire name; the field is named
+// distinctly so RegularStep can expose Path() to satisfy Step.
 type RegularStep struct {
 	Name        string            `json:"name"`
-	Path        string            `json:"path"`
+	ScriptPath  string            `json:"path"`
 	Arguments   []string          `json:"arguments"`
 	Returncodes []int             `json:"returncodes"`
 	OnHost      bool              `json:"on_host"`
@@ -41,14 +44,16 @@ type RegularStep struct {
 	UpgradeStep bool              `json:"upgrade_step"`
 	Env         map[string]string `json:"env,omitempty"`
 
-	// RequiresInterrupt round-trips via the wire as
-	// "requires_interrupt", emitted only when true. Python's Step.dump
-	// drops it entirely; here we keep it round-trippable, which stays
-	// schema-valid (the step schema permits extra properties).
+	// RequiresInterrupt round-trips via the wire as "requires_interrupt",
+	// emitted only when true; it stays schema-valid because the step schema
+	// permits extra properties.
 	RequiresInterrupt bool `json:"requires_interrupt,omitempty"`
 }
 
 var _ Step = RegularStep{}
+
+// Path returns the step's script path, relative to the package root.
+func (s RegularStep) Path() string { return s.ScriptPath }
 
 // Encode writes the JSON wire form with upgrade_step:false. Defaults
 // are applied to a local copy so the caller's value is not mutated;
@@ -81,7 +86,7 @@ func (s RegularStep) encode() ([]byte, error) {
 // slices and pass them through.
 type RegularStepOption func(*RegularStep)
 
-// WithName overrides the default Name (which otherwise falls back to Path).
+// WithName overrides the default Name (which otherwise falls back to ScriptPath).
 func WithName(name string) RegularStepOption { return func(s *RegularStep) { s.Name = name } }
 
 // WithArguments sets the step's arguments.
@@ -121,7 +126,7 @@ func NewRegularStep(path string, opts ...RegularStepOption) RegularStep {
 	// OnHost is seeded true here because Go's bool has no "absent"
 	// state, so applyDefaults can't tell zero apart from "explicit
 	// false"; WithOnHost(false) overrides this initial value.
-	rs := RegularStep{Path: path, OnHost: true}
+	rs := RegularStep{ScriptPath: path, OnHost: true}
 	for _, opt := range opts {
 		opt(&rs)
 	}
@@ -138,7 +143,7 @@ func NewRegularStep(path string, opts ...RegularStepOption) RegularStep {
 // constructor seeds it and stdlib decode reads whatever the payload set.
 func (s *RegularStep) applyDefaults() {
 	if s.Name == "" {
-		s.Name = s.Path
+		s.Name = s.ScriptPath
 	}
 	if len(s.Arguments) == 0 {
 		s.Arguments = []string{}

--- a/agent/go/internal/step/regular_step_test.go
+++ b/agent/go/internal/step/regular_step_test.go
@@ -25,43 +25,43 @@ import (
 
 var _ = Describe("RegularStep.applyDefaults", func() {
 	It("fills name from path when name is empty", func() {
-		s := RegularStep{Path: "foo.sh"}
+		s := RegularStep{ScriptPath: "foo.sh"}
 		s.applyDefaults()
 		Expect(s.Name).To(Equal("foo.sh"))
 	})
 
 	It("preserves name when it is set", func() {
-		s := RegularStep{Name: "explicit", Path: "foo.sh"}
+		s := RegularStep{Name: "explicit", ScriptPath: "foo.sh"}
 		s.applyDefaults()
 		Expect(s.Name).To(Equal("explicit"))
 	})
 
 	It("defaults arguments to an empty slice", func() {
-		s := RegularStep{Path: "foo.sh"}
+		s := RegularStep{ScriptPath: "foo.sh"}
 		s.applyDefaults()
 		Expect(s.Arguments).To(Equal([]string{}))
 	})
 
 	It("defaults returncodes to [0]", func() {
-		s := RegularStep{Path: "foo.sh"}
+		s := RegularStep{ScriptPath: "foo.sh"}
 		s.applyDefaults()
 		Expect(s.Returncodes).To(Equal([]int{0}))
 	})
 
 	It("defaults env to an empty map", func() {
-		s := RegularStep{Path: "foo.sh"}
+		s := RegularStep{ScriptPath: "foo.sh"}
 		s.applyDefaults()
 		Expect(s.Env).To(Equal(map[string]string{}))
 	})
 
 	It("defaults idempotence to Auto", func() {
-		s := RegularStep{Path: "foo.sh"}
+		s := RegularStep{ScriptPath: "foo.sh"}
 		s.applyDefaults()
 		Expect(s.Idempotence).To(Equal(Auto))
 	})
 
 	It("does not change OnHost (the constructor seeds it; the schema requires it)", func() {
-		s := RegularStep{Path: "foo.sh", OnHost: true}
+		s := RegularStep{ScriptPath: "foo.sh", OnHost: true}
 		s.applyDefaults()
 		Expect(s.OnHost).To(BeTrue())
 	})
@@ -69,14 +69,14 @@ var _ = Describe("RegularStep.applyDefaults", func() {
 
 var _ = Describe("RegularStep.Encode", func() {
 	It("emits upgrade_step:false", func() {
-		s := RegularStep{Path: "foo.sh"}
+		s := RegularStep{ScriptPath: "foo.sh"}
 		dumped, err := s.Encode()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(string(dumped)).To(ContainSubstring(`"upgrade_step":false`))
 	})
 
 	It("does not mutate the caller's value when applying defaults", func() {
-		s := RegularStep{Path: "foo.sh"}
+		s := RegularStep{ScriptPath: "foo.sh"}
 		_, err := s.Encode()
 		Expect(err).NotTo(HaveOccurred())
 
@@ -85,7 +85,7 @@ var _ = Describe("RegularStep.Encode", func() {
 	})
 
 	It("rejects an explicitly invalid idempotence value", func() {
-		s := RegularStep{Path: "foo.sh", Idempotence: "bogus"}
+		s := RegularStep{ScriptPath: "foo.sh", Idempotence: "bogus"}
 		_, err := s.Encode()
 		Expect(err).To(MatchError(ContainSubstring("bogus is not a valid idempotence value")))
 	})
@@ -94,7 +94,7 @@ var _ = Describe("RegularStep.Encode", func() {
 var _ = Describe("NewRegularStep", func() {
 	It("applies all defaults when only path is provided", func() {
 		s := NewRegularStep("foo.sh")
-		Expect(s.Path).To(Equal("foo.sh"))
+		Expect(s.ScriptPath).To(Equal("foo.sh"))
 		Expect(s.Name).To(Equal("foo.sh"))
 		Expect(s.Arguments).To(Equal([]string{}))
 		Expect(s.Returncodes).To(Equal([]int{0}))
@@ -141,7 +141,7 @@ var _ = Describe("NewRegularStep", func() {
 
 		round, err := Decode(dumped)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(round.(RegularStep).Path).To(Equal("foo.sh"))
+		Expect(round.(RegularStep).ScriptPath).To(Equal("foo.sh"))
 		Expect(round.(RegularStep).Idempotence).To(Equal(Disabled))
 	})
 })

--- a/agent/go/internal/step/step.go
+++ b/agent/go/internal/step/step.go
@@ -24,64 +24,16 @@ import (
 )
 
 // Step is the interface satisfied by every concrete step type the
-// agent recognises. Concrete types (RegularStep, UpgradeStep) expose
-// their data as exported fields; callers that need to distinguish the
-// two kinds use a type switch (or check `_, ok := s.(UpgradeStep)`).
+// agent recognises (RegularStep, UpgradeStep). Callers that must
+// distinguish the kinds type-assert on UpgradeStep.
 type Step interface {
 	// Encode serializes the step to its JSON wire form. Each concrete
 	// type owns its own discriminator bit and any invariants it
 	// enforces before marshaling.
 	Encode() ([]byte, error)
-}
 
-// Stage identifies an agent lifecycle stage.
-type Stage string
-
-const (
-	Uninstall          Stage = "uninstall"
-	UninstallCheck     Stage = "uninstall-check"
-	Upgrade            Stage = "upgrade"
-	UpgradeCheck       Stage = "upgrade-check"
-	Apply              Stage = "apply"
-	ApplyCheck         Stage = "apply-check"
-	Config             Stage = "config"
-	ConfigCheck        Stage = "config-check"
-	Interrupt          Stage = "interrupt"
-	PostInterrupt      Stage = "post-interrupt"
-	PostInterruptCheck Stage = "post-interrupt-check"
-)
-
-// ApplyToCheck maps each non-check stage to its check counterpart.
-var ApplyToCheck = map[Stage]Stage{
-	Uninstall:     UninstallCheck,
-	Upgrade:       UpgradeCheck,
-	Apply:         ApplyCheck,
-	Config:        ConfigCheck,
-	PostInterrupt: PostInterruptCheck,
-}
-
-// CheckToApply maps each check stage to its non-check counterpart.
-var CheckToApply = map[Stage]Stage{
-	UninstallCheck:     Uninstall,
-	UpgradeCheck:       Upgrade,
-	ApplyCheck:         Apply,
-	ConfigCheck:        Config,
-	PostInterruptCheck: PostInterrupt,
-}
-
-// nonStepStages is the Go counterpart to Python's NON_STEP_MODES list.
-// A "non-step" stage is one the agent dispatches without an apply/check
-// companion: Interrupt today, possibly more in the future. Adding a
-// stage here is enough to exclude it from IsStepStage.
-var nonStepStages = map[Stage]struct{}{
-	Interrupt: {},
-}
-
-// IsStepStage reports whether s carries normal step/check pairs.
-// Non-step stages (see nonStepStages) are dispatched on their own.
-func IsStepStage(s Stage) bool {
-	_, isNonStep := nonStepStages[s]
-	return !isNonStep
+	// Path is the step's script path, relative to the package root.
+	Path() string
 }
 
 // Idempotence controls how the agent treats step re-runs.
@@ -96,12 +48,6 @@ const (
 )
 
 // Validate reports whether the receiver is a recognised value.
-//
-// The error message intentionally differs from Python's
-// skyhook_agent.step.Idempotence.validate, which says "is not a valid
-// mode". The Go form is more specific so log readers don't confuse it
-// with Stage validation. Callers comparing error strings across the
-// language boundary must account for this.
 func (i Idempotence) Validate() error {
 	switch i {
 	case Auto, Disabled:
@@ -134,24 +80,17 @@ func (i *Idempotence) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// Decode parses a JSON step payload, returning either a RegularStep or
-// an UpgradeStep based on the upgrade_step discriminator. Stdlib drives
-// field parsing (the exported tags + the Idempotence codec); Decode
-// routes on the discriminator and applies defaults.
+// Decode parses a JSON step payload, returning either a RegularStep or an
+// UpgradeStep based on the upgrade_step discriminator. Stdlib drives field
+// parsing (the exported tags + the Idempotence codec); Decode routes on the
+// discriminator and applies defaults.
 //
-// The probe's on_host is *bool so Decode can distinguish "field absent"
-// (default to true, matching Python's Step(on_host=True)) from "present
-// and false" - the plain bool field on RegularStep can't carry that
-// distinction, so the lenient default lives here at the gate.
-//
-// The Go contract is otherwise intentionally looser than Python's:
-// Python's load requires "idempotence" to be present and KeyErrors
-// otherwise; Go treats it as optional and defaults to Auto. UpgradeStep
-// invariant violations are propagated from Validate.
+// Missing JSON fields retain their Go zero values unless applyDefaults handles
+// them. Full package configs are schema-validated before they reach Decode, so
+// required fields such as on_host are present on that path.
 func Decode(data []byte) (Step, error) {
 	var probe struct {
-		OnHost      *bool `json:"on_host"`
-		UpgradeStep bool  `json:"upgrade_step"`
+		UpgradeStep bool `json:"upgrade_step"`
 	}
 	if err := json.Unmarshal(data, &probe); err != nil {
 		return nil, fmt.Errorf("decode step: %w", err)
@@ -161,9 +100,6 @@ func Decode(data []byte) (Step, error) {
 		var u UpgradeStep
 		if err := json.Unmarshal(data, &u); err != nil {
 			return nil, fmt.Errorf("decode upgrade step: %w", err)
-		}
-		if probe.OnHost == nil {
-			u.OnHost = true
 		}
 		u.RegularStep.applyDefaults()
 		if err := u.Validate(); err != nil {
@@ -175,9 +111,6 @@ func Decode(data []byte) (Step, error) {
 	var rs RegularStep
 	if err := json.Unmarshal(data, &rs); err != nil {
 		return nil, fmt.Errorf("decode step: %w", err)
-	}
-	if probe.OnHost == nil {
-		rs.OnHost = true
 	}
 	rs.applyDefaults()
 	return rs, nil

--- a/agent/go/internal/step/step_test.go
+++ b/agent/go/internal/step/step_test.go
@@ -37,20 +37,20 @@ var (
 )
 
 var _ = Describe("Step interface", func() {
-	It("is satisfied by RegularStep", func() {
-		var s Step = RegularStep{Path: "foo.sh"}
-		Expect(s.(RegularStep).Path).To(Equal("foo.sh"))
+	It("is satisfied by RegularStep and exposes its path", func() {
+		var s Step = RegularStep{ScriptPath: "foo.sh"}
+		Expect(s.Path()).To(Equal("foo.sh"))
 	})
 
-	It("is satisfied by UpgradeStep", func() {
-		var s Step = UpgradeStep{RegularStep: RegularStep{Path: "foo.sh"}}
-		Expect(s.(UpgradeStep).Path).To(Equal("foo.sh"))
+	It("is satisfied by UpgradeStep and promotes Path through embedding", func() {
+		var s Step = UpgradeStep{RegularStep: RegularStep{ScriptPath: "foo.sh"}}
+		Expect(s.Path()).To(Equal("foo.sh"))
 	})
 
 	It("promotes RegularStep fields to UpgradeStep through embedding", func() {
 		rs := RegularStep{
 			Name:        "explicit-name",
-			Path:        "foo.sh",
+			ScriptPath:  "foo.sh",
 			Arguments:   []string{},
 			Returncodes: []int{0},
 			Env:         map[string]string{"K": "V"},
@@ -60,7 +60,7 @@ var _ = Describe("Step interface", func() {
 		u := UpgradeStep{RegularStep: rs}
 
 		Expect(u.Name).To(Equal("explicit-name"))
-		Expect(u.Path).To(Equal("foo.sh"))
+		Expect(u.ScriptPath).To(Equal("foo.sh"))
 		Expect(u.Arguments).To(Equal([]string{}))
 		Expect(u.Returncodes).To(Equal([]int{0}))
 		Expect(u.Env).To(Equal(map[string]string{"K": "V"}))
@@ -71,8 +71,8 @@ var _ = Describe("Step interface", func() {
 
 	It("supports type-switching between RegularStep and UpgradeStep", func() {
 		steps := []Step{
-			RegularStep{Path: "foo.sh"},
-			UpgradeStep{RegularStep: RegularStep{Path: "upgrade.sh"}},
+			RegularStep{ScriptPath: "foo.sh"},
+			UpgradeStep{RegularStep: RegularStep{ScriptPath: "upgrade.sh"}},
 		}
 
 		var sawRegular, sawUpgrade bool
@@ -95,43 +95,41 @@ var _ = Describe("Idempotence", func() {
 		Expect(Disabled.Validate()).To(Succeed())
 	})
 
-	It("rejects unrecognised values with a go-specific message", func() {
+	It("rejects unrecognised values", func() {
 		Expect(Idempotence("bad").Validate()).To(MatchError("bad is not a valid idempotence value"))
 	})
 })
 
-var _ = Describe("Stage", func() {
-	It("treats Interrupt as a non-step stage", func() {
-		Expect(IsStepStage(Interrupt)).To(BeFalse())
-	})
-
-	It("treats every apply/check pair as a step stage", func() {
-		for apply, check := range ApplyToCheck {
-			Expect(IsStepStage(apply)).To(BeTrue(), "expected %s to be a step stage", apply)
-			Expect(IsStepStage(check)).To(BeTrue(), "expected %s to be a step stage", check)
-		}
-	})
-
-	It("locks Interrupt as the only known non-step stage", func() {
-		Expect(nonStepStages).To(HaveLen(1))
-		Expect(nonStepStages).To(HaveKey(Interrupt))
-	})
-})
-
 var _ = Describe("Decode", func() {
-	It("loads defaults like python step.load", func() {
-		data := []byte(`{"path":"foo.sh","idempotence":false,"upgrade_step":false}`)
+	It("applies defaults to a direct decode payload", func() {
+		// idempotence is omitted so this exercises the missing-field fallback
+		// (absent -> Auto), not the legacy boolean form.
+		data := []byte(`{"path":"foo.sh","on_host":true,"upgrade_step":false}`)
 		s, err := Decode(data)
 		Expect(err).NotTo(HaveOccurred())
 
 		rs := s.(RegularStep)
 		Expect(rs.Name).To(Equal("foo.sh"))
-		Expect(rs.Path).To(Equal("foo.sh"))
+		Expect(rs.ScriptPath).To(Equal("foo.sh"))
 		Expect(rs.Arguments).To(Equal([]string{}))
 		Expect(rs.Returncodes).To(Equal([]int{0}))
 		Expect(rs.OnHost).To(BeTrue())
 		Expect(rs.Env).To(Equal(map[string]string{}))
 		Expect(rs.Idempotence).To(Equal(Auto))
+	})
+
+	It("leaves on_host at its zero value when absent", func() {
+		data := []byte(`{"path":"foo.sh","upgrade_step":false}`)
+		s, err := Decode(data)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(s.(RegularStep).OnHost).To(BeFalse())
+	})
+
+	It("decodes the legacy idempotence boolean", func() {
+		data := []byte(`{"path":"foo.sh","idempotence":true,"upgrade_step":false}`)
+		s, err := Decode(data)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(s.(RegularStep).Idempotence).To(Equal(Disabled))
 	})
 
 	It("returns a RegularStep when upgrade_step is false", func() {
@@ -163,7 +161,7 @@ var _ = Describe("Encode/Decode round-trip", func() {
 	It("round-trips idempotence and preserves RegularStep type", func() {
 		start := RegularStep{
 			Name:        "foo",
-			Path:        "foo",
+			ScriptPath:  "foo",
 			Arguments:   []string{},
 			Returncodes: []int{0},
 			OnHost:      true,
@@ -222,7 +220,7 @@ var _ = Describe("Encode/Decode round-trip", func() {
 	})
 
 	It("encodes a zero-value RegularStep by applying defaults", func() {
-		bare := RegularStep{Path: "foo.sh"}
+		bare := RegularStep{ScriptPath: "foo.sh"}
 		dumped, err := bare.Encode()
 		Expect(err).NotTo(HaveOccurred())
 
@@ -240,7 +238,7 @@ var _ = Describe("Encode env handling", func() {
 	It("omits env when empty and includes it when populated", func() {
 		noEnv := RegularStep{
 			Name:        "a",
-			Path:        "a",
+			ScriptPath:  "a",
 			Arguments:   []string{},
 			Returncodes: []int{0},
 			OnHost:      true,

--- a/agent/go/internal/step/upgrade_step.go
+++ b/agent/go/internal/step/upgrade_step.go
@@ -21,7 +21,7 @@ package step
 import "fmt"
 
 // UpgradeStep is a Step that runs only during the Upgrade and
-// UpgradeCheck modes. It mirrors Python's UpgradeStep subclass.
+// UpgradeCheck modes.
 //
 // Invariant: UpgradeSteps may not declare arguments. Construct via
 // NewUpgradeStep or call Validate() before encoding.
@@ -33,10 +33,8 @@ var _ Step = UpgradeStep{}
 
 // NewUpgradeStep constructs an UpgradeStep using the same option set
 // as NewRegularStep, sets the upgrade_step discriminator on the
-// embedded value, then checks the no-arguments invariant. The shared
-// option set keeps construction symmetric; if a caller passes
-// WithArguments, the Python-parity error is returned at runtime
-// (matching Python's UpgradeStep.__init__ which raises StepError).
+// embedded value, then checks the no-arguments invariant. Passing
+// WithArguments returns the invariant error at construction.
 func NewUpgradeStep(path string, opts ...RegularStepOption) (UpgradeStep, error) {
 	rs := NewRegularStep(path, opts...)
 	rs.UpgradeStep = true
@@ -48,8 +46,7 @@ func NewUpgradeStep(path string, opts ...RegularStepOption) (UpgradeStep, error)
 }
 
 // Validate reports whether u satisfies the UpgradeStep invariant:
-// arguments must be empty. Mirrors Python's StepError raised in
-// UpgradeStep.__init__.
+// arguments must be empty.
 func (u UpgradeStep) Validate() error {
 	if len(u.Arguments) != 0 {
 		return fmt.Errorf(

--- a/agent/go/internal/step/upgrade_step_test.go
+++ b/agent/go/internal/step/upgrade_step_test.go
@@ -29,10 +29,10 @@ var _ = Describe("NewUpgradeStep", func() {
 	It("succeeds when no arguments are supplied", func() {
 		u, err := NewUpgradeStep("upgrade.sh")
 		Expect(err).NotTo(HaveOccurred())
-		Expect(u.Path).To(Equal("upgrade.sh"))
+		Expect(u.ScriptPath).To(Equal("upgrade.sh"))
 	})
 
-	It("rejects WithArguments at construction with the python-parity error", func() {
+	It("rejects WithArguments at construction", func() {
 		_, err := NewUpgradeStep(
 			"upgrade.sh",
 			WithName("upgrade"),
@@ -63,15 +63,15 @@ var _ = Describe("NewUpgradeStep", func() {
 
 var _ = Describe("UpgradeStep.Validate", func() {
 	It("passes when arguments are empty", func() {
-		u := UpgradeStep{RegularStep: RegularStep{Path: "upgrade.sh"}}
+		u := UpgradeStep{RegularStep: RegularStep{ScriptPath: "upgrade.sh"}}
 		Expect(u.Validate()).To(Succeed())
 	})
 
 	It("rejects directly-constructed values with non-empty arguments", func() {
 		u := UpgradeStep{RegularStep: RegularStep{
-			Name:      "upgrade",
-			Path:      "upgrade.sh",
-			Arguments: []string{"x"},
+			Name:       "upgrade",
+			ScriptPath: "upgrade.sh",
+			Arguments:  []string{"x"},
 		}}
 		Expect(u.Validate()).To(MatchError(
 			"UpgradeStep upgrade can not have any arguments, but found: [x]",
@@ -83,7 +83,7 @@ var _ = Describe("UpgradeStep fields", func() {
 	It("promote field access from the embedded RegularStep", func() {
 		rs := RegularStep{
 			Name:        "explicit",
-			Path:        "upgrade.sh",
+			ScriptPath:  "upgrade.sh",
 			Returncodes: []int{0},
 			Env:         map[string]string{"K": "V"},
 			OnHost:      true,
@@ -92,7 +92,7 @@ var _ = Describe("UpgradeStep fields", func() {
 		u := UpgradeStep{RegularStep: rs}
 
 		Expect(u.Name).To(Equal("explicit"))
-		Expect(u.Path).To(Equal("upgrade.sh"))
+		Expect(u.ScriptPath).To(Equal("upgrade.sh"))
 		Expect(u.Returncodes).To(Equal([]int{0}))
 		Expect(u.Env).To(Equal(map[string]string{"K": "V"}))
 		Expect(u.OnHost).To(BeTrue())
@@ -111,7 +111,7 @@ var _ = Describe("UpgradeStep.Encode", func() {
 	})
 
 	It("forces upgrade_step:true for a directly-constructed value", func() {
-		u := UpgradeStep{RegularStep: RegularStep{Path: "upgrade.sh"}}
+		u := UpgradeStep{RegularStep: RegularStep{ScriptPath: "upgrade.sh"}}
 		dumped, err := u.Encode()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(string(dumped)).To(ContainSubstring(`"upgrade_step":true`))
@@ -119,9 +119,9 @@ var _ = Describe("UpgradeStep.Encode", func() {
 
 	It("returns the invariant error before marshaling when arguments are set", func() {
 		u := UpgradeStep{RegularStep: RegularStep{
-			Name:      "upgrade",
-			Path:      "upgrade.sh",
-			Arguments: []string{"x"},
+			Name:       "upgrade",
+			ScriptPath: "upgrade.sh",
+			Arguments:  []string{"x"},
 		}}
 		_, err := u.Encode()
 		Expect(err).To(MatchError(


### PR DESCRIPTION
# feat(agent): config loader with embedded JSON schemas + stage/step validation (#214)

## Description

Adds the config layer of the Go agent rewrite: a new `internal/config` package that
loads, validates, and serializes a package `config.json`, plus a new `internal/stage`
package for the lifecycle-stage vocabulary and cross-step validation rules. This is the
layer every later agent module (#215, #217, #219) builds on.

Validation follows the same split the Python agent uses: the **JSON schema owns the
declarative half** (required fields, the semver/name `pattern`s, types) and
**hand-written Go owns the structural/cross-step rules** (no defined steps, apply
stages without checks, `UpgradeStep` placement, step files existing on disk, check-pair
warnings). The v1 schemas are embedded so the binary stays a single static artifact.

Builds on #213 (`internal/{schema,step,interrupts}`, already on `main`). No changes to
the Python agent.

## Architecture

The package-config domain is split into three packages, each with one job:

- **`internal/stage`** — the lifecycle-stage vocabulary: the `Stage` type, the stage
  constants, `ParseStage`, `IsStepStage`, and the `ApplyToCheck`/`CheckToApply` pairing
  maps. Names are unprefixed (`stage.Apply`, `stage.ApplyCheck`) since the package name
  already namespaces them.
- **`internal/step`** — the step *types*: the `Step` interface, `RegularStep`,
  `UpgradeStep`, `Idempotence`, and `Decode`/`Encode`. No dependency on `stage` (the
  `stage → step` relationship lives in `config` as `map[stage.Stage][]step.Step`).
- **`internal/config`** — assembles the two: loads/validates/dumps the whole document
  and owns the cross-step rules that no single step can enforce.

## What's in here

- **`internal/config/config.go`** — `Config` struct + a `Loader` with `Load` / `Dump`.
  - `Config` holds typed `Modes` (`map[stage.Stage][]step.Step`); custom
    `MarshalJSON`/`UnmarshalJSON` route the `modes` section through `step.Decode` /
    `step.Encode` so the `step.Step` interface stays the contract.
  - `Loader.Load(data, stepRootDir, *slog.Logger)`: read declared version →
    schema-validate (which also rejects unknown versions) → materialize `modes` via
    `stage.ParseStage` + `step.Decode` → run the cross-step rules.
  - `Loader.Dump`: emits the latest schema version; deterministic output (struct field
    order + stdlib-sorted map keys), each step re-encoded through `step.Encode`, and now
    runs the **same structural cross-step rules** Load does so a dumped config can't
    serialize cleanly yet fail on reload.
- **`internal/config/validate.go`** — the single home for config validation. Holds both
  the `SchemaValidator` interface + the embedded-schema implementation
  (`//go:embed schemas/v1/*.json`, validated via `github.com/santhosh-tekuri/jsonschema/v6`)
  **and** the cross-step document rules (`validateModes`, `checkModeRules`,
  `warnMissingCheckPairs`, `checkStepFilesExist`).
- **`internal/config/schemas/v1/*.json`** — copies of the Python agent's v1 schemas;
  these become the Go module's authoritative copy at cutover (#222).
- **`internal/stage/stage.go`** — the `Stage` type, constants, registry (`stage.All`),
  pairing maps, `IsStepStage`, and `ParseStage` (which rejects unknown mode keys — the
  schema does not forbid extras).
- **`internal/step`** — `Step` gained a `Path()` method so callers read a step's path
  through the interface instead of type-switching on the concrete types.
- **`cmd/agent/main.go`** — establishes the agent's `slog` logging seam.

Closes #214.

## New dependency

`github.com/santhosh-tekuri/jsonschema/v6` (+ transitive `github.com/dlclark/regexp2`) —
the agent's first runtime dependency. Native JSON Schema Draft 2020-12 with a custom
`URLLoader` hook, which is what lets us resolve the cross-file `$ref` straight out of the
embed FS. Per AGENTS.md, flagging it explicitly as the one new pattern this PR introduces.
Rejected alternatives: pure-Go hand-rolled validation (loses the schema as the single
source of truth), `google/jsonschema-go` (less ergonomic embed/`$ref` wiring at the time),
and `omissis/go-jsonschema` (a code generator — it would own the type layer and collide
with the hand-built `step` types from #213).

## Notable design decisions

Calling these out for review, since several depart from a literal port of the Python agent:

1. **Validation lives in one place (`config/validate.go`).** Cross-step rules sit with
   `Load`/`Dump`, where the whole document is materialized — not scattered across the
   `step` package. This also removes the "schema" name overload: `internal/schema` is
   version arithmetic, and JSON-schema validation no longer has a separate `schema.go`.
2. **A dedicated `internal/stage` package.** `Stage` is one of the three core vocab
   concepts (Status/State/Stage); giving it its own package keeps `step` to just the step
   types and matches how the operator treats `Stage` as first-class. Names are unprefixed
   (`stage.Apply`) since the package name carries the namespace.
3. **`SchemaValidator` interface + injectable `Loader`.** Schema validation sits behind a
   small interface that `Loader` holds, instead of a package-level function backed by a
   global cache. The validator is stateless (the embedded schemas are tiny and
   single-version), and tests can inject a fake — no `sync.Map`/`sync.Once` machinery.
4. **No `migrate` function.** With only v1 defined, schema validation already rejects
   unknown/newer versions, so the version check is inlined into `Load` rather than kept as
   a speculative migration seam. (This also drops the Python `migrate()` bug where it
   `return`s a `ValidationError` instead of raising it.)
5. **`Stage` and `Step` are exposed through behavior, not type switches.** `Step.Path()`
   replaced a `stepPath` type switch whose `default` returned `""` — a latent bug where a
   future step type would silently stat the root dir and pass file validation. The
   `RegularStep` data field is named `ScriptPath` so the type can expose `Path()`.
6. **`Dump` enforces the cross-step contract.** `Dump` now runs the structural rules
   (`checkModeRules`: empty steps, missing paired checks, misplaced `UpgradeStep`) before
   marshaling, so `Dump` → `Load` stays consistent. The on-disk step-file check is
   intentionally excluded — `Dump` records a package-relative root, not a path it can stat.
7. **Errors use sentinel values + `fmt.Errorf("…: %w")`**, matching `interrupts.go`,
   instead of porting Python's `StepError`/`ValueError` hierarchy. `interrupts.Decode`
   returns an `errors.Is`-able sentinel and wraps the underlying base64/JSON error for
   diagnostics.
8. **Schema `$ref` resolution uses a custom `URLLoader`** (keyed by URL basename over the
   embed FS) instead of `AddResource`. The v1 schemas use relative `$id`/`$ref` values
   whose URI math makes `AddResource` resolve to doubled-up paths; the loader keeps
   resolution entirely inside the embed FS.
9. **Logging uses `slog`, not controller-runtime `logr`.** The agent is a standalone
   container entrypoint with no reconcile loop or controller-runtime dependency, so
   `slog` (with `slog.Default()` fallback when a `nil` logger is passed) is the right seam
   here — the operator's `logr` contract does not apply to this module.
10. **No byte-for-byte parity with Python's `dump()` output.** The Go agent isn't wired
    into the operator e2e suite until cutover (#222), so dump/log string parity isn't
    load-bearing yet. `Dump` targets deterministic + schema-valid + round-trippable.

## Testing

- `cd agent/go && make test` — 5 Ginkgo suites, 110 specs, all passing.
- `cd agent/go && make lint` — golangci-lint clean (0 issues).
- `cd agent/go && make build` — builds with the `slog` seam.
- `go mod tidy` is stable.

Coverage includes: valid load; missing required field; unknown schema version;
non-semver `package_version`; missing `schema_version`; `Dump`→`Load` round-trip;
`Dump` rejecting configs that would fail Load's cross-step rules; an injected fake
`SchemaValidator` (proving `Load` depends on the interface, not the embedded schemas);
embedded-schema compilation; every cross-step rule (no steps, only-check stages,
apply-without-check, `UpgradeStep` misplacement, missing step files, path-escape
rejection, and the non-fatal check-pair warning asserted via a buffer-backed
`slog.Logger`); `expectedCheckName` including dotted parent directories; `stage.ParseStage`
against an explicit stage list; and `step.Decode` defaulting (including the absent
`idempotence` → `Auto` fallback and the legacy boolean form).

## Out of scope (follow-ups)

- Filesystem helpers for flag/log/history paths (#215).
- Runtime step execution / tee streaming (#217).
- Controller wiring of `Load` / validation (#219).
- Schema `root_dir` field + Go↔Python schema drift test — `root_dir` is in the wire
  format but unvalidated, and the Python source schema omits it too; aligning that
  belongs with the source-of-truth schema, not a unilateral divergence here.

## Files

```
 agent/go/cmd/agent/main.go                                    |   8 +
 agent/go/go.mod                                               |   1 +
 agent/go/go.sum                                               |   4 +
 agent/go/internal/config/config.go                            | 225 +++++++++++++++
 agent/go/internal/config/config_test.go                       | 195 +++++++++++++
 agent/go/internal/config/schemas/v1/skyhook-agent-schema.json | 114 ++++++++
 agent/go/internal/config/schemas/v1/step-schema.json          |  62 ++++
 agent/go/internal/config/validate.go                          | 325 ++++++++++++++++++++
 agent/go/internal/config/validate_test.go                     | 185 ++++++++++++
 agent/go/internal/interrupts/interrupts.go                    |  25 +-
 agent/go/internal/interrupts/interrupts_test.go               |  18 +-
 agent/go/internal/stage/stage.go                              | 104 +++++++
 agent/go/internal/stage/stage_test.go                         |  73 +++++
 agent/go/internal/step/regular_step.go                        |  31 +-
 agent/go/internal/step/regular_step_test.go                   |  24 +-
 agent/go/internal/step/step.go                                |  82 +-----
 agent/go/internal/step/step_test.go                           |  61 +--
 agent/go/internal/step/upgrade_step.go                        |  11 +-
 agent/go/internal/step/upgrade_step_test.go                   |  24 +-
 19 files changed, 1405 insertions(+), 167 deletions(-)
```

## Checklist

- [X] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/skyhook/blob/main/CONTRIBUTING.md).
- [X] My commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
