### PR TITLE
feat(agent): add filesystem flag and log helpers

### DIFF
--- a/agent/go/internal/flags/flags.go
+++ b/agent/go/internal/flags/flags.go
@@ -1,0 +1,332 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package flags
+
+import (
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/NVIDIA/nodewright/agent/internal/config"
+	"github.com/NVIDIA/nodewright/agent/internal/stage"
+	"github.com/NVIDIA/nodewright/agent/internal/step"
+)
+
+const flagFileMode = 0o600
+
+// Reason explains why a step should run or be skipped.
+type Reason string
+
+const (
+	ReasonFlagMissing         Reason = "flag-missing"
+	ReasonAlwaysRun           Reason = "always-run"
+	ReasonStageAlwaysRuns     Reason = "stage-always-runs"
+	ReasonIdempotenceDisabled Reason = "idempotence-disabled"
+	ReasonAlreadyCompleted    Reason = "already-completed"
+)
+
+// Decision is the result of checking a step's completion flag.
+type Decision struct {
+	Run    bool
+	Reason Reason
+}
+
+// Store manages completion and control flags for one package.
+//
+// A flag is a small marker file the agent writes on the host after a step
+// finishes successfully. On later runs the agent checks for the flag to decide
+// whether the step already completed and can be skipped, which is how package
+// execution stays idempotent across agent restarts and node reboots. Flag
+// filenames embed a fingerprint of the step's execution-relevant inputs (path,
+// arguments, return codes, environment, host execution), so changing any of
+// those produces a new flag and the step runs again. Flags live beneath the
+// package state directory on the mounted host root, grouped by package name
+// and version.
+type Store interface {
+	Path(value step.Step) (string, error)
+	Mark(value step.Step, message string) (string, error)
+	Write(path string, data []byte) error
+	Check(value step.Step, alwaysRun bool, currentStage stage.Stage) (Decision, error)
+}
+
+// NewStore returns the file-backed flag store. The implementation is
+// unexported so downstream consumers depend on the Store interface.
+func NewStore(layout Layout, cfg config.Config) (Store, error) {
+	s, err := newFileStore(layout, cfg)
+	if err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+// fileStore keeps one package's flags under a host layout.
+type fileStore struct {
+	rootMount      string
+	dir            string
+	packageName    string
+	packageVersion string
+}
+
+var _ Store = (*fileStore)(nil)
+
+// newFileStore returns a store for the package described by cfg. Package
+// identity is validated once here so later flag paths cannot escape the
+// package's flag directory.
+func newFileStore(layout Layout, cfg config.Config) (*fileStore, error) {
+	if err := validatePackagePath(cfg); err != nil {
+		return nil, fmt.Errorf("validating package path: %w", err)
+	}
+	return &fileStore{
+		rootMount:      layout.rootMount,
+		dir:            filepath.Join(layout.stateRoot, "flags"),
+		packageName:    cfg.PackageName,
+		packageVersion: cfg.PackageVersion,
+	}, nil
+}
+
+// Path returns the completion-flag path for a step. The filename contains a
+// stable SHA-256 fingerprint of the step path, arguments, and accepted return
+// codes so any execution-relevant change gets a distinct flag.
+func (s *fileStore) Path(value step.Step) (string, error) {
+	if value == nil {
+		return "", errors.New("building flag path: step must not be nil")
+	}
+	if !filepath.IsLocal(value.Path()) {
+		return "", fmt.Errorf("building flag path: step path %q must be relative to the package root", value.Path())
+	}
+
+	marker, err := value.Fingerprint()
+	if err != nil {
+		return "", fmt.Errorf("building flag path: fingerprinting step %q: %w", value.Path(), err)
+	}
+	filename := filepath.Base(value.Path()) + "-" + marker + ".flag"
+	return filepath.Join(s.rootMount, s.dir, s.packageName, s.packageVersion, filename), nil
+}
+
+// Mark records successful completion and returns the flag path written.
+func (s *fileStore) Mark(value step.Step, message string) (string, error) {
+	path, err := s.Path(value)
+	if err != nil {
+		return "", fmt.Errorf("marking step: resolving flag path: %w", err)
+	}
+	if err := s.Write(path, []byte(message)); err != nil {
+		return "", fmt.Errorf("marking step %q: %w", value.Path(), err)
+	}
+	return path, nil
+}
+
+// Write creates or replaces a flag file owned by this store. In addition to
+// per-step flags, callers can use it for control files such as START and
+// check_results without duplicating directory and permission handling.
+func (s *fileStore) Write(path string, data []byte) (retErr error) {
+	relative, err := s.rootRelativePath(path)
+	if err != nil {
+		return fmt.Errorf("validating flag store path %q: %w", path, err)
+	}
+	root, err := os.OpenRoot(s.rootMount)
+	if err != nil {
+		return fmt.Errorf("opening mounted host root %q: %w", s.rootMount, err)
+	}
+	defer closeStoreRoot(root, &retErr)
+
+	if err := ensureDirectoriesNoSymlinks(root, filepath.Dir(relative)); err != nil {
+		return fmt.Errorf("preparing flag directory for %q: %w", path, err)
+	}
+	info, exists, err := lstatNoSymlinks(root, relative)
+	if err != nil {
+		return fmt.Errorf("validating flag target %q: %w", path, err)
+	}
+	if exists && !info.Mode().IsRegular() {
+		return fmt.Errorf("flag path %q is not a regular file", path)
+	}
+	if err := writeFlagFile(root, relative, data, exists); err != nil {
+		return fmt.Errorf("writing flag %q: %w", path, err)
+	}
+	return nil
+}
+
+// Check reports whether a step should run based on its completion flag and
+// current execution policy.
+func (s *fileStore) Check(value step.Step, alwaysRun bool, currentStage stage.Stage) (decision Decision, retErr error) {
+	if value == nil {
+		return Decision{}, errors.New("checking flag: step must not be nil")
+	}
+	if _, err := stage.ParseStage(string(currentStage)); err != nil {
+		return Decision{}, fmt.Errorf("checking flag for step %q: validating stage: %w", value.Path(), err)
+	}
+	if err := value.Idempotence().Validate(); err != nil {
+		return Decision{}, fmt.Errorf("checking flag for step %q: validating idempotence: %w", value.Path(), err)
+	}
+	path, err := s.Path(value)
+	if err != nil {
+		return Decision{}, fmt.Errorf("checking flag for step %q: resolving store path: %w", value.Path(), err)
+	}
+	relative, err := s.rootRelativePath(path)
+	if err != nil {
+		return Decision{}, fmt.Errorf("checking flag for step %q: validating store path: %w", value.Path(), err)
+	}
+	root, err := os.OpenRoot(s.rootMount)
+	if err != nil {
+		return Decision{}, fmt.Errorf("checking flag for step %q: opening mounted host root %q: %w", value.Path(), s.rootMount, err)
+	}
+	defer closeStoreRoot(root, &retErr)
+
+	info, exists, err := lstatNoSymlinks(root, relative)
+	if err != nil {
+		return Decision{}, fmt.Errorf("checking flag for step %q: inspecting store path: %w", value.Path(), err)
+	}
+	if !exists {
+		return Decide(false, alwaysRun, currentStage, value.Idempotence()), nil
+	}
+	if !info.Mode().IsRegular() {
+		return Decision{}, fmt.Errorf("checking flag for step %q: flag path %q is not a regular file", value.Path(), path)
+	}
+	return Decide(true, alwaysRun, currentStage, value.Idempotence()), nil
+}
+
+// Decide applies flag policy without filesystem access.
+func Decide(flagExists, alwaysRun bool, currentStage stage.Stage, idempotence step.Idempotence) Decision {
+	if !flagExists {
+		return Decision{Run: true, Reason: ReasonFlagMissing}
+	}
+	if alwaysRun {
+		return Decision{Run: true, Reason: ReasonAlwaysRun}
+	}
+	switch currentStage {
+	case stage.Config, stage.Uninstall, stage.Upgrade:
+		return Decision{Run: true, Reason: ReasonStageAlwaysRuns}
+	}
+	if idempotence == step.Disabled {
+		return Decision{Run: true, Reason: ReasonIdempotenceDisabled}
+	}
+	return Decision{Run: false, Reason: ReasonAlreadyCompleted}
+}
+
+func (s *fileStore) rootRelativePath(path string) (string, error) {
+	storePath := filepath.Join(s.rootMount, s.dir)
+	relative, err := filepath.Rel(storePath, path)
+	if err != nil {
+		return "", fmt.Errorf("resolving path relative to flag store: %w", err)
+	}
+	if !filepath.IsLocal(relative) {
+		return "", fmt.Errorf("flag path %q must be contained within %q", path, storePath)
+	}
+	return filepath.Join(s.dir, relative), nil
+}
+
+func ensureDirectoriesNoSymlinks(root *os.Root, directory string) error {
+	current := ""
+	for _, component := range pathComponents(directory) {
+		current = filepath.Join(current, component)
+		info, err := root.Lstat(current)
+		if errors.Is(err, fs.ErrNotExist) {
+			if err := root.Mkdir(current, directoryMode); err != nil && !errors.Is(err, fs.ErrExist) {
+				return fmt.Errorf("creating directory %q: %w", current, err)
+			}
+			info, err = root.Lstat(current)
+		}
+		if err != nil {
+			return fmt.Errorf("inspecting directory %q: %w", current, err)
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("path component %q is a symbolic link", current)
+		}
+		if !info.IsDir() {
+			return fmt.Errorf("path component %q is not a directory", current)
+		}
+	}
+	return nil
+}
+
+func lstatNoSymlinks(root *os.Root, path string) (os.FileInfo, bool, error) {
+	components := pathComponents(path)
+	current := ""
+	for i, component := range components {
+		current = filepath.Join(current, component)
+		info, err := root.Lstat(current)
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, false, nil
+		}
+		if err != nil {
+			return nil, false, fmt.Errorf("inspecting path component %q: %w", current, err)
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return nil, false, fmt.Errorf("path component %q is a symbolic link", current)
+		}
+		if i < len(components)-1 && !info.IsDir() {
+			return nil, false, fmt.Errorf("path component %q is not a directory", current)
+		}
+		if i == len(components)-1 {
+			return info, true, nil
+		}
+	}
+	return nil, false, nil
+}
+
+func pathComponents(path string) []string {
+	clean := filepath.Clean(path)
+	if clean == "." {
+		return nil
+	}
+	return strings.Split(clean, string(filepath.Separator))
+}
+
+func writeFlagFile(root *os.Root, path string, data []byte, replace bool) (retErr error) {
+	writePath := path
+	if replace {
+		writePath = filepath.Join(filepath.Dir(path), ".flag-"+rand.Text()+".tmp")
+	}
+	file, err := root.OpenFile(writePath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, flagFileMode)
+	if err != nil {
+		return fmt.Errorf("creating flag %q without following symlinks: %w", path, err)
+	}
+	defer func() {
+		if err := file.Close(); err != nil && !errors.Is(err, os.ErrClosed) && retErr == nil {
+			retErr = fmt.Errorf("closing flag %q: %w", path, err)
+		}
+		if retErr != nil {
+			if err := root.Remove(writePath); err != nil && !errors.Is(err, fs.ErrNotExist) {
+				retErr = errors.Join(retErr, fmt.Errorf("removing incomplete flag %q: %w", writePath, err))
+			}
+		}
+	}()
+
+	if _, err := file.Write(data); err != nil {
+		return fmt.Errorf("writing flag %q: %w", path, err)
+	}
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("closing flag %q: %w", path, err)
+	}
+	if replace {
+		if err := root.Rename(writePath, path); err != nil {
+			return fmt.Errorf("atomically replacing flag %q: %w", path, err)
+		}
+	}
+	return nil
+}
+
+func closeStoreRoot(root *os.Root, retErr *error) {
+	if err := root.Close(); err != nil && *retErr == nil {
+		*retErr = fmt.Errorf("closing mounted host root %q: %w", root.Name(), err)
+	}
+}

--- a/agent/go/internal/flags/flags_test.go
+++ b/agent/go/internal/flags/flags_test.go
@@ -1,0 +1,268 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package flags
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/NVIDIA/nodewright/agent/internal/config"
+	"github.com/NVIDIA/nodewright/agent/internal/stage"
+	"github.com/NVIDIA/nodewright/agent/internal/step"
+)
+
+func TestFlags(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Flags Suite")
+}
+
+var _ = Describe("flag store", func() {
+	var (
+		root  string
+		store *fileStore
+		cfg   config.Config
+		value step.RegularStep
+	)
+
+	BeforeEach(func() {
+		root = GinkgoT().TempDir()
+		cfg = config.Config{PackageName: "driver", PackageVersion: "1.2.3"}
+		value = step.NewRegularStep(
+			"scripts/apply.sh",
+			step.WithArguments([]string{"--mode", "fast"}),
+			step.WithReturncodes([]int{0, 2}),
+		)
+
+		var err error
+		store, err = newFileStore(DefaultLayout(root), cfg)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("constructs the store behind its interface", func() {
+		s, err := NewStore(DefaultLayout(root), cfg)
+		Expect(err).NotTo(HaveOccurred())
+		decision, err := s.Check(value, false, stage.Apply)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(decision).To(Equal(Decision{Run: true, Reason: ReasonFlagMissing}))
+
+		invalid := cfg
+		invalid.PackageName = "../driver"
+		s, err = NewStore(DefaultLayout(root), invalid)
+		Expect(err).To(MatchError(ContainSubstring("single path component")))
+		Expect(s).To(BeNil())
+	})
+
+	It("uses a stable Go-native fingerprint", func() {
+		path, err := store.Path(value)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(path).To(Equal(filepath.Join(
+			root,
+			"etc", "skyhook", "flags", "driver", "1.2.3",
+			"apply.sh-f3f526b85e0a962f2b4b68089385cd5b4829c09a436112f6586ff5f288e4ecf4.flag",
+		)))
+	})
+
+	It("changes the fingerprint when execution inputs change", func() {
+		original, err := store.Path(value)
+		Expect(err).NotTo(HaveOccurred())
+		environmentChanged := value
+		environmentChanged.Env = map[string]string{"MODE": "debug"}
+		hostExecutionChanged := value
+		hostExecutionChanged.OnHost = false
+
+		cases := []step.RegularStep{
+			step.NewRegularStep("scripts/other.sh", step.WithArguments([]string{"--mode", "fast"}), step.WithReturncodes([]int{0, 2})),
+			step.NewRegularStep("scripts/apply.sh", step.WithArguments([]string{"--mode", "slow"}), step.WithReturncodes([]int{0, 2})),
+			step.NewRegularStep("scripts/apply.sh", step.WithArguments([]string{"--mode", "fast"}), step.WithReturncodes([]int{0})),
+			environmentChanged,
+			hostExecutionChanged,
+		}
+		for _, candidate := range cases {
+			path, err := store.Path(candidate)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(path).NotTo(Equal(original))
+		}
+	})
+
+	It("supports upgrade steps", func() {
+		upgrade, err := step.NewUpgradeStep("upgrade.sh")
+		Expect(err).NotTo(HaveOccurred())
+
+		path, err := store.Path(upgrade)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(filepath.Base(path)).To(HavePrefix("upgrade.sh-"))
+	})
+
+	It("writes a private flag file", func() {
+		path, err := store.Mark(value, "complete")
+		Expect(err).NotTo(HaveOccurred())
+
+		data, err := os.ReadFile(path)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(data)).To(Equal("complete"))
+		info, err := os.Stat(path)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(info.Mode().Perm()).To(Equal(os.FileMode(0o600)))
+	})
+
+	It("writes control flags inside the store", func() {
+		path := filepath.Join(DefaultLayout(root).FlagDir(), "START")
+		Expect(store.Write(path, []byte("started"))).To(Succeed())
+		Expect(store.Write(path, []byte("restarted"))).To(Succeed())
+		data, err := os.ReadFile(path)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(data)).To(Equal("restarted"))
+	})
+
+	It("keeps the existing path when an atomic replacement fails", func() {
+		rootPath := GinkgoT().TempDir()
+		Expect(os.Mkdir(filepath.Join(rootPath, "flag"), 0o755)).To(Succeed())
+		root, err := os.OpenRoot(rootPath)
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() {
+			Expect(root.Close()).To(Succeed())
+		})
+
+		err = writeFlagFile(root, "flag", []byte("replacement"), true)
+		Expect(err).To(MatchError(ContainSubstring("atomically replacing flag")))
+		info, err := os.Stat(filepath.Join(rootPath, "flag"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(info.IsDir()).To(BeTrue())
+		entries, err := os.ReadDir(rootPath)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(entries).To(HaveLen(1))
+	})
+
+	It("rejects a symlinked flag parent", func() {
+		flagDir := DefaultLayout(root).FlagDir()
+		Expect(os.MkdirAll(flagDir, 0o755)).To(Succeed())
+		outside := GinkgoT().TempDir()
+		linkedParent := filepath.Join(flagDir, "linked")
+		Expect(os.Symlink(outside, linkedParent)).To(Succeed())
+
+		err := store.Write(filepath.Join(linkedParent, "START"), []byte("started"))
+		Expect(err).To(MatchError(ContainSubstring("is a symbolic link")))
+		Expect(filepath.Join(outside, "START")).NotTo(BeAnExistingFile())
+	})
+
+	It("rejects a symlinked flag target without modifying it", func() {
+		flagDir := DefaultLayout(root).FlagDir()
+		Expect(os.MkdirAll(flagDir, 0o755)).To(Succeed())
+		outside := filepath.Join(GinkgoT().TempDir(), "target")
+		Expect(os.WriteFile(outside, []byte("original"), 0o600)).To(Succeed())
+		flag := filepath.Join(flagDir, "START")
+		Expect(os.Symlink(outside, flag)).To(Succeed())
+
+		Expect(store.Write(flag, []byte("changed"))).To(MatchError(ContainSubstring("is a symbolic link")))
+		data, err := os.ReadFile(outside)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(data)).To(Equal("original"))
+	})
+
+	It("refuses to write outside the store", func() {
+		outside := filepath.Join(root, "outside")
+		Expect(store.Write(outside, nil)).To(MatchError(ContainSubstring("must be contained")))
+		Expect(outside).NotTo(BeAnExistingFile())
+	})
+
+	It("runs when no flag exists", func() {
+		decision, err := store.Check(value, false, stage.Apply)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(decision).To(Equal(Decision{Run: true, Reason: ReasonFlagMissing}))
+	})
+
+	It("skips an idempotent completed step", func() {
+		_, err := store.Mark(value, "")
+		Expect(err).NotTo(HaveOccurred())
+
+		decision, err := store.Check(value, false, stage.Apply)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(decision).To(Equal(Decision{Run: false, Reason: ReasonAlreadyCompleted}))
+	})
+
+	It("does not accept a symlink as a completion flag", func() {
+		path, err := store.Path(value)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(os.MkdirAll(filepath.Dir(path), 0o755)).To(Succeed())
+		target := filepath.Join(GinkgoT().TempDir(), "complete")
+		Expect(os.WriteFile(target, nil, 0o600)).To(Succeed())
+		Expect(os.Symlink(target, path)).To(Succeed())
+
+		_, err = store.Check(value, false, stage.Apply)
+		Expect(err).To(MatchError(ContainSubstring("is a symbolic link")))
+	})
+
+	It("rejects a non-file at the flag path", func() {
+		path, err := store.Path(value)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(os.MkdirAll(path, 0o755)).To(Succeed())
+
+		_, err = store.Check(value, false, stage.Apply)
+		Expect(err).To(MatchError(ContainSubstring("is not a regular file")))
+	})
+
+	It("rejects invalid package identities at construction", func() {
+		invalid := cfg
+		invalid.PackageName = "../driver"
+		_, err := newFileStore(DefaultLayout(root), invalid)
+		Expect(err).To(MatchError(ContainSubstring(`package name "../driver" must be a single path component`)))
+
+		invalid = cfg
+		invalid.PackageVersion = "1.2.3/patched"
+		_, err = newFileStore(DefaultLayout(root), invalid)
+		Expect(err).To(MatchError(ContainSubstring("single path component")))
+	})
+
+	It("rejects steps that escape the package root", func() {
+		escaping := step.NewRegularStep("../escape.sh")
+		_, err := store.Path(escaping)
+		Expect(err).To(MatchError(ContainSubstring(`step path "../escape.sh" must be relative to the package root`)))
+	})
+
+	It("adds operation context when marking fails", func() {
+		escaping := step.NewRegularStep("../escape.sh")
+		_, err := store.Mark(escaping, "")
+		Expect(err).To(MatchError(ContainSubstring("marking step: resolving flag path")))
+		Expect(err).To(MatchError(ContainSubstring("must be relative to the package root")))
+	})
+
+	It("rejects unknown stages", func() {
+		_, err := store.Check(value, false, stage.Stage("bogus"))
+		Expect(err).To(MatchError(ContainSubstring(`checking flag for step "scripts/apply.sh": validating stage`)))
+		Expect(err).To(MatchError(ContainSubstring(`unknown stage "bogus"`)))
+	})
+})
+
+var _ = DescribeTable(
+	"Decide",
+	func(flagExists, alwaysRun bool, currentStage stage.Stage, idempotence step.Idempotence, expected Decision) {
+		Expect(Decide(flagExists, alwaysRun, currentStage, idempotence)).To(Equal(expected))
+	},
+	Entry("missing flag", false, false, stage.Apply, step.Auto, Decision{Run: true, Reason: ReasonFlagMissing}),
+	Entry("always-run override", true, true, stage.Apply, step.Auto, Decision{Run: true, Reason: ReasonAlwaysRun}),
+	Entry("config stage", true, false, stage.Config, step.Auto, Decision{Run: true, Reason: ReasonStageAlwaysRuns}),
+	Entry("uninstall stage", true, false, stage.Uninstall, step.Auto, Decision{Run: true, Reason: ReasonStageAlwaysRuns}),
+	Entry("upgrade stage", true, false, stage.Upgrade, step.Auto, Decision{Run: true, Reason: ReasonStageAlwaysRuns}),
+	Entry("disabled idempotence", true, false, stage.Apply, step.Disabled, Decision{Run: true, Reason: ReasonIdempotenceDisabled}),
+	Entry("completed idempotent step", true, false, stage.Apply, step.Auto, Decision{Run: false, Reason: ReasonAlreadyCompleted}),
+)

--- a/agent/go/internal/flags/layout.go
+++ b/agent/go/internal/flags/layout.go
@@ -1,0 +1,191 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package flags
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/NVIDIA/nodewright/agent/internal/config"
+)
+
+const (
+	DefaultStateRoot = "/etc/skyhook"
+	DefaultLogRoot   = "/var/log/skyhook"
+	logTimeFormat    = "2006-01-02-150405"
+	directoryMode    = 0o755
+)
+
+// Layout resolves agent-owned paths beneath the mounted host root. StateRoot
+// and LogRoot are supplied by the process configuration rather than read from
+// the environment here, which keeps path construction deterministic.
+type Layout struct {
+	rootMount string
+	stateRoot string
+	logRoot   string
+}
+
+// NewLayout constructs a host layout. Empty state and log roots select the
+// agent defaults. Absolute state and log roots are interpreted relative to the
+// mounted host root; roots that would traverse above it are rejected.
+func NewLayout(rootMount, stateRoot, logRoot string) (Layout, error) {
+	if stateRoot == "" {
+		stateRoot = DefaultStateRoot
+	}
+	if logRoot == "" {
+		logRoot = DefaultLogRoot
+	}
+	stateRoot, err := normalizeLayoutRoot("state root", stateRoot)
+	if err != nil {
+		return Layout{}, fmt.Errorf("constructing layout: normalizing state root: %w", err)
+	}
+	logRoot, err = normalizeLayoutRoot("log root", logRoot)
+	if err != nil {
+		return Layout{}, fmt.Errorf("constructing layout: normalizing log root: %w", err)
+	}
+	return Layout{
+		rootMount: normalizeRootMount(rootMount),
+		stateRoot: stateRoot,
+		logRoot:   logRoot,
+	}, nil
+}
+
+// DefaultLayout constructs a layout using the standard agent directories.
+func DefaultLayout(rootMount string) Layout {
+	return Layout{
+		rootMount: normalizeRootMount(rootMount),
+		stateRoot: strings.TrimPrefix(DefaultStateRoot, string(filepath.Separator)),
+		logRoot:   strings.TrimPrefix(DefaultLogRoot, string(filepath.Separator)),
+	}
+}
+
+func (l Layout) StateDir() string {
+	return filepath.Join(l.rootMount, l.stateRoot)
+}
+
+func (l Layout) FlagDir() string {
+	return filepath.Join(l.StateDir(), "flags")
+}
+
+func (l Layout) HistoryDir() string {
+	return filepath.Join(l.StateDir(), "history")
+}
+
+func (l Layout) LogDir() string {
+	return filepath.Join(l.rootMount, l.logRoot)
+}
+
+// StepsDir returns the directory where package step files are copied.
+func StepsDir(copyDir string) string {
+	return filepath.Join(copyDir, "skyhook_dir")
+}
+
+// LogFilePath derives a log path without touching the filesystem. stepPath
+// must be relative to the package's step root.
+func (l Layout) LogFilePath(cfg config.Config, stepPath string, at time.Time) (string, error) {
+	logDir, err := l.packageLogDir(cfg, stepPath)
+	if err != nil {
+		return "", fmt.Errorf("building log file path for step %q: resolving package log path: %w", stepPath, err)
+	}
+	if at.IsZero() {
+		return "", fmt.Errorf("log timestamp must not be zero")
+	}
+
+	return logDir + "-" + at.UTC().Format(logTimeFormat) + ".log", nil
+}
+
+// LogFiles identifies prior logs for one step without interpreting the step
+// path as a glob expression.
+type LogFiles struct {
+	directory string
+	prefix    string
+	suffix    string
+}
+
+// LogFilePattern returns the literal directory and filename shape used to find
+// prior logs for one step.
+func (l Layout) LogFilePattern(cfg config.Config, stepPath string) (LogFiles, error) {
+	logBase, err := l.packageLogDir(cfg, stepPath)
+	if err != nil {
+		return LogFiles{}, fmt.Errorf("building log file pattern for step %q: resolving package log path: %w", stepPath, err)
+	}
+	return LogFiles{
+		directory: filepath.Dir(logBase),
+		prefix:    filepath.Base(logBase) + "-",
+		suffix:    ".log",
+	}, nil
+}
+
+// PrepareLogFile returns the next log path and creates its parent directory.
+func (l Layout) PrepareLogFile(cfg config.Config, stepPath string, at time.Time) (string, error) {
+	path, err := l.LogFilePath(cfg, stepPath, at)
+	if err != nil {
+		return "", fmt.Errorf("preparing log file for step %q: resolving log file path: %w", stepPath, err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), directoryMode); err != nil {
+		return "", fmt.Errorf("creating log directory %q: %w", filepath.Dir(path), err)
+	}
+	return path, nil
+}
+
+func (l Layout) packageLogDir(cfg config.Config, stepPath string) (string, error) {
+	if err := validatePackagePath(cfg); err != nil {
+		return "", fmt.Errorf("building package log path for step %q: validating package path: %w", stepPath, err)
+	}
+	if !filepath.IsLocal(stepPath) {
+		return "", fmt.Errorf("step path %q must be relative to the package root", stepPath)
+	}
+	return filepath.Join(l.LogDir(), cfg.PackageName, cfg.PackageVersion, stepPath), nil
+}
+
+func validatePackagePath(cfg config.Config) error {
+	if err := validatePathComponent("package name", cfg.PackageName); err != nil {
+		return err
+	}
+	if err := validatePathComponent("package version", cfg.PackageVersion); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validatePathComponent(name, value string) error {
+	if value == "" || value == "." || !filepath.IsLocal(value) || filepath.Base(value) != value {
+		return fmt.Errorf("%s %q must be a single path component", name, value)
+	}
+	return nil
+}
+
+func normalizeRootMount(rootMount string) string {
+	if rootMount == "" {
+		return string(filepath.Separator)
+	}
+	return filepath.Clean(rootMount)
+}
+
+func normalizeLayoutRoot(name, root string) (string, error) {
+	root = strings.TrimLeft(root, string(filepath.Separator))
+	root = filepath.Clean(root)
+	if root == "." || !filepath.IsLocal(root) {
+		return "", fmt.Errorf("%s %q must remain within the mounted host root", name, root)
+	}
+	return root, nil
+}

--- a/agent/go/internal/flags/layout_test.go
+++ b/agent/go/internal/flags/layout_test.go
@@ -1,0 +1,136 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package flags
+
+import (
+	"os"
+	"path/filepath"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/NVIDIA/nodewright/agent/internal/config"
+)
+
+var _ = Describe("Layout", func() {
+	It("resolves the default host directories", func() {
+		root := GinkgoT().TempDir()
+		layout := DefaultLayout(root)
+
+		Expect(layout.StateDir()).To(Equal(filepath.Join(root, "etc", "skyhook")))
+		Expect(layout.FlagDir()).To(Equal(filepath.Join(root, "etc", "skyhook", "flags")))
+		Expect(layout.HistoryDir()).To(Equal(filepath.Join(root, "etc", "skyhook", "history")))
+		Expect(layout.LogDir()).To(Equal(filepath.Join(root, "var", "log", "skyhook")))
+	})
+
+	It("uses caller-supplied state and log roots", func() {
+		layout, err := NewLayout("/host", "/state/nodewright", "/logs/nodewright")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(layout.StateDir()).To(Equal("/host/state/nodewright"))
+		Expect(layout.LogDir()).To(Equal("/host/logs/nodewright"))
+	})
+
+	It("rejects roots that traverse above the mounted host root", func() {
+		_, err := NewLayout("/host", "../../state", "/logs/nodewright")
+		Expect(err).To(MatchError(ContainSubstring("constructing layout: normalizing state root")))
+		Expect(err).To(MatchError(ContainSubstring("must remain within the mounted host root")))
+
+		_, err = NewLayout("/host", "/state/nodewright", "/../../logs")
+		Expect(err).To(MatchError(ContainSubstring("constructing layout: normalizing log root")))
+		Expect(err).To(MatchError(ContainSubstring("must remain within the mounted host root")))
+	})
+
+	It("resolves the copied step directory", func() {
+		Expect(StepsDir("/copy/package")).To(Equal("/copy/package/skyhook_dir"))
+	})
+
+	It("rejects dot package path components", func() {
+		Expect(validatePathComponent("package name", ".")).To(MatchError(`package name "." must be a single path component`))
+		Expect(validatePathComponent("package version", ".")).To(MatchError(`package version "." must be a single path component`))
+	})
+})
+
+var _ = Describe("log paths", func() {
+	var (
+		root   string
+		layout Layout
+		cfg    config.Config
+	)
+
+	BeforeEach(func() {
+		root = GinkgoT().TempDir()
+		layout = DefaultLayout(root)
+		cfg = config.Config{PackageName: "driver", PackageVersion: "1.2.3"}
+	})
+
+	It("uses UTC and preserves a relative step hierarchy", func() {
+		zone := time.FixedZone("test", 2*60*60)
+		at := time.Date(2026, time.June, 30, 12, 34, 56, 0, zone)
+
+		path, err := layout.LogFilePath(cfg, "scripts/apply.sh", at)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(path).To(Equal(filepath.Join(
+			root,
+			"var", "log", "skyhook", "driver", "1.2.3", "scripts", "apply.sh-2026-06-30-103456.log",
+		)))
+	})
+
+	It("creates the parent directory when preparing a log", func() {
+		path, err := layout.PrepareLogFile(cfg, "scripts/apply.sh", time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC))
+		Expect(err).NotTo(HaveOccurred())
+
+		info, err := os.Stat(filepath.Dir(path))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(info.IsDir()).To(BeTrue())
+	})
+
+	It("derives a literal log selector", func() {
+		pattern, err := layout.LogFilePattern(cfg, "scripts/apply[*?].sh")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(pattern.directory).To(Equal(filepath.Join(root, "var", "log", "skyhook", "driver", "1.2.3", "scripts")))
+		Expect(pattern.prefix).To(Equal("apply[*?].sh-"))
+		Expect(pattern.suffix).To(Equal(".log"))
+	})
+
+	It("rejects paths that escape the package root", func() {
+		_, err := layout.LogFilePath(cfg, "../apply.sh", time.Now())
+		Expect(err).To(MatchError(ContainSubstring(`building log file path for step "../apply.sh": resolving package log path`)))
+		Expect(err).To(MatchError(ContainSubstring("must be relative")))
+	})
+
+	It("adds operation context to package path failures", func() {
+		invalidConfig := cfg
+		invalidConfig.PackageName = "../driver"
+
+		_, err := layout.LogFilePattern(invalidConfig, "apply.sh")
+		Expect(err).To(MatchError(ContainSubstring(`building log file pattern for step "apply.sh": resolving package log path`)))
+
+		_, err = layout.PrepareLogFile(invalidConfig, "apply.sh", time.Now())
+		Expect(err).To(MatchError(ContainSubstring(`preparing log file for step "apply.sh": resolving log file path`)))
+
+		_, err = layout.packageLogDir(invalidConfig, "apply.sh")
+		Expect(err).To(MatchError(ContainSubstring(`building package log path for step "apply.sh": validating package path`)))
+	})
+
+	It("requires an explicit timestamp", func() {
+		_, err := layout.LogFilePath(cfg, "apply.sh", time.Time{})
+		Expect(err).To(MatchError("log timestamp must not be zero"))
+	})
+})

--- a/agent/go/internal/flags/logs.go
+++ b/agent/go/internal/flags/logs.go
@@ -1,0 +1,90 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package flags
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+const DefaultLogRetention = 5
+
+type logCandidate struct {
+	path      string
+	timestamp time.Time
+}
+
+// CleanupOldLogs removes all but the newest keep regular files matching the
+// literal filename shape. Files with equal timestamps are ordered by path so
+// retention is deterministic.
+func CleanupOldLogs(logFiles LogFiles, keep int) error {
+	if keep < 0 {
+		return fmt.Errorf("log retention must not be negative: %d", keep)
+	}
+	entries, err := os.ReadDir(logFiles.directory)
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("reading log directory %q: %w", logFiles.directory, err)
+	}
+
+	files := make([]logCandidate, 0, len(entries))
+	for _, entry := range entries {
+		name := entry.Name()
+		if !strings.HasPrefix(name, logFiles.prefix) || !strings.HasSuffix(name, logFiles.suffix) {
+			continue
+		}
+		timestamp := strings.TrimSuffix(strings.TrimPrefix(name, logFiles.prefix), logFiles.suffix)
+		parsedTimestamp, err := time.Parse(logTimeFormat, timestamp)
+		if err != nil {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return fmt.Errorf("stating log file %q: %w", filepath.Join(logFiles.directory, name), err)
+		}
+		if !info.Mode().IsRegular() {
+			continue
+		}
+		files = append(files, logCandidate{
+			path:      filepath.Join(logFiles.directory, name),
+			timestamp: parsedTimestamp,
+		})
+	}
+
+	sort.Slice(files, func(i, j int) bool {
+		if files[i].timestamp.Equal(files[j].timestamp) {
+			return files[i].path < files[j].path
+		}
+		return files[i].timestamp.After(files[j].timestamp)
+	})
+	for _, file := range files[min(keep, len(files)):] {
+		if err := os.Remove(file.path); err != nil {
+			return fmt.Errorf("removing old log %q: %w", file.path, err)
+		}
+	}
+	return nil
+}

--- a/agent/go/internal/flags/logs_test.go
+++ b/agent/go/internal/flags/logs_test.go
@@ -1,0 +1,76 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package flags
+
+import (
+	"os"
+	"path/filepath"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/NVIDIA/nodewright/agent/internal/config"
+)
+
+var _ = Describe("CleanupOldLogs", func() {
+	It("keeps the newest filename timestamps for a literal step path", func() {
+		root := GinkgoT().TempDir()
+		layout := DefaultLayout(root)
+		cfg := config.Config{PackageName: "driver", PackageVersion: "1.2.3"}
+		stepPath := "scripts/apply[*?].sh"
+		logFiles, err := layout.LogFilePattern(cfg, stepPath)
+		Expect(err).NotTo(HaveOccurred())
+		base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+		creationOrder := []int{5, 6, 7, 8, 9, 0, 1, 2, 3, 4}
+		paths := make([]string, len(creationOrder))
+		for _, second := range creationOrder {
+			path, err := layout.LogFilePath(cfg, stepPath, base.Add(time.Duration(second)*time.Second))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(os.MkdirAll(filepath.Dir(path), 0o755)).To(Succeed())
+			Expect(os.WriteFile(path, []byte("log"), 0o600)).To(Succeed())
+			paths[second] = path
+		}
+		unrelated := filepath.Join(logFiles.directory, "applyX.sh-2026-01-01-000000.log")
+		malformed := filepath.Join(logFiles.directory, logFiles.prefix+"not-a-timestamp"+logFiles.suffix)
+		Expect(os.WriteFile(unrelated, nil, 0o600)).To(Succeed())
+		Expect(os.WriteFile(malformed, nil, 0o600)).To(Succeed())
+
+		Expect(CleanupOldLogs(logFiles, DefaultLogRetention)).To(Succeed())
+		for _, path := range paths[:5] {
+			Expect(path).NotTo(BeAnExistingFile())
+		}
+		for _, path := range paths[5:] {
+			Expect(path).To(BeAnExistingFile())
+		}
+		Expect(unrelated).To(BeAnExistingFile())
+		Expect(malformed).To(BeAnExistingFile())
+	})
+
+	It("does nothing when no files match", func() {
+		layout := DefaultLayout(GinkgoT().TempDir())
+		logFiles, err := layout.LogFilePattern(config.Config{PackageName: "driver", PackageVersion: "1.2.3"}, "apply.sh")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(CleanupOldLogs(logFiles, DefaultLogRetention)).To(Succeed())
+	})
+
+	It("rejects negative retention", func() {
+		Expect(CleanupOldLogs(LogFiles{}, -1)).To(MatchError("log retention must not be negative: -1"))
+	})
+})

--- a/agent/go/internal/step/regular_step.go
+++ b/agent/go/internal/step/regular_step.go
@@ -19,6 +19,8 @@
 package step
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 )
@@ -32,17 +34,18 @@ import (
 // Returncodes to []int{0}, Env to map[string]string{}, and Idempotence to Auto.
 // NewRegularStep additionally defaults OnHost to true.
 //
-// ScriptPath carries the json:"path" wire name; the field is named
-// distinctly so RegularStep can expose Path() to satisfy Step.
+// ScriptPath carries the json:"path" wire name and IdempotenceMode the
+// json:"idempotence" wire name; both fields are named distinctly so
+// RegularStep can expose Path() and Idempotence() to satisfy Step.
 type RegularStep struct {
-	Name        string            `json:"name"`
-	ScriptPath  string            `json:"path"`
-	Arguments   []string          `json:"arguments"`
-	Returncodes []int             `json:"returncodes"`
-	OnHost      bool              `json:"on_host"`
-	Idempotence Idempotence       `json:"idempotence"`
-	UpgradeStep bool              `json:"upgrade_step"`
-	Env         map[string]string `json:"env,omitempty"`
+	Name            string            `json:"name"`
+	ScriptPath      string            `json:"path"`
+	Arguments       []string          `json:"arguments"`
+	Returncodes     []int             `json:"returncodes"`
+	OnHost          bool              `json:"on_host"`
+	IdempotenceMode Idempotence       `json:"idempotence"`
+	UpgradeStep     bool              `json:"upgrade_step"`
+	Env             map[string]string `json:"env,omitempty"`
 
 	// RequiresInterrupt round-trips via the wire as "requires_interrupt",
 	// emitted only when true; it stays schema-valid because the step schema
@@ -54,6 +57,45 @@ var _ Step = RegularStep{}
 
 // Path returns the step's script path, relative to the package root.
 func (s RegularStep) Path() string { return s.ScriptPath }
+
+// Idempotence reports how the agent treats re-runs of the step.
+func (s RegularStep) Idempotence() Idempotence { return s.IdempotenceMode }
+
+// Fingerprint returns a stable SHA-256 hex digest of the step's
+// execution-relevant inputs. Nil and empty arguments, return codes, and
+// env hash identically so hand-constructed and decoded steps agree.
+func (s RegularStep) Fingerprint() (string, error) {
+	arguments := s.Arguments
+	if arguments == nil {
+		arguments = []string{}
+	}
+	returnCodes := s.Returncodes
+	if returnCodes == nil {
+		returnCodes = []int{}
+	}
+	env := s.Env
+	if env == nil {
+		env = map[string]string{}
+	}
+	payload, err := json.Marshal(struct {
+		Path        string            `json:"path"`
+		Arguments   []string          `json:"arguments"`
+		ReturnCodes []int             `json:"returnCodes"`
+		Env         map[string]string `json:"env"`
+		OnHost      bool              `json:"onHost"`
+	}{
+		Path:        s.ScriptPath,
+		Arguments:   arguments,
+		ReturnCodes: returnCodes,
+		Env:         env,
+		OnHost:      s.OnHost,
+	})
+	if err != nil {
+		return "", fmt.Errorf("encoding step fingerprint: %w", err)
+	}
+	sum := sha256.Sum256(payload)
+	return hex.EncodeToString(sum[:]), nil
+}
 
 // Encode writes the JSON wire form with upgrade_step:false. Defaults
 // are applied to a local copy so the caller's value is not mutated;
@@ -71,7 +113,7 @@ func (s RegularStep) Encode() ([]byte, error) {
 // delegates here for defaulting, validation, and marshaling.
 func (s RegularStep) encode() ([]byte, error) {
 	s.applyDefaults()
-	if err := s.Idempotence.Validate(); err != nil {
+	if err := s.IdempotenceMode.Validate(); err != nil {
 		return nil, fmt.Errorf("validate idempotence: %w", err)
 	}
 	out, err := json.Marshal(s)
@@ -111,7 +153,7 @@ func WithOnHost(onHost bool) RegularStepOption {
 
 // WithIdempotence overrides the default Idempotence=Auto.
 func WithIdempotence(i Idempotence) RegularStepOption {
-	return func(s *RegularStep) { s.Idempotence = i }
+	return func(s *RegularStep) { s.IdempotenceMode = i }
 }
 
 // WithRequiresInterrupt sets the requires_interrupt flag.
@@ -154,7 +196,7 @@ func (s *RegularStep) applyDefaults() {
 	if s.Env == nil {
 		s.Env = map[string]string{}
 	}
-	if s.Idempotence == "" {
-		s.Idempotence = Auto
+	if s.IdempotenceMode == "" {
+		s.IdempotenceMode = Auto
 	}
 }

--- a/agent/go/internal/step/regular_step_test.go
+++ b/agent/go/internal/step/regular_step_test.go
@@ -57,7 +57,7 @@ var _ = Describe("RegularStep.applyDefaults", func() {
 	It("defaults idempotence to Auto", func() {
 		s := RegularStep{ScriptPath: "foo.sh"}
 		s.applyDefaults()
-		Expect(s.Idempotence).To(Equal(Auto))
+		Expect(s.Idempotence()).To(Equal(Auto))
 	})
 
 	It("does not change OnHost (the constructor seeds it; the schema requires it)", func() {
@@ -81,11 +81,11 @@ var _ = Describe("RegularStep.Encode", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(s.Name).To(Equal(""), "Encode received a value copy; the caller's RegularStep must be untouched")
-		Expect(s.Idempotence).To(Equal(Idempotence("")))
+		Expect(s.Idempotence()).To(Equal(Idempotence("")))
 	})
 
 	It("rejects an explicitly invalid idempotence value", func() {
-		s := RegularStep{ScriptPath: "foo.sh", Idempotence: "bogus"}
+		s := RegularStep{ScriptPath: "foo.sh", IdempotenceMode: "bogus"}
 		_, err := s.Encode()
 		Expect(err).To(MatchError(ContainSubstring("bogus is not a valid idempotence value")))
 	})
@@ -100,7 +100,7 @@ var _ = Describe("NewRegularStep", func() {
 		Expect(s.Returncodes).To(Equal([]int{0}))
 		Expect(s.Env).To(Equal(map[string]string{}))
 		Expect(s.OnHost).To(BeTrue())
-		Expect(s.Idempotence).To(Equal(Auto))
+		Expect(s.Idempotence()).To(Equal(Auto))
 		Expect(s.RequiresInterrupt).To(BeFalse())
 	})
 
@@ -130,7 +130,7 @@ var _ = Describe("NewRegularStep", func() {
 		Expect(s.Returncodes).To(Equal([]int{0, 2}))
 		Expect(s.Env).To(Equal(map[string]string{"K": "V"}))
 		Expect(s.OnHost).To(BeFalse())
-		Expect(s.Idempotence).To(Equal(Disabled))
+		Expect(s.Idempotence()).To(Equal(Disabled))
 		Expect(s.RequiresInterrupt).To(BeTrue())
 	})
 
@@ -142,6 +142,6 @@ var _ = Describe("NewRegularStep", func() {
 		round, err := Decode(dumped)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(round.(RegularStep).ScriptPath).To(Equal("foo.sh"))
-		Expect(round.(RegularStep).Idempotence).To(Equal(Disabled))
+		Expect(round.(RegularStep).Idempotence()).To(Equal(Disabled))
 	})
 })

--- a/agent/go/internal/step/step.go
+++ b/agent/go/internal/step/step.go
@@ -34,6 +34,14 @@ type Step interface {
 
 	// Path is the step's script path, relative to the package root.
 	Path() string
+
+	// Fingerprint is a stable SHA-256 hex digest of the step's
+	// execution-relevant inputs (path, arguments, return codes, env,
+	// host execution); changing any of them changes the fingerprint.
+	Fingerprint() (string, error)
+
+	// Idempotence reports how the agent treats re-runs of the step.
+	Idempotence() Idempotence
 }
 
 // Idempotence controls how the agent treats step re-runs.

--- a/agent/go/internal/step/step_test.go
+++ b/agent/go/internal/step/step_test.go
@@ -49,13 +49,13 @@ var _ = Describe("Step interface", func() {
 
 	It("promotes RegularStep fields to UpgradeStep through embedding", func() {
 		rs := RegularStep{
-			Name:        "explicit-name",
-			ScriptPath:  "foo.sh",
-			Arguments:   []string{},
-			Returncodes: []int{0},
-			Env:         map[string]string{"K": "V"},
-			OnHost:      true,
-			Idempotence: Auto,
+			Name:            "explicit-name",
+			ScriptPath:      "foo.sh",
+			Arguments:       []string{},
+			Returncodes:     []int{0},
+			Env:             map[string]string{"K": "V"},
+			OnHost:          true,
+			IdempotenceMode: Auto,
 		}
 		u := UpgradeStep{RegularStep: rs}
 
@@ -65,7 +65,7 @@ var _ = Describe("Step interface", func() {
 		Expect(u.Returncodes).To(Equal([]int{0}))
 		Expect(u.Env).To(Equal(map[string]string{"K": "V"}))
 		Expect(u.OnHost).To(BeTrue())
-		Expect(u.Idempotence).To(Equal(Auto))
+		Expect(u.Idempotence()).To(Equal(Auto))
 		Expect(u.RequiresInterrupt).To(BeFalse())
 	})
 
@@ -115,7 +115,7 @@ var _ = Describe("Decode", func() {
 		Expect(rs.Returncodes).To(Equal([]int{0}))
 		Expect(rs.OnHost).To(BeTrue())
 		Expect(rs.Env).To(Equal(map[string]string{}))
-		Expect(rs.Idempotence).To(Equal(Auto))
+		Expect(rs.Idempotence()).To(Equal(Auto))
 	})
 
 	It("leaves on_host at its zero value when absent", func() {
@@ -129,7 +129,7 @@ var _ = Describe("Decode", func() {
 		data := []byte(`{"path":"foo.sh","idempotence":true,"upgrade_step":false}`)
 		s, err := Decode(data)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(s.(RegularStep).Idempotence).To(Equal(Disabled))
+		Expect(s.(RegularStep).Idempotence()).To(Equal(Disabled))
 	})
 
 	It("returns a RegularStep when upgrade_step is false", func() {
@@ -160,12 +160,12 @@ var _ = Describe("Decode", func() {
 var _ = Describe("Encode/Decode round-trip", func() {
 	It("round-trips idempotence and preserves RegularStep type", func() {
 		start := RegularStep{
-			Name:        "foo",
-			ScriptPath:  "foo",
-			Arguments:   []string{},
-			Returncodes: []int{0},
-			OnHost:      true,
-			Idempotence: Disabled,
+			Name:            "foo",
+			ScriptPath:      "foo",
+			Arguments:       []string{},
+			Returncodes:     []int{0},
+			OnHost:          true,
+			IdempotenceMode: Disabled,
 		}
 
 		dumped, err := start.Encode()
@@ -176,7 +176,7 @@ var _ = Describe("Encode/Decode round-trip", func() {
 
 		rs, ok := end.(RegularStep)
 		Expect(ok).To(BeTrue(), "expected RegularStep, got %T", end)
-		Expect(rs.Idempotence).To(Equal(Disabled))
+		Expect(rs.Idempotence()).To(Equal(Disabled))
 	})
 
 	It("preserves UpgradeStep type through the round-trip", func() {
@@ -230,19 +230,19 @@ var _ = Describe("Encode/Decode round-trip", func() {
 		Expect(rs.Name).To(Equal("foo.sh"))
 		Expect(rs.Arguments).To(Equal([]string{}))
 		Expect(rs.Returncodes).To(Equal([]int{0}))
-		Expect(rs.Idempotence).To(Equal(Auto))
+		Expect(rs.Idempotence()).To(Equal(Auto))
 	})
 })
 
 var _ = Describe("Encode env handling", func() {
 	It("omits env when empty and includes it when populated", func() {
 		noEnv := RegularStep{
-			Name:        "a",
-			ScriptPath:  "a",
-			Arguments:   []string{},
-			Returncodes: []int{0},
-			OnHost:      true,
-			Idempotence: Auto,
+			Name:            "a",
+			ScriptPath:      "a",
+			Arguments:       []string{},
+			Returncodes:     []int{0},
+			OnHost:          true,
+			IdempotenceMode: Auto,
 		}
 		noEnvJSON, err := noEnv.Encode()
 		Expect(err).NotTo(HaveOccurred())

--- a/agent/go/internal/step/upgrade_step_test.go
+++ b/agent/go/internal/step/upgrade_step_test.go
@@ -57,7 +57,7 @@ var _ = Describe("NewUpgradeStep", func() {
 		Expect(u.Returncodes).To(Equal([]int{0, 2}))
 		Expect(u.Env).To(Equal(map[string]string{"K": "V"}))
 		Expect(u.OnHost).To(BeFalse())
-		Expect(u.Idempotence).To(Equal(Disabled))
+		Expect(u.Idempotence()).To(Equal(Disabled))
 	})
 })
 
@@ -82,12 +82,12 @@ var _ = Describe("UpgradeStep.Validate", func() {
 var _ = Describe("UpgradeStep fields", func() {
 	It("promote field access from the embedded RegularStep", func() {
 		rs := RegularStep{
-			Name:        "explicit",
-			ScriptPath:  "upgrade.sh",
-			Returncodes: []int{0},
-			Env:         map[string]string{"K": "V"},
-			OnHost:      true,
-			Idempotence: Disabled,
+			Name:            "explicit",
+			ScriptPath:      "upgrade.sh",
+			Returncodes:     []int{0},
+			Env:             map[string]string{"K": "V"},
+			OnHost:          true,
+			IdempotenceMode: Disabled,
 		}
 		u := UpgradeStep{RegularStep: rs}
 
@@ -96,7 +96,7 @@ var _ = Describe("UpgradeStep fields", func() {
 		Expect(u.Returncodes).To(Equal([]int{0}))
 		Expect(u.Env).To(Equal(map[string]string{"K": "V"}))
 		Expect(u.OnHost).To(BeTrue())
-		Expect(u.Idempotence).To(Equal(Disabled))
+		Expect(u.Idempotence()).To(Equal(Disabled))
 	})
 })
 


### PR DESCRIPTION
# feat(agent): add filesystem flag and log helpers

## Summary

This PR adds the Go agent's host-path, completion-flag, log-path, and log-retention helpers in a new `internal/flags` package.

It is the filesystem/flags half of #215. Package history is intentionally handled in a separate PR so the persistence and corruption-recovery behavior can be reviewed independently.

Relates to #215

### What changed

- Added a configurable `flags.Layout` for resolving state, flag, history, copied-step, and log directories beneath the mounted host root.
- Added deterministic UTC log filenames and a matching glob helper, with timestamps passed explicitly by callers.
- Added `flags.Store` for:
  - deriving per-step completion-flag paths;
  - writing step and control flags with contained-path validation;
  - evaluating flags into structured run/skip decisions;
  - returning errors instead of printing from filesystem helpers.
- Added deterministic log cleanup that retains the newest configured number of regular files (`5` by default).
- Added path validation to prevent package names, versions, and step paths from escaping their intended host directories.
- Added focused Ginkgo coverage for path construction, fingerprint stability, input changes, flag policy, control flags, invalid paths, and log retention.

### Go-native design choices

This package introduces two new conventions because the Go agent did not yet have an established filesystem seam:

- `Layout` receives resolved roots from process configuration instead of reading environment variables inside helpers. This keeps path construction deterministic and easy to test.
- `Store` owns flag I/O and returns a `Decision` with a typed `Reason`. The eventual controller can decide how to log each outcome without coupling this low-level package to Python's print strings.

Times are explicit inputs rather than hidden `time.Now()` calls, filesystem failures retain operation and path context, and flag writes use private file permissions.

### Compatibility note

The completion marker is intentionally Go-native rather than byte-compatible with the Python agent. It hashes a canonical JSON representation of the step path, arguments, and accepted return codes with SHA-256, producing a path-safe hexadecimal filename.

As a result, completion flags created by the Python agent are not recognized by this implementation. The first Go-agent execution after cutover will treat those steps as incomplete and run them again. This is deliberate for the rewrite and avoids carrying Python list-`repr` semantics into the Go API.

The host directory roots remain `/etc/skyhook` and `/var/log/skyhook` by default, while allowing the caller to supply different resolved roots.

### Testing

- `make unit-tests` — 142 specs passed, including 30 flags specs
- `make lint` — 0 issues
- `make vet`

### Documentation

No user documentation changes are included because these helpers are not wired into the agent executable yet. The controller/entrypoint integration will land separately and will document any user-visible behavior at that point.

## Checklist

- [X] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/skyhook/blob/main/CONTRIBUTING.md).
- [X] My commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
