### PR TITLE
chore: bump version, plus small change to changelog tooling (#290) (cherry-pick)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Install NodeWright quickly using Helm without downloading the repository:
 # The chart is distributed as an OCI artifact on GitHub Container Registry.
 # Helm 3.8+ supports OCI natively — no `helm repo add` needed.
 helm install nodewright oci://ghcr.io/nvidia/nodewright/charts/nodewright \
-  --version v0.17.0 \
+  --version v0.17.1 \
   --namespace skyhook \
   --create-namespace
 ```

--- a/chart/CHANGELOG.md
+++ b/chart/CHANGELOG.md
@@ -5,6 +5,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [chart/v0.17.1] - 2026-06-26
+
+### Bug Fixes
+
+- *(chart)* Repair immutable Deployment selector on skyhook->nodewright upgrade  
+
 ## [chart/v0.17.0] - 2026-06-12
 
 ### Bug Fixes
@@ -28,7 +34,7 @@ fix(chart): agent container path pointing to skyhook not nodewright
 - Merge pull request #255 from NVIDIA/chore/chart-bump-v0.16.1
 
 chore(chart): bump to v0.16.1 with operator webhook cert deadlock fix
-
+- Bump chart versions  
 
 ## [chart/v0.16.1] - 2026-05-26
 

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -2,10 +2,12 @@ apiVersion: v2
 name: nodewright
 description: A Helm chart for NodeWright (formerly Skyhook).
 type: application
-# This is the chart version. This version number must be incremented each time you make changes to the helm chart. OR
-# it the agent version is updated, or operator version is updated.
+# This is the chart version. This version number must be incremented each time you make changes any of the following:
+# - chart
+# - agent container
+# - operator container
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v0.17.0
+version: v0.17.1
 # This is the version number operator container being deployed.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 appVersion: v0.17.0

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -233,6 +233,18 @@ for c in operator agent chart cli; do scripts/gen-changelog.sh "$c"; done   # bu
 make release-tag
 ```
 
+### Where a cut section is sourced from (patch vs. minor)
+
+When you cut a **patch** (`vX.Y.Z` whose `X.Y` already has a final tag), the new section is sourced from that line's release branch, `release/vX.Y.x`, not from your current `HEAD`. A patch ships only the fixes cherry-picked onto its release branch; `main` meanwhile carries unrelated work bound for the next minor (a breaking API change, a dependency bump, …), and ranging `prevTag..HEAD` on `main` would sweep all of that into the patch. Sourcing from the release branch gives exactly what the patch ships, and lets you run the generator from any branch.
+
+Practical consequences for a patch cut:
+
+- The release branch must already exist and already carry the cherry-picks. Order is: cherry-pick the fix onto `release/vX.Y.x` first, then run the generator. The generator prints `Patch cut: sourcing <c>/vX.Y.Z from release/vX.Y.x (...)` so you can see the source it chose.
+- If `release/vX.Y.x` (or `origin/release/vX.Y.x`) doesn't exist, it errors and tells you to create the branch and cherry-pick first.
+- If nothing new is on the release branch since the previous tag, it warns (`no <c> commits for vX.Y.Z ... cherry-picked onto ... yet?`) rather than emitting an empty section: the usual cause is forgetting the cherry-pick.
+
+A **minor or major** (`vX.Y.0`, no prior tag on that `X.Y`) has no backport branch to read from, so it still walks commits after the latest tag from `HEAD`. Cut it on its release branch as the workflow above describes.
+
 ### Cutting a release tag (`make release-tag`)
 
 `scripts/gen-changelog.sh` writes changelogs; `scripts/release-tag.sh` (via `make release-tag`) creates the git tag. They are separate steps. The tag helper:

--- a/scripts/gen-changelog.sh
+++ b/scripts/gen-changelog.sh
@@ -179,6 +179,42 @@ released_section() {
 # commit is path-filtered out).
 ROOT="$(git rev-list --max-parents=0 HEAD | tail -1)"
 
+# Decide where the version-being-cut section is sourced from.
+#
+# A PATCH ships only the commits cherry-picked onto its release branch -- NOT
+# everything on main since the last tag, because main interleaves fixes bound for
+# this line with features bound for the next minor (e.g. main carries a breaking
+# api change that must not appear in a 0.17 patch). So for a patch we source the
+# new section from release/v<major>.<minor>.x rather than HEAD. That lets you run
+# this from any branch (main included) and still get exactly what the patch ships.
+#
+# A minor/major has no backport branch to read from, so it falls through to the
+# normal "commits after the latest tag, walked from HEAD" behaviour.
+CUT_RANGE=""
+CUT_REF=""
+if [[ -n "$NEXT_VERSION" ]]; then
+    next_mm="${NEXT_VERSION%.*}" # v0.17.1 -> v0.17
+    prev_same_line=$(printf '%s\n' "${TAGS[@]}" |
+        grep -E "^${COMPONENT}/${next_mm//./\\.}\." | tail -1 || true)
+    if [[ -n "$prev_same_line" ]]; then
+        for _cand in "release/${next_mm}.x" "origin/release/${next_mm}.x"; do
+            if git rev-parse --verify --quiet "${_cand}^{commit}" >/dev/null; then
+                CUT_REF="$_cand"
+                break
+            fi
+        done
+        if [[ -z "$CUT_REF" ]]; then
+            echo "ERROR: cutting patch ${COMPONENT}/${NEXT_VERSION}, but no release branch" >&2
+            echo "       release/${next_mm}.x (or origin/release/${next_mm}.x) exists." >&2
+            echo "       Create it and cherry-pick the fix(es) onto it first." >&2
+            echo "       See docs/release-process.md (Patch Release Workflow)." >&2
+            exit 1
+        fi
+        CUT_RANGE="${prev_same_line}..${CUT_REF}"
+        echo "${C_DIM}Patch cut: sourcing ${COMPONENT}/${NEXT_VERSION} from ${CUT_REF} (${CUT_RANGE})${C_RESET}" >&2
+    fi
+fi
+
 {
     printf '# Changelog\n\n'
     printf '<!-- DO NOT EDIT. Generated from git commit history by scripts/gen-changelog.sh.\n'
@@ -186,8 +222,22 @@ ROOT="$(git rev-list --max-parents=0 HEAD | tail -1)"
     printf 'All notable changes to this project will be documented in this file.\n\n'
 
     # Unreleased (= commits after the latest tag), or the version being cut.
-    if [[ -n "$NEXT_VERSION" ]]; then
-        # A fresh release: --tag labels the unreleased commits; today's date is correct.
+    if [[ -n "$NEXT_VERSION" && -n "$CUT_RANGE" ]]; then
+        # Patch: source only what's on the release branch since this line's last
+        # tag (set above). Explicit range, not --unreleased, so the source is the
+        # release branch rather than HEAD. No tag exists yet, so stamp the heading
+        # with the release branch tip's date.
+        # shellcheck disable=SC2086
+        cut_body=$(git-cliff "${CLIFF_COMMON[@]}" --tag "${COMPONENT}/${NEXT_VERSION}" $CUT_RANGE 2>/dev/null) || true
+        if [[ -z "${cut_body//[[:space:]]/}" ]]; then
+            echo "WARNING: no ${COMPONENT} commits for ${NEXT_VERSION} in ${CUT_RANGE} -- cherry-picked onto ${CUT_REF} yet?" >&2
+        else
+            cut_date=$(git log -1 --format=%cs "${CUT_REF}^{commit}")
+            printf '%s\n' "$cut_body" | sed "1s|^## \[.*|## [${COMPONENT}/${NEXT_VERSION}] - ${cut_date}|"
+            printf '\n'
+        fi
+    elif [[ -n "$NEXT_VERSION" ]]; then
+        # A fresh minor/major: --tag labels the unreleased commits; today's date is correct.
         git-cliff "${CLIFF_COMMON[@]}" --unreleased --tag "${COMPONENT}/${NEXT_VERSION}" 2>/dev/null
         printf '\n'
     else


### PR DESCRIPTION
update docs to reflect this tooling change to match process

## Description
<!-- Provide a brief description of the changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/skyhook/blob/main/CONTRIBUTING.md).
- [ ] My commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
