### PR TITLE
feat(agent): add package history store

### DIFF
--- a/agent/go/internal/history/history.go
+++ b/agent/go/internal/history/history.go
@@ -1,0 +1,260 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package history
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/NVIDIA/nodewright/agent/internal/config"
+	"github.com/NVIDIA/nodewright/agent/internal/stage"
+)
+
+const (
+	UnknownVersion       = "unknown"
+	UninstalledVersion   = "uninstalled"
+	CurrentVersionEnv    = "CURRENT_VERSION"
+	PreviousVersionEnv   = "PREVIOUS_VERSION"
+	historyDirectoryMode = 0o755
+	historyFileMode      = 0o600
+	historyEntryLimit    = 100
+)
+
+// LedgerEntry is one recorded version transition.
+type LedgerEntry struct {
+	Version string    `json:"version"`
+	Time    time.Time `json:"time"`
+}
+
+// Ledger is the persisted history document for one package.
+type Ledger struct {
+	CurrentVersion string        `json:"current-version"`
+	Entries        []LedgerEntry `json:"history"`
+}
+
+// Versions is the current package version and the previously recorded host
+// version. It is returned to callers instead of mutating a step in place.
+type Versions struct {
+	Current  string
+	Previous string
+}
+
+func (v Versions) Environment() map[string]string {
+	return map[string]string{
+		CurrentVersionEnv:  v.Current,
+		PreviousVersionEnv: v.Previous,
+	}
+}
+
+func (v Versions) UpgradeArguments() []string {
+	return []string{v.Previous, v.Current}
+}
+
+// Store records completed version transitions for one package and reports the
+// versions a step should receive.
+type Store interface {
+	Read() (Versions, error)
+	Record(completedStage stage.Stage, at time.Time) error
+}
+
+// NewStore returns the file-backed history store. The implementation is
+// unexported so downstream consumers depend on the Store interface.
+func NewStore(dir string, cfg config.Config, logger *slog.Logger) (Store, error) {
+	s, err := newFileStore(dir, cfg, logger)
+	if err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+// fileStore keeps one package's install history in a JSON ledger file.
+type fileStore struct {
+	path        string
+	packageName string
+	version     string
+	logger      *slog.Logger
+}
+
+var _ Store = (*fileStore)(nil)
+
+// newFileStore returns a store for the package described by cfg, keeping its
+// ledger under dir. Package identity is validated once here so later reads
+// and writes cannot escape dir or record an unusable version.
+func newFileStore(dir string, cfg config.Config, logger *slog.Logger) (*fileStore, error) {
+	name := cfg.PackageName
+	if name == "" || !filepath.IsLocal(name) || filepath.Base(name) != name {
+		return nil, fmt.Errorf("package name %q must be a single path component", name)
+	}
+	if cfg.PackageVersion == "" {
+		return nil, errors.New("package version must not be empty")
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &fileStore{
+		path:        filepath.Join(dir, name+".json"),
+		packageName: name,
+		version:     cfg.PackageVersion,
+		logger:      logger,
+	}, nil
+}
+
+// Path returns the ledger path for this package.
+func (s *fileStore) Path() string {
+	return s.path
+}
+
+// Read returns the versions a step should receive. A package with no usable
+// history is treated as an unknown prior installation.
+func (s *fileStore) Read() (Versions, error) {
+	ledger, err := s.load()
+	if err != nil {
+		return Versions{}, fmt.Errorf("reading versions for package %q: %w", s.packageName, err)
+	}
+	return Versions{Current: s.version, Previous: ledger.CurrentVersion}, nil
+}
+
+// Record prepends a completed version transition to the package ledger.
+// UninstallCheck records the package as uninstalled; every other valid stage
+// records the configured package version.
+func (s *fileStore) Record(completedStage stage.Stage, at time.Time) error {
+	if _, err := stage.ParseStage(string(completedStage)); err != nil {
+		return fmt.Errorf("recording history for package %q: validating completed stage: %w", s.packageName, err)
+	}
+	if at.IsZero() {
+		return errors.New("history timestamp must not be zero")
+	}
+
+	ledger, err := s.load()
+	if err != nil {
+		return fmt.Errorf("recording history for package %q: %w", s.packageName, err)
+	}
+	version := s.version
+	if completedStage == stage.UninstallCheck {
+		version = UninstalledVersion
+	}
+	ledger.CurrentVersion = version
+	ledger.Entries = append([]LedgerEntry{{Version: version, Time: at.UTC()}}, ledger.Entries...)
+	if len(ledger.Entries) > historyEntryLimit {
+		ledger.Entries = ledger.Entries[:historyEntryLimit]
+	}
+
+	if err := os.MkdirAll(filepath.Dir(s.path), historyDirectoryMode); err != nil {
+		return fmt.Errorf("creating history directory %q: %w", filepath.Dir(s.path), err)
+	}
+	data, err := json.MarshalIndent(ledger, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encoding history for package %q: %w", s.packageName, err)
+	}
+	data = append(data, '\n')
+	if err := writeAtomic(s.path, data); err != nil {
+		return fmt.Errorf("writing history for package %q: %w", s.packageName, err)
+	}
+	return nil
+}
+
+func (s *fileStore) load() (Ledger, error) {
+	data, err := os.ReadFile(s.path)
+	if errors.Is(err, fs.ErrNotExist) {
+		s.logger.Info("package history does not exist", "package", s.packageName, "path", s.path)
+		return Ledger{CurrentVersion: UnknownVersion, Entries: []LedgerEntry{}}, nil
+	}
+	if err != nil {
+		return Ledger{}, fmt.Errorf("reading history %q: %w", s.path, err)
+	}
+
+	var result Ledger
+	if err := json.Unmarshal(data, &result); err != nil {
+		backup := s.path + ".backup"
+		// Preserve the damaged bytes and continue from an unknown version so a
+		// corrupt file cannot permanently block package execution on this node.
+		if renameErr := os.Rename(s.path, backup); renameErr != nil {
+			return Ledger{}, fmt.Errorf("moving corrupt history %q to %q: %w", s.path, backup, renameErr)
+		}
+		s.logger.Error(
+			"moved corrupt package history aside",
+			"package", s.packageName,
+			"path", s.path,
+			"backup", backup,
+			"error", err,
+		)
+		return Ledger{CurrentVersion: UnknownVersion, Entries: []LedgerEntry{}}, nil
+	}
+	if result.CurrentVersion == "" {
+		result.CurrentVersion = UnknownVersion
+	}
+	if result.Entries == nil {
+		result.Entries = []LedgerEntry{}
+	}
+	return result, nil
+}
+
+func writeAtomic(path string, data []byte) (retErr error) {
+	tmp, err := os.CreateTemp(filepath.Dir(path), "."+filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("creating temporary history file: %w", err)
+	}
+
+	tmpPath := tmp.Name()
+	defer func() {
+		if err := tmp.Close(); err != nil && !errors.Is(err, os.ErrClosed) && retErr == nil {
+			retErr = fmt.Errorf("closing temporary history file %q: %w", tmpPath, err)
+		}
+		if err := os.Remove(tmpPath); err != nil && !errors.Is(err, fs.ErrNotExist) && retErr == nil {
+			retErr = fmt.Errorf("removing temporary history file %q: %w", tmpPath, err)
+		}
+	}()
+
+	if err := tmp.Chmod(historyFileMode); err != nil {
+		return fmt.Errorf("setting permissions on temporary history file %q: %w", tmpPath, err)
+	}
+	if _, err := tmp.Write(data); err != nil {
+		return fmt.Errorf("writing temporary history file %q: %w", tmpPath, err)
+	}
+	if err := tmp.Sync(); err != nil {
+		return fmt.Errorf("syncing temporary history file %q: %w", tmpPath, err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("closing temporary history file %q: %w", tmpPath, err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("replacing history file %q: %w", path, err)
+	}
+	// The rename is only durable once the parent directory's metadata reaches
+	// disk; without this sync a crash after a successful Record could lose the
+	// ledger, and this file exists to survive reboots.
+	dir, err := os.Open(filepath.Dir(path))
+	if err != nil {
+		return fmt.Errorf("opening history directory %q: %w", filepath.Dir(path), err)
+	}
+	if err := dir.Sync(); err != nil {
+		_ = dir.Close()
+		return fmt.Errorf("syncing history directory %q: %w", filepath.Dir(path), err)
+	}
+	if err := dir.Close(); err != nil {
+		return fmt.Errorf("closing history directory %q: %w", filepath.Dir(path), err)
+	}
+	return nil
+}

--- a/agent/go/internal/history/history_test.go
+++ b/agent/go/internal/history/history_test.go
@@ -1,0 +1,242 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package history
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/NVIDIA/nodewright/agent/internal/config"
+	"github.com/NVIDIA/nodewright/agent/internal/stage"
+)
+
+func TestHistory(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "History Suite")
+}
+
+var _ = Describe("history store", func() {
+	var (
+		dir    string
+		store  *fileStore
+		logger *slog.Logger
+		cfg    config.Config
+		now    time.Time
+	)
+
+	BeforeEach(func() {
+		dir = filepath.Join(GinkgoT().TempDir(), "history")
+		logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+		cfg = config.Config{PackageName: "driver", PackageVersion: "1.2.3"}
+		now = time.Date(2026, time.June, 30, 12, 34, 56, 123456789, time.FixedZone("test", -7*60*60))
+
+		var err error
+		store, err = newFileStore(dir, cfg, logger)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("constructs the store behind its interface", func() {
+		s, err := NewStore(dir, cfg, logger)
+		Expect(err).NotTo(HaveOccurred())
+		versions, err := s.Read()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(versions).To(Equal(Versions{Current: "1.2.3", Previous: UnknownVersion}))
+
+		cfg.PackageVersion = ""
+		s, err = NewStore(dir, cfg, logger)
+		Expect(err).To(MatchError("package version must not be empty"))
+		Expect(s).To(BeNil())
+	})
+
+	It("returns unknown without creating a missing history file", func() {
+		versions, err := store.Read()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(versions).To(Equal(Versions{Current: "1.2.3", Previous: UnknownVersion}))
+		Expect(versions.Environment()).To(Equal(map[string]string{
+			CurrentVersionEnv:  "1.2.3",
+			PreviousVersionEnv: UnknownVersion,
+		}))
+		Expect(versions.UpgradeArguments()).To(Equal([]string{UnknownVersion, "1.2.3"}))
+		Expect(dir).NotTo(BeADirectory())
+	})
+
+	It("reads an existing ledger", func() {
+		Expect(os.MkdirAll(dir, 0o755)).To(Succeed())
+		data := `{
+  "current-version": "1.1.0",
+  "history": [{"version":"1.1.0","time":"2024-08-28T14:33:20.123456+00:00"}]
+}`
+		Expect(os.WriteFile(store.Path(), []byte(data), 0o600)).To(Succeed())
+
+		versions, err := store.Read()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(versions).To(Equal(Versions{Current: "1.2.3", Previous: "1.1.0"}))
+	})
+
+	It("treats empty or missing current versions as unknown", func() {
+		Expect(os.MkdirAll(dir, 0o755)).To(Succeed())
+
+		for _, data := range []string{`{}`, `{"current-version":"","history":[]}`} {
+			Expect(os.WriteFile(store.Path(), []byte(data), 0o600)).To(Succeed())
+			loaded, err := store.load()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(loaded.CurrentVersion).To(Equal(UnknownVersion))
+			Expect(loaded.Entries).To(Equal([]LedgerEntry{}))
+
+			versions, err := store.Read()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(versions.Previous).To(Equal(UnknownVersion))
+		}
+	})
+
+	It("moves corrupt history aside and returns unknown", func() {
+		Expect(os.MkdirAll(dir, 0o755)).To(Succeed())
+		Expect(os.WriteFile(store.Path(), []byte("{"), 0o600)).To(Succeed())
+
+		versions, err := store.Read()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(versions.Previous).To(Equal(UnknownVersion))
+		Expect(store.Path()).NotTo(BeAnExistingFile())
+		backup, err := os.ReadFile(store.Path() + ".backup")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(backup)).To(Equal("{"))
+	})
+
+	It("records a new installed version", func() {
+		Expect(store.Record(stage.ApplyCheck, now)).To(Succeed())
+
+		data, err := os.ReadFile(store.Path())
+		Expect(err).NotTo(HaveOccurred())
+		var saved Ledger
+		Expect(json.Unmarshal(data, &saved)).To(Succeed())
+		Expect(saved.CurrentVersion).To(Equal("1.2.3"))
+		Expect(saved.Entries).To(Equal([]LedgerEntry{{Version: "1.2.3", Time: now.UTC()}}))
+
+		info, err := os.Stat(store.Path())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(info.Mode().Perm()).To(Equal(os.FileMode(0o600)))
+
+		entries, err := os.ReadDir(dir)
+		Expect(err).NotTo(HaveOccurred())
+		names := make([]string, 0, len(entries))
+		for _, entry := range entries {
+			names = append(names, entry.Name())
+		}
+		Expect(names).To(ConsistOf("driver.json"), "no temporary or stray files may remain after Record")
+	})
+
+	It("prepends entries without losing prior history", func() {
+		oldConfig := cfg
+		oldConfig.PackageVersion = "1.1.0"
+		oldStore, err := newFileStore(dir, oldConfig, logger)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(oldStore.Record(stage.ApplyCheck, now.Add(-time.Hour))).To(Succeed())
+		Expect(store.Record(stage.UpgradeCheck, now)).To(Succeed())
+
+		data, err := os.ReadFile(store.Path())
+		Expect(err).NotTo(HaveOccurred())
+		var saved Ledger
+		Expect(json.Unmarshal(data, &saved)).To(Succeed())
+		Expect(saved.CurrentVersion).To(Equal("1.2.3"))
+		Expect(saved.Entries).To(Equal([]LedgerEntry{
+			{Version: "1.2.3", Time: now.UTC()},
+			{Version: "1.1.0", Time: now.Add(-time.Hour).UTC()},
+		}))
+	})
+
+	It("retains only the most recent history entries", func() {
+		entries := make([]LedgerEntry, historyEntryLimit)
+		for i := range entries {
+			entries[i] = LedgerEntry{Version: "old", Time: now.Add(-time.Duration(i+1) * time.Hour).UTC()}
+		}
+		Expect(os.MkdirAll(dir, 0o755)).To(Succeed())
+		data, err := json.Marshal(Ledger{CurrentVersion: "old", Entries: entries})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(os.WriteFile(store.Path(), data, 0o600)).To(Succeed())
+
+		Expect(store.Record(stage.UpgradeCheck, now)).To(Succeed())
+		data, err = os.ReadFile(store.Path())
+		Expect(err).NotTo(HaveOccurred())
+		var saved Ledger
+		Expect(json.Unmarshal(data, &saved)).To(Succeed())
+		Expect(saved.Entries).To(HaveLen(historyEntryLimit))
+		Expect(saved.Entries[0]).To(Equal(LedgerEntry{Version: cfg.PackageVersion, Time: now.UTC()}))
+		Expect(saved.Entries[1:]).To(Equal(entries[:historyEntryLimit-1]))
+	})
+
+	It("records uninstall completion distinctly", func() {
+		Expect(store.Record(stage.UninstallCheck, now)).To(Succeed())
+
+		versions, err := store.Read()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(versions.Previous).To(Equal(UninstalledVersion))
+	})
+
+	It("recovers corrupt history before recording", func() {
+		Expect(os.MkdirAll(dir, 0o755)).To(Succeed())
+		Expect(os.WriteFile(store.Path(), []byte("{"), 0o600)).To(Succeed())
+
+		Expect(store.Record(stage.ApplyCheck, now)).To(Succeed())
+		Expect(store.Path() + ".backup").To(BeAnExistingFile())
+		versions, err := store.Read()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(versions.Previous).To(Equal("1.2.3"))
+	})
+
+	It("rejects invalid package identities at construction", func() {
+		invalid := cfg
+		invalid.PackageVersion = ""
+		_, err := newFileStore(dir, invalid, logger)
+		Expect(err).To(MatchError("package version must not be empty"))
+
+		invalid = cfg
+		invalid.PackageName = "../driver"
+		_, err = newFileStore(dir, invalid, logger)
+		Expect(err).To(MatchError(ContainSubstring(`package name "../driver" must be a single path component`)))
+
+		invalid.PackageName = ""
+		_, err = newFileStore(dir, invalid, logger)
+		Expect(err).To(MatchError(ContainSubstring("single path component")))
+		Expect(dir).NotTo(BeADirectory())
+	})
+
+	It("rejects invalid record input before writing", func() {
+		err := store.Record(stage.Stage("bogus"), now)
+		Expect(err).To(MatchError(ContainSubstring(`recording history for package "driver": validating completed stage`)))
+		Expect(err).To(MatchError(ContainSubstring(`unknown stage "bogus"`)))
+		Expect(store.Record(stage.ApplyCheck, time.Time{})).To(MatchError("history timestamp must not be zero"))
+		Expect(dir).NotTo(BeADirectory())
+	})
+
+	It("returns filesystem errors with context", func() {
+		Expect(os.MkdirAll(dir, 0o755)).To(Succeed())
+		Expect(os.Mkdir(store.Path(), 0o755)).To(Succeed())
+
+		_, err := store.Read()
+		Expect(err).To(MatchError(ContainSubstring("reading history")))
+	})
+})


### PR DESCRIPTION
## Description

This PR adds the Go agent's package-history store. The store gives lifecycle steps a consistent view of the package version requested by the current config and the version most recently recorded on the host, without mutating step definitions or keeping process-local state.

Closes #215 

## What changed

### Version inputs

- add a `Versions` value containing the current configured version and the
  previously recorded host version
- expose those versions as `CURRENT_VERSION` and `PREVIOUS_VERSION`
  environment values
- provide upgrade arguments in `[previous, current]` order
- use `unknown` when no usable prior history exists and `uninstalled` after a
  completed uninstall check

### History persistence

- store one JSON ledger per package under the configured history directory
- prepend completed transitions so the newest version remains available as the
  ledger's current version while older entries are preserved
- normalize recorded timestamps to UTC
- write history through a same-directory temporary file, sync and close it,
  then atomically replace the ledger
- create history files with `0600` permissions and history directories with
  `0755` permissions

### Validation and recovery

- reject invalid package names, empty package versions, unknown stages, and
  zero timestamps before writing
- add contextual filesystem errors for failed reads and writes
- move malformed history to a `.backup` file and continue from an unknown
  previous version so corrupt host state does not permanently block package
  execution
- emit structured messages for missing history and corrupt-file recovery

## Test coverage

The history suite covers missing and existing ledgers, ordered version updates, uninstall state, corrupt-history recovery, atomic-write cleanup, file permissions, input validation, and filesystem error propagation.

## Testing

- `make unit-tests`
- `make lint`

## Checklist

- [X] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/skyhook/blob/main/CONTRIBUTING.md).
- [X] My commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
