### PR TITLE
chore: bump Go to 1.26.5 and centralize the Go version in go.mod

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -41,7 +41,7 @@ If a doc above is silent on a question you need to answer, say so explicitly rat
 
 ## Three components, three toolchains
 
-- **`operator/`** — Go controller-manager (controller-runtime, Kubebuilder v4). Go 1.26.4, vendored (`GOFLAGS=-mod=vendor`). Also hosts the CLI (`cmd/cli`) built as a kubectl plugin.
+- **`operator/`** — Go controller-manager (controller-runtime, Kubebuilder v4). Go 1.26.5, vendored (`GOFLAGS=-mod=vendor`). Also hosts the CLI (`cmd/cli`) built as a kubectl plugin.
 - **`agent/skyhook-agent/`** — Python 3.10+ package (hatch-managed). Runs inside every package container; reads `/skyhook-package/config.json` and executes lifecycle steps (apply / config / interrupt / post-interrupt / upgrade / uninstall). Tests via pytest, vendored deps under `agent/vendor/`.
 - **`chart/`** — Helm chart. Generated from `operator/config/` via `helmify` (`make generate-helm`) but hand-edited after; don't regenerate blindly.
 

--- a/.github/workflows/agent-ci.yaml
+++ b/.github/workflows/agent-ci.yaml
@@ -43,7 +43,6 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
-  GO_VERSION: 1.26.4
   PYTHON_VERSION: 3.13
   DEBIAN_VERSION: trixie
   PUSH_TO_REGISTRY: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
@@ -315,10 +314,10 @@ jobs:
           fetch-tags: true
           fetch-depth: 0
       
-      - name: Set up Go ${{ env.GO_VERSION }}
+      - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: operator/go.mod
           cache-dependency-path: operator/go.sum
       
       - name: Log in to the Container registry
@@ -337,7 +336,7 @@ jobs:
 
       - name: Validate KinD node image
         env:
-          K8S_VERSION: ${{ steps.k8s-versions.outputs.kind-node-image-version }}
+          K8S_VERSION: ${{ steps.k8s-versions.outputs.kind-nodeimage }}
         run: |
           cd operator
           make validate-kind-node-image KIND_NODE_IMAGE_VERSION="$K8S_VERSION"
@@ -345,8 +344,8 @@ jobs:
       - name: Create Kubernetes KinD Cluster
         uses: helm/kind-action@v1.14.0
         with:
-          version: ${{ steps.k8s-versions.outputs.kind-binary-version }}
-          node_image: kindest/node:v${{ steps.k8s-versions.outputs.kind-node-image-version }}
+          version: ${{ steps.k8s-versions.outputs.kind-binary }}
+          node_image: kindest/node:v${{ steps.k8s-versions.outputs.kind-nodeimage }}
           config: operator/config/local-dev/kind-config.yaml
           cluster_name: kind
       
@@ -354,8 +353,8 @@ jobs:
         id: cached-binaries
         uses: actions/cache/restore@v5
         with:
-          key: ${{ env.GO_VERSION }}-${{ runner.os }}-${{ runner.arch }}-bin-${{ hashFiles('operator/deps.mk', 'operator/versions.yaml', 'operator/versions.sh') }}
-          restore-keys: ${{ env.GO_VERSION }}-${{ runner.os }}-${{ runner.arch }}-bin-
+          key: ${{ runner.os }}-${{ runner.arch }}-bin-${{ hashFiles('operator/go.mod', 'operator/deps.mk', 'operator/versions.yaml', 'operator/versions.sh') }}
+          restore-keys: ${{ runner.os }}-${{ runner.arch }}-bin-
           path: |
             ${{ github.workspace }}/operator/bin
             ~/.cache/go-build
@@ -370,7 +369,7 @@ jobs:
         if: steps.cached-binaries.outputs.cache-hit != 'true'
         uses: actions/cache/save@v5
         with:
-          key: ${{ env.GO_VERSION }}-${{ runner.os }}-${{ runner.arch }}-bin-${{ hashFiles('operator/deps.mk', 'operator/versions.yaml', 'operator/versions.sh') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-bin-${{ hashFiles('operator/go.mod', 'operator/deps.mk', 'operator/versions.yaml', 'operator/versions.sh') }}
           path: |
             ${{ github.workspace }}/operator/bin
             ~/.cache/go-build

--- a/.github/workflows/agent-go-ci.yaml
+++ b/.github/workflows/agent-go-ci.yaml
@@ -29,19 +29,16 @@ on:
       - agent/go/**
       - .github/workflows/agent-go-ci.yaml
 
-env:
-  GO_VERSION: 1.26.4
-
 jobs:
   test:
     name: Agent Go Unit Tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - name: Set up Go ${{ env.GO_VERSION }}
+      - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: agent/go/go.mod
           cache-dependency-path: agent/go/go.sum
       - name: Run tests
         run: |
@@ -53,10 +50,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - name: Set up Go ${{ env.GO_VERSION }}
+      - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: agent/go/go.mod
           cache-dependency-path: agent/go/go.sum
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v8

--- a/.github/workflows/cli-release.yaml
+++ b/.github/workflows/cli-release.yaml
@@ -23,7 +23,6 @@ on:
       - cli/*
 
 env:
-  GO_VERSION: 1.26.4
   # Opt all JS actions into Node 24 ahead of GitHub's Node 20 phase-out.
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
@@ -45,10 +44,10 @@ jobs:
             | tar xz --wildcards "*/git-cliff" --strip-components=1
           sudo mv git-cliff /usr/local/bin/
 
-      - name: Setup Go ${{ env.GO_VERSION }}
+      - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: operator/go.mod
           cache-dependency-path: operator/go.sum
 
       - name: Extract version from tag

--- a/.github/workflows/operator-ci.yaml
+++ b/.github/workflows/operator-ci.yaml
@@ -56,7 +56,6 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
-  GO_VERSION: 1.26.4
   DEBIAN_VERSION: trixie
   # Opt all JS actions into Node 24. Node 20 is being phased out by GitHub
   # Actions starting June 2026; this avoids the deprecation warnings without
@@ -74,11 +73,10 @@ jobs:
       contents: read
     outputs:
       envtest-k8s-version: ${{ steps.versions.outputs.envtest-k8s-version }}
-      kind-version: ${{ steps.versions.outputs.kind-version }}
-      kind-node-image-version: ${{ steps.versions.outputs.kind-node-image-version }}
-      kind-binary-version: ${{ steps.versions.outputs.kind-binary-version }}
-      ci-kind-node-image-versions-json: ${{ steps.versions.outputs.ci-kind-node-image-versions-json }}
-      ci-primary-kind-node-image-version: ${{ steps.versions.outputs.ci-primary-kind-node-image-version }}
+      kind-node-image-version: ${{ steps.versions.outputs.kind-nodeimage }}
+      kind-binary-version: ${{ steps.versions.outputs.kind-binary }}
+      ci-kind-node-image-versions-json: ${{ steps.versions.outputs.ci-kindnodeimages }}
+      ci-primary-kind-node-image-version: ${{ steps.versions.outputs.ci-primarykindnodeimage }}
     steps:
       - uses: actions/checkout@v6
       - name: Load versions
@@ -140,10 +138,10 @@ jobs:
         with:
           fetch-tags: true
           fetch-depth: 0
-      - name: Setup Go ${{ env.GO_VERSION }}
+      - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: operator/go.mod
           cache-dependency-path: operator/go.sum
       - name: Log in to the Container registry
         if: matrix.test-suite != 'unit-tests' # unit tests don't need a container registry login
@@ -157,8 +155,8 @@ jobs:
         id: cached-binaries
         uses: actions/cache/restore@v5
         with:
-          key: ${{ env.GO_VERSION }}-${{ runner.os }}-${{ runner.arch }}-bin-${{ hashFiles('operator/deps.mk', 'operator/versions.yaml', 'operator/versions.sh') }}
-          restore-keys: ${{ env.GO_VERSION }}-${{ runner.os }}-${{ runner.arch }}-bin-
+          key: ${{ runner.os }}-${{ runner.arch }}-bin-${{ hashFiles('operator/go.mod', 'operator/deps.mk', 'operator/versions.yaml', 'operator/versions.sh') }}
+          restore-keys: ${{ runner.os }}-${{ runner.arch }}-bin-
           path: |
             ${{ github.workspace }}/operator/bin
             ~/.cache/go-build
@@ -172,7 +170,7 @@ jobs:
         if: steps.cached-binaries.outputs.cache-hit != 'true'
         uses: actions/cache/save@v5
         with:
-          key: ${{ env.GO_VERSION }}-${{ runner.os }}-${{ runner.arch }}-bin-${{ hashFiles('operator/deps.mk', 'operator/versions.yaml', 'operator/versions.sh') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-bin-${{ hashFiles('operator/go.mod', 'operator/deps.mk', 'operator/versions.yaml', 'operator/versions.sh') }}
           path: |
             ${{ github.workspace }}/operator/bin
             ~/.cache/go-build
@@ -235,10 +233,10 @@ jobs:
     if: success() && !startsWith(github.ref, 'refs/tags/')
     steps:
       - uses: actions/checkout@v6
-      - name: Setup Go ${{ env.GO_VERSION }}
+      - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: operator/go.mod
       - name: Download all coverage artifacts
         uses: actions/download-artifact@v5
         with:
@@ -347,6 +345,7 @@ jobs:
           PLATFORM: ${{ matrix.platform }}
         run: |
           cd operator
+          GO_VERSION=$(awk '/^go /{go=$2} /^toolchain /{tc=$2; sub(/^go/,"",tc)} END{print (tc!=""?tc:go)}' go.mod)
           PLATFORM_TAG=$(echo "$PLATFORM" | tr '/' '-')
           
           # Lowercase for Docker compliance
@@ -370,7 +369,7 @@ jobs:
           docker buildx build \
             --build-arg GIT_SHA=${GIT_SHA} \
             --build-arg VERSION=${VERSION} \
-            --build-arg GO_VERSION=${{ env.GO_VERSION }} \
+            --build-arg GO_VERSION="${GO_VERSION}" \
             --build-arg DEBIAN_VERSION=${{ env.DEBIAN_VERSION }} \
             --build-arg DISTROLESS_VERSION=${{ needs.fetch-distroless-versions.outputs.go-version }} \
             ${PUSH_OR_LOAD} \

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -24,7 +24,6 @@ variables:
   KUBERNETES_CPU_REQUEST: "2"
   KUBERNETES_MEMORY_LIMIT: "6Gi"
   KUBERNETES_MEMORY_REQUEST: "3Gi"
-  GO_VERSION: 1.26.4
   ARCH_LIST: "linux/amd64,linux/arm64"
 
 workflow:
@@ -32,9 +31,6 @@ workflow:
     - if: $CI_COMMIT_TAG
 
 include:
-  - project: dgx/infra/gitlint-ci
-    ref: main
-    file: gitlint.yml
   - project: dgx/infra/ngc-publishing-automation
     ref: main
     file: ngc-publishing-automation.yml

--- a/agent/go/go.mod
+++ b/agent/go/go.mod
@@ -1,6 +1,6 @@
 module github.com/NVIDIA/nodewright/agent
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/onsi/ginkgo/v2 v2.28.1

--- a/docs/development.md
+++ b/docs/development.md
@@ -20,24 +20,27 @@ Keep manual installs in sync with `CTLPTL_VERSION` in `operator/deps.mk`.
 
 ## Kubernetes Test Versions
 
-`operator/versions.yaml` is the source of truth for Kubernetes versions used by envtest, local kind clusters, and GitHub Actions test matrices. `operator/versions.sh` is the only reader for that file; it uses `yq` and exports the Make and CI values.
+`operator/versions.yaml` is the source of truth for the Kubernetes versions used by envtest, local kind clusters, and GitHub Actions test matrices. `operator/versions.sh` is the only reader for that file; it uses `yq` and derives every consumer name from the key's path (see the header comment in `versions.yaml`). The Go toolchain version is not here: it lives in `go.mod`, which the Make build (image build-arg) and CI (`setup-go` `go-version-file`) both read directly.
 
-- `envtest.kubernetes` controls `setup-envtest` binary assets under `operator/bin/k8s/`.
+- `envtest.k8s.version` controls `setup-envtest` binary assets under `operator/bin/k8s/`. It is nested three deep so the derived name is `ENVTEST_K8S_VERSION`, which the test lib expects.
 - `kind.nodeImage` controls the default `kindest/node` image for local kind clusters. Make also exposes this as `KIND_VERSION` and `KIND_NODE_IMAGE_VERSION` for local overrides.
 - `kind.binary` controls the Kind CLI/action version and is intentionally separate from Kubernetes node image versions.
 - `ci.kindNodeImages` and `ci.primaryKindNodeImage` feed the GitHub Actions matrix.
 
-For a development shell, install the local reader dependency and source the reader:
+For a development shell, install the local reader dependency and load the `UPPER_SNAKE` values into your environment. `source` works in bash; in other shells (zsh, etc.) eval the exports instead:
 
 ```bash
 make -C operator yq
-source operator/versions.sh
+source operator/versions.sh                 # bash
+eval "$(operator/versions.sh --export)"     # any shell
 ```
 
-For scripts, read one key or print the GitHub Actions output shape:
+Note the exported names are derived from the yaml path (`kind.nodeImage` → `KIND_NODEIMAGE`) and are not the same as the Make override variables (`KIND_VERSION`, `KIND_NODE_IMAGE_VERSION`, …). To override a Make default, set that Make variable directly, e.g. `make KIND_VERSION=1.34.0 …`.
+
+For scripts, read one key (a yq path) or print the GitHub Actions output shape:
 
 ```bash
-operator/versions.sh --get envtestK8s
+operator/versions.sh --get envtest.k8s.version
 operator/versions.sh --print
 ```
 

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -16,7 +16,10 @@ include deps.mk
 
 ## Version of the operator
 VERSION ?= $(GIT_TAG_LAST)
-GO_VERSION ?= 1.26.4
+# Go toolchain version read from go.mod (the single source; also used by CI's
+# setup-go go-version-file and the image build-arg). Prefer a toolchain
+# directive over the go directive, matching how setup-go resolves the version.
+GO_VERSION ?= $(shell awk '/^go /{go=$$2} /^toolchain /{tc=$$2; sub(/^go/,"",tc)} END{print (tc!=""?tc:go)}' $(CURDIR)/go.mod)
 DEBIAN_VERSION ?= trixie
 DISTROLESS_VERSION ?= 4.0.2
 

--- a/operator/README.md
+++ b/operator/README.md
@@ -90,7 +90,7 @@ Packages can depend on each other, so if you needed `something_important` to be 
 
 ### Prerequisites
 
-- go version v1.26.4+
+- go version v1.26.5+
 - docker version 17.03+ or podman 4.9.4+ (project makefile kind of assumes podman)
 - kubectl version v1.27.3+.
 - Access to a Kubernetes v1.27+ cluster. (We test on 1.32+, could work on older, not regularly tested. Could be api compatibilities issues.)

--- a/operator/deps.mk
+++ b/operator/deps.mk
@@ -24,12 +24,12 @@ $(LOCALBIN):
 YQ ?= $(LOCALBIN)/yq
 VERSIONS ?= $(CURDIR)/versions.sh
 
-ENVTEST_K8S_VERSION ?= $(shell YQ="$(YQ)" $(VERSIONS) --get envtestK8s)
-KIND_VERSION ?= $(shell YQ="$(YQ)" $(VERSIONS) --get kindVersion)
+ENVTEST_K8S_VERSION ?= $(shell YQ="$(YQ)" $(VERSIONS) --get envtest.k8s.version)
+KIND_VERSION ?= $(shell YQ="$(YQ)" $(VERSIONS) --get kind.nodeImage)
 KIND_NODE_IMAGE_VERSION ?= $(KIND_VERSION)
-KIND_BINARY_VERSION ?= $(shell YQ="$(YQ)" $(VERSIONS) --get kindBinary)
-CI_KIND_NODE_IMAGE_VERSIONS_JSON ?= $(shell YQ="$(YQ)" $(VERSIONS) --get ciKindNodeImagesJson)
-CI_PRIMARY_KIND_NODE_IMAGE_VERSION ?= $(shell YQ="$(YQ)" $(VERSIONS) --get ciPrimaryKindNodeImage)
+KIND_BINARY_VERSION ?= $(shell YQ="$(YQ)" $(VERSIONS) --get kind.binary)
+CI_KIND_NODE_IMAGE_VERSIONS_JSON ?= $(shell YQ="$(YQ)" $(VERSIONS) --get ci.kindNodeImages -o=json -I=0)
+CI_PRIMARY_KIND_NODE_IMAGE_VERSION ?= $(shell YQ="$(YQ)" $(VERSIONS) --get ci.primaryKindNodeImage)
 
 UNAMEO 	?=$(shell uname -o | tr A-Z a-z)
 ifndef OS

--- a/operator/go.mod
+++ b/operator/go.mod
@@ -1,6 +1,6 @@
 module github.com/NVIDIA/nodewright/operator
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/go-logr/logr v1.4.3

--- a/operator/versions.sh
+++ b/operator/versions.sh
@@ -38,61 +38,78 @@ _versions_yq() {
 }
 
 _versions_get() {
-	local key="${1:-}"
+	local path="${1:-}"
 	local yq
 	yq="$(_versions_yq)" || return 1
 
-	case "${key}" in
-	envtestK8s)
-		"${yq}" -r '.envtest.kubernetes' "${_versions_file}"
-		;;
-	kindVersion | kindNodeImage)
-		"${yq}" -r '.kind.nodeImage' "${_versions_file}"
-		;;
-	kindBinary)
-		"${yq}" -r '.kind.binary' "${_versions_file}"
-		;;
-	ciKindNodeImagesJson)
-		"${yq}" -o=json -I=0 '.ci.kindNodeImages' "${_versions_file}"
-		;;
-	ciPrimaryKindNodeImage)
-		"${yq}" -r '.ci.primaryKindNodeImage' "${_versions_file}"
-		;;
-	*)
-		printf 'unknown version key: %s\n' "${key}" >&2
+	if [ -z "${path}" ]; then
+		printf 'usage: %s --get <yq-path> [yq-args...]\n' "${_versions_script}" >&2
 		return 1
-		;;
-	esac
+	fi
+
+	# The path is a bare yq key expression (e.g. kind.binary); prepend the root
+	# dot and forward any trailing yq flags (e.g. -o=json for array output).
+	shift
+	local out
+	out="$("${yq}" -r "$@" ".${path}" "${_versions_file}")" || return 1
+	# yq yields "null" for a missing path and still exits 0; treat that as an
+	# error so a typo'd key fails loudly instead of returning an empty value.
+	if [ "${out}" = "null" ]; then
+		printf 'versions.sh: no value at .%s in %s\n' "${path}" "${_versions_file##*/}" >&2
+		return 1
+	fi
+	printf '%s\n' "${out}"
 }
 
+# Leaf keys read straight from versions.yaml: every scalar or sequence node,
+# skipping map containers and sequence elements (a sequence is one value). All
+# names below derive from these paths, so adding a key to versions.yaml surfaces
+# it in --print/--export with no edit here.
+_versions_leaves() {
+	local yq
+	yq="$(_versions_yq)" || return 1
+	"${yq}" -r '.. | select(tag != "!!map") | select((path | .[-1] | tag) != "!!int") | path | join(".")' "${_versions_file}"
+}
+
+# Names derive straight from the yq leaf path, so the versions.yaml key
+# structure is the single source of naming (e.g. envtest.k8s.version yields
+# ENVTEST_K8S_VERSION / envtest-k8s-version). env name: upper-case with '.'/'-'
+# collapsed to '_'; out key: lower-case with '.'/'_' collapsed to '-'.
+_versions_env_name() { printf '%s' "$1" | tr '[:lower:]' '[:upper:]' | tr '.-' '__'; }
+_versions_out_key() { printf '%s' "$1" | tr '[:upper:]' '[:lower:]' | tr '._' '--'; }
+
+# Scalars print raw; sequences print as compact JSON so array values survive.
+_versions_value() {
+	local path="$1" yq
+	yq="$(_versions_yq)" || return 1
+	if [ "$("${yq}" -r ".${path} | tag" "${_versions_file}")" = "!!seq" ]; then
+		"${yq}" -o=json -I=0 ".${path}" "${_versions_file}"
+	else
+		"${yq}" -r ".${path}" "${_versions_file}"
+	fi
+}
+
+# Print `export NAME=value` statements for every leaf so the output can be
+# eval'd or sourced: `eval "$(versions.sh --export)"`. Names are UPPER_SNAKE
+# (shell convention); values are %q shell-quoted so any characters (quotes,
+# the JSON array) survive the eval intact.
 _versions_export() {
-	local envtest_k8s
-	local kind_version
-	local kind_binary
-	local ci_kind_node_images_json
-	local ci_primary_kind_node_image
-
-	envtest_k8s="$(_versions_get envtestK8s)" || return 1
-	kind_version="$(_versions_get kindVersion)" || return 1
-	kind_binary="$(_versions_get kindBinary)" || return 1
-	ci_kind_node_images_json="$(_versions_get ciKindNodeImagesJson)" || return 1
-	ci_primary_kind_node_image="$(_versions_get ciPrimaryKindNodeImage)" || return 1
-
-	export ENVTEST_K8S_VERSION="${ENVTEST_K8S_VERSION:-${envtest_k8s}}"
-	export KIND_VERSION="${KIND_VERSION:-${kind_version}}"
-	export KIND_NODE_IMAGE_VERSION="${KIND_NODE_IMAGE_VERSION:-${KIND_VERSION}}"
-	export KIND_BINARY_VERSION="${KIND_BINARY_VERSION:-${kind_binary}}"
-	export CI_KIND_NODE_IMAGE_VERSIONS_JSON="${CI_KIND_NODE_IMAGE_VERSIONS_JSON:-${ci_kind_node_images_json}}"
-	export CI_PRIMARY_KIND_NODE_IMAGE_VERSION="${CI_PRIMARY_KIND_NODE_IMAGE_VERSION:-${ci_primary_kind_node_image}}"
+	local path env value
+	while IFS= read -r path; do
+		[ -n "${path}" ] || continue
+		env="$(_versions_env_name "${path}")"
+		value="$(_versions_value "${path}")" || return 1
+		printf 'export %s=%q\n' "${env}" "${value}"
+	done < <(_versions_leaves)
 }
 
 _versions_print() {
-	printf 'envtest-k8s-version=%s\n' "$(_versions_get envtestK8s)"
-	printf 'kind-version=%s\n' "$(_versions_get kindVersion)"
-	printf 'kind-node-image-version=%s\n' "$(_versions_get kindNodeImage)"
-	printf 'kind-binary-version=%s\n' "$(_versions_get kindBinary)"
-	printf 'ci-kind-node-image-versions-json=%s\n' "$(_versions_get ciKindNodeImagesJson)"
-	printf 'ci-primary-kind-node-image-version=%s\n' "$(_versions_get ciPrimaryKindNodeImage)"
+	local path value
+	while IFS= read -r path; do
+		[ -n "${path}" ] || continue
+		value="$(_versions_value "${path}")" || return 1
+		printf '%s=%s\n' "$(_versions_out_key "${path}")" "${value}"
+	done < <(_versions_leaves)
 }
 
 _versions_main() {
@@ -100,32 +117,40 @@ _versions_main() {
 
 	case "${1:-}" in
 	--get)
-		if [ "$#" -ne 2 ]; then
-			printf 'usage: %s --get <key>\n' "${_versions_script}" >&2
-			return 1
-		fi
-		_versions_get "$2"
+		shift
+		_versions_get "$@"
 		;;
 	--print)
 		_versions_print
 		;;
 	--export)
 		_versions_export
-		export -p ENVTEST_K8S_VERSION KIND_VERSION KIND_NODE_IMAGE_VERSION KIND_BINARY_VERSION CI_KIND_NODE_IMAGE_VERSIONS_JSON CI_PRIMARY_KIND_NODE_IMAGE_VERSION
 		;;
 	"" | -h | --help)
 		cat <<EOF
-usage: ${_versions_script} --get <key>
+Read tool/runtime versions from ${_versions_file##*/}.
+
+usage: ${_versions_script} --get <yq-path> [yq-args...]
        ${_versions_script} --print
+       ${_versions_script} --export
        source ${_versions_script}
 
-keys:
-  envtestK8s
-  kindVersion
-  kindNodeImage
-  kindBinary
-  ciKindNodeImagesJson
-  ciPrimaryKindNodeImage
+--get     print one value at <yq-path> (the leading . is added for you) and
+          forward any trailing yq flags. A missing path is an error, e.g.:
+            ${_versions_script} --get envtest.k8s.version
+            ${_versions_script} --get kind.binary
+            ${_versions_script} --get ci.kindNodeImages -o=json -I=0
+--print   enumerate every key and emit lower-case hyphenated 'key=value' lines
+          for GitHub Actions step outputs (>> \$GITHUB_OUTPUT).
+--export  enumerate every key and emit UPPER_SNAKE 'export NAME=value' lines
+          for the shell: eval "\$(${_versions_script##*/} --export)".
+source    (bash) applies the --export assignments to your shell; in other
+          shells use: eval "\$(${_versions_script##*/} --export)".
+
+--print / --export names derive from each key's path: dots become the
+separators, so kind.binary -> kind-binary / KIND_BINARY and envtest.k8s.version ->
+envtest-k8s-version / ENVTEST_K8S_VERSION. Add a key to the file and it appears
+in both with no change here.
 EOF
 		;;
 	*)
@@ -135,8 +160,21 @@ EOF
 	esac
 }
 
-if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+# Run directly (bash via the shebang): dispatch CLI args. Sourced into bash:
+# apply the exports to the caller's shell. Sourced into another shell (zsh,
+# etc.) the bash-isms above misbehave, so point the user at the portable form
+# instead of failing with a misleading yq error.
+if [ -z "${BASH_VERSION:-}" ]; then
+	printf 'versions.sh: source needs bash; in other shells run: eval "$(./%s --export)"\n' "${0##*/}" >&2
+elif [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
 	_versions_main "$@"
 else
-	_versions_export
+	# Capture first so a mid-stream _versions_export failure does not leave the
+	# caller's shell with a partial set of exports.
+	if ! __versions_exports="$(_versions_export)"; then
+		printf 'versions.sh: failed to read %s\n' "${_versions_file##*/}" >&2
+		return 1
+	fi
+	eval "${__versions_exports}"
+	unset __versions_exports
 fi

--- a/operator/versions.yaml
+++ b/operator/versions.yaml
@@ -12,8 +12,26 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 
+## Kubernetes test versions (envtest, local kind clusters, the GitHub Actions
+## test matrix). The Go toolchain version is NOT here - it lives in go.mod, the
+## single source that Make and CI both read.
+##
+## operator/versions.sh is the only reader. It uses yq and derives consumer
+## names from each key's PATH - there is no separate name mapping:
+##   ./versions.sh --get <yq.path>   one value (append yq flags, e.g. -o=json)
+##   ./versions.sh --print           lower-case hyphenated key=value lines for
+##                                   $GITHUB_OUTPUT (kind.binary -> kind-binary)
+##   ./versions.sh --export          UPPER_SNAKE `export NAME=value` lines for
+##                                   eval/source (kind.binary -> KIND_BINARY)
+##
+## Because dots in the path become the name separators, a key is sometimes
+## nested purely to derive the name a consumer already expects - see envtest.
+## Adding a key here surfaces it in --print/--export with no code change.
+
+## this 3 nested value is this way for ENVTEST_K8S_VERSION which the test lib expects
 envtest:
-  kubernetes: "1.36.0"
+  k8s:
+    version: "1.36.0"
 
 kind:
   nodeImage: "1.35.0"
@@ -26,3 +44,4 @@ ci:
     - "1.34.3"
     - "1.35.0"
   primaryKindNodeImage: "1.35.0"
+


### PR DESCRIPTION
## Summary

Bumps the Go toolchain to 1.26.5 and removes the version duplication that came with it. `go.mod` is now the single source for the Go version, and `operator/versions.sh` is refactored into a generic, data-driven reader.

## Go version → single source (`go.mod`)

`go.mod` must carry the Go version as a literal anyway, so everything reads from it:

- CI `actions/setup-go` uses `go-version-file: <module>/go.mod` (matching the existing `merge-gate.yaml` / `release.yml`).
- The operator `Makefile` `GO_VERSION` and the image build-arg read it via `awk`.
- Cache keys drop the `GO_VERSION-` prefix and add `operator/go.mod` to `hashFiles` (same invalidation, no value needed).
- `versions.yaml` no longer carries `go.version`; the workflow `env: GO_VERSION` literals are gone.

## `versions.sh` refactor

`operator/versions.yaml` now owns only the k8s/kind/envtest versions, and `operator/versions.sh` reads it generically:

- `--get <yq-path> [yq-args...]` prepends the root `.` and forwards yq flags; a missing key is an error (exit 1) instead of printing `null`.
- `--print` (GitHub Actions output shape) and `--export` (`export NAME=value` for eval/source) enumerate the yaml's keys and derive each consumer name from the key path. No hardcoded name mapping.
- Key nesting shapes the derived name, so `envtest.k8s.version` yields the `ENVTEST_K8S_VERSION` the test lib expects.
- Sourcing in a non-bash shell now points at `eval "$(./versions.sh --export)"` instead of failing with a misleading error.

CI `--print` consumers in `operator-ci.yaml` / `agent-ci.yaml` were repointed to the derived key names; job-output names and downstream `needs.*.outputs.*` are unchanged.

## Also

Drops the unused `gitlint-ci` include from `.gitlab-ci.yml` (unrelated cleanup).

## Testing

- `versions.sh --get/--print/--export` exercised locally, including against the CI-pinned `yq v4.44.3`; missing-key exits 1; shellcheck clean.
- Makefile resolves `GO_VERSION=1.26.5` from `go.mod`; the `awk` build-arg agrees.
- Operator module builds (`go build ./...`).
- Workflow YAML validated with `yq -e` and `git grep`; GitHub Actions logic verified by inspection + parse (not run locally).
- Docs updated in lockstep (`docs/development.md`, `versions.yaml` header, `--help`).