### PR TITLE
fix(operator): exempt package pods from drain by label as defense-in-depth

### DIFF
--- a/docs/interrupt_flow.md
+++ b/docs/interrupt_flow.md
@@ -125,8 +125,12 @@ The fields map to Kubernetes drain behavior:
 - `gracePeriod`: overrides the grace period used for eviction or direct deletion. Unset uses each pod's own `terminationGracePeriodSeconds`.
 
 The operator also skips pods that are already terminating, pods that tolerate
-the `node.kubernetes.io/unschedulable` taint, mirror/static pods, and pods in
-`kube-system`. These exclusions are not user-configurable.
+the `node.kubernetes.io/unschedulable` taint, mirror/static pods, pods in
+`kube-system`, and its own package pods — identified by the
+`skyhook.nvidia.com/name` and `skyhook.nvidia.com/package` labels stamped on
+every package pod, so they remain exempt even if an admission controller
+rewrites or strips their tolerations. These exclusions are not
+user-configurable.
 
 Compared to earlier releases, the default drain filter now follows Kubernetes
 matching more closely: the unschedulable toleration check uses Kubernetes

--- a/docs/interrupt_flow.md
+++ b/docs/interrupt_flow.md
@@ -129,8 +129,9 @@ the `node.kubernetes.io/unschedulable` taint, mirror/static pods, pods in
 `kube-system`, and its own package pods — identified by the
 `skyhook.nvidia.com/name` and `skyhook.nvidia.com/package` labels stamped on
 every package pod, so they remain exempt even if an admission controller
-rewrites or strips their tolerations. These exclusions are not
-user-configurable.
+rewrites or strips their tolerations. The label exemption only applies to
+pods in the operator's own namespace, so workloads elsewhere cannot opt out
+of drain by copying the labels. These exclusions are not user-configurable.
 
 Compared to earlier releases, the default drain filter now follows Kubernetes
 matching more closely: the unschedulable toleration check uses Kubernetes

--- a/operator/internal/controller/skyhook_controller.go
+++ b/operator/internal/controller/skyhook_controller.go
@@ -1490,6 +1490,7 @@ func (r *SkyhookReconciler) IsDrained(ctx context.Context, skyhookNode wrapper.S
 	}
 
 	options := drain.OptionsFromConfig(skyhookNode.GetSkyhook().Spec.DrainConfig)
+	options.PackageNamespace = r.opts.Namespace
 	for _, pod := range pods.Items {
 		if drain.DecidePod(&pod, options).BlocksDrain() {
 			return false, nil
@@ -1802,6 +1803,7 @@ func (r *SkyhookReconciler) DrainNode(ctx context.Context, skyhookNode wrapper.S
 	)
 
 	options := drain.OptionsFromConfig(skyhookNode.GetSkyhook().Spec.DrainConfig)
+	options.PackageNamespace = r.opts.Namespace
 	errs := make([]error, 0)
 	waitingForPods := false
 	for _, pod := range pods.Items {

--- a/operator/internal/drain/drain.go
+++ b/operator/internal/drain/drain.go
@@ -19,6 +19,7 @@
 package drain
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/NVIDIA/nodewright/operator/api/v1alpha1"
@@ -33,6 +34,7 @@ const (
 
 	ReasonPhase                   = "phase"
 	ReasonTerminating             = "terminating"
+	ReasonSkyhookPackage          = "skyhook-package"
 	ReasonUnschedulableToleration = "unschedulable-toleration"
 	ReasonDaemonSet               = "daemonset"
 	ReasonKubeSystem              = "kube-system"
@@ -146,6 +148,14 @@ func DecidePod(pod *corev1.Pod, options Options) Decision {
 		return Decision{Action: ActionIgnore, Reason: ReasonTerminating}
 	}
 
+	// Package pods normally dodge drain via toleratesUnschedulable below, but
+	// some admission controllers rewrite or strip pod tolerations, so the
+	// operator's own in-flight pods are also recognized by the labels stamped
+	// on every package pod.
+	if isSkyhookPackagePod(pod) {
+		return Decision{Action: ActionIgnore, Reason: ReasonSkyhookPackage}
+	}
+
 	if toleratesUnschedulable(pod) {
 		return Decision{Action: ActionIgnore, Reason: ReasonUnschedulableToleration}
 	}
@@ -176,6 +186,12 @@ func DecidePod(pod *corev1.Pod, options Options) Decision {
 	}
 
 	return Decision{Action: ActionEvict, Reason: ReasonEviction}
+}
+
+func isSkyhookPackagePod(pod *corev1.Pod) bool {
+	_, hasName := pod.Labels[fmt.Sprintf("%s/name", v1alpha1.METADATA_PREFIX)]
+	_, hasPackage := pod.Labels[fmt.Sprintf("%s/package", v1alpha1.METADATA_PREFIX)]
+	return hasName && hasPackage
 }
 
 func toleratesUnschedulable(pod *corev1.Pod) bool {

--- a/operator/internal/drain/drain.go
+++ b/operator/internal/drain/drain.go
@@ -60,6 +60,11 @@ type Options struct {
 	Force              bool
 	IgnoreDaemonSets   bool
 	GracePeriodSeconds *int64
+	// PackageNamespace is the namespace the operator creates package pods in.
+	// It is operator identity, not user configuration, so callers set it
+	// directly rather than through DrainConfig. When empty, the label-based
+	// package-pod exemption is disabled.
+	PackageNamespace string
 }
 
 func DefaultOptions() Options {
@@ -151,8 +156,10 @@ func DecidePod(pod *corev1.Pod, options Options) Decision {
 	// Package pods normally dodge drain via toleratesUnschedulable below, but
 	// some admission controllers rewrite or strip pod tolerations, so the
 	// operator's own in-flight pods are also recognized by the labels stamped
-	// on every package pod.
-	if isSkyhookPackagePod(pod) {
+	// on every package pod. The check is scoped to the operator's namespace:
+	// the labels alone could be copied onto any pod, while creating pods in
+	// the operator's namespace requires RBAC there.
+	if isSkyhookPackagePod(pod, options.PackageNamespace) {
 		return Decision{Action: ActionIgnore, Reason: ReasonSkyhookPackage}
 	}
 
@@ -188,7 +195,10 @@ func DecidePod(pod *corev1.Pod, options Options) Decision {
 	return Decision{Action: ActionEvict, Reason: ReasonEviction}
 }
 
-func isSkyhookPackagePod(pod *corev1.Pod) bool {
+func isSkyhookPackagePod(pod *corev1.Pod, packageNamespace string) bool {
+	if packageNamespace == "" || pod.Namespace != packageNamespace {
+		return false
+	}
 	_, hasName := pod.Labels[fmt.Sprintf("%s/name", v1alpha1.METADATA_PREFIX)]
 	_, hasPackage := pod.Labels[fmt.Sprintf("%s/package", v1alpha1.METADATA_PREFIX)]
 	return hasName && hasPackage

--- a/operator/internal/drain/drain_test.go
+++ b/operator/internal/drain/drain_test.go
@@ -153,6 +153,40 @@ var _ = Describe("DecidePod", func() {
 		),
 	)
 
+	DescribeTable("should exempt the operator's own package pods by label even when admission strips tolerations",
+		func(labels map[string]string, expectedDecision Decision) {
+			pod := basePod()
+			pod.Labels = labels
+
+			decision := DecidePod(pod, DefaultOptions())
+
+			Expect(decision).To(Equal(expectedDecision))
+		},
+		Entry("ignores pods with both skyhook package labels",
+			map[string]string{
+				"skyhook.nvidia.com/name":    "my-skyhook",
+				"skyhook.nvidia.com/package": "pkg-1.0.0",
+			},
+			Decision{Action: ActionIgnore, Reason: ReasonSkyhookPackage},
+		),
+		Entry("ignores interrupt pods carrying the package labels",
+			map[string]string{
+				"skyhook.nvidia.com/name":      "my-skyhook",
+				"skyhook.nvidia.com/package":   "pkg-1.0.0",
+				"skyhook.nvidia.com/interrupt": "True",
+			},
+			Decision{Action: ActionIgnore, Reason: ReasonSkyhookPackage},
+		),
+		Entry("still drains pods with only the name label",
+			map[string]string{"skyhook.nvidia.com/name": "my-skyhook"},
+			Decision{Action: ActionEvict, Reason: ReasonEviction},
+		),
+		Entry("still drains pods with only the package label",
+			map[string]string{"skyhook.nvidia.com/package": "pkg-1.0.0"},
+			Decision{Action: ActionEvict, Reason: ReasonEviction},
+		),
+	)
+
 	It("should ignore daemonset pods by default", func() {
 		pod := basePod()
 		pod.OwnerReferences[0].Kind = daemonSetKind

--- a/operator/internal/drain/drain_test.go
+++ b/operator/internal/drain/drain_test.go
@@ -154,35 +154,64 @@ var _ = Describe("DecidePod", func() {
 	)
 
 	DescribeTable("should exempt the operator's own package pods by label even when admission strips tolerations",
-		func(labels map[string]string, expectedDecision Decision) {
+		func(podNamespace string, labels map[string]string, packageNamespace string, expectedDecision Decision) {
 			pod := basePod()
+			pod.Namespace = podNamespace
 			pod.Labels = labels
+			options := DefaultOptions()
+			options.PackageNamespace = packageNamespace
 
-			decision := DecidePod(pod, DefaultOptions())
+			decision := DecidePod(pod, options)
 
 			Expect(decision).To(Equal(expectedDecision))
 		},
-		Entry("ignores pods with both skyhook package labels",
+		Entry("ignores pods with both skyhook package labels in the operator namespace",
+			"skyhook",
 			map[string]string{
 				"skyhook.nvidia.com/name":    "my-skyhook",
 				"skyhook.nvidia.com/package": "pkg-1.0.0",
 			},
+			"skyhook",
 			Decision{Action: ActionIgnore, Reason: ReasonSkyhookPackage},
 		),
 		Entry("ignores interrupt pods carrying the package labels",
+			"skyhook",
 			map[string]string{
 				"skyhook.nvidia.com/name":      "my-skyhook",
 				"skyhook.nvidia.com/package":   "pkg-1.0.0",
 				"skyhook.nvidia.com/interrupt": "True",
 			},
+			"skyhook",
 			Decision{Action: ActionIgnore, Reason: ReasonSkyhookPackage},
 		),
 		Entry("still drains pods with only the name label",
+			"skyhook",
 			map[string]string{"skyhook.nvidia.com/name": "my-skyhook"},
+			"skyhook",
 			Decision{Action: ActionEvict, Reason: ReasonEviction},
 		),
 		Entry("still drains pods with only the package label",
+			"skyhook",
 			map[string]string{"skyhook.nvidia.com/package": "pkg-1.0.0"},
+			"skyhook",
+			Decision{Action: ActionEvict, Reason: ReasonEviction},
+		),
+		Entry("still drains pods carrying both labels outside the operator namespace",
+			"default",
+			map[string]string{
+				"skyhook.nvidia.com/name":    "my-skyhook",
+				"skyhook.nvidia.com/package": "pkg-1.0.0",
+			},
+			"skyhook",
+			Decision{Action: ActionEvict, Reason: ReasonEviction},
+		),
+		Entry("does not exempt by label when no package namespace is configured",
+			"skyhook",
+			map[string]string{
+				"skyhook.nvidia.com/name":    "my-skyhook",
+				"skyhook.nvidia.com/package": "pkg-1.0.0",
+			},
+			"",
 			Decision{Action: ActionEvict, Reason: ReasonEviction},
 		),
 	)


### PR DESCRIPTION
## Description

`DecidePod` exempted the operator's own package pods from drain only via `toleratesUnschedulable`. That is robust against AKS-style admission that collapses keyed tolerations into a wildcard (#296), but not against an admission controller that strips tolerations entirely. This adds a label-based exemption as belt-and-suspenders: a pod carrying both `skyhook.nvidia.com/name` and `skyhook.nvidia.com/package` — the labels stamped on every package and interrupt pod — is never evicted by the operator's drain, regardless of admission-time toleration rewriting. The existing `toleratesUnschedulable` check is kept; the label check is additive.

Design notes:

- Both labels are required rather than just `name` — a tighter fingerprint against accidental collisions with user workloads. No new patterns introduced; the helper mirrors the file's existing shape and the label keys are built from `v1alpha1.METADATA_PREFIX` like everywhere else.
- The label exemption is scoped to the operator's namespace (`Options.PackageNamespace`, set from the operator's runtime namespace at both drain call sites): package pods only ever run there and pod creation in that namespace is RBAC-gated, so workloads elsewhere cannot opt out of drain by copying the labels. When the namespace is unset the label exemption is disabled entirely. An owner-reference check was considered and rejected — `ownerReferences` is settable by any pod author and only trustworthy if resolved against the apiserver per pod.
- The operator's own controller-manager pods are unaffected: they carry only `control-plane`/`app.kubernetes.io/*` labels, so they still drain normally under the chart's 2-replica + `minAvailable: 1` PDB defaults.
- CLI and chart are unaffected: `Decision.Reason` isn't part of any contract surface (annotations, metrics, CLI); only `Action`/`BlocksDrain()` are consumed, at the two existing call sites.

Docs: the non-configurable drain-exclusions paragraph in `docs/interrupt_flow.md` now lists the operator's own package pods and the namespace scoping.

Tested via new `DescribeTable` specs in `internal/drain/drain_test.go` (both-labels pods and interrupt pods in the operator namespace ignored; single-label pods, forged labels outside the operator namespace, and unset-namespace cases still drained) plus the full `make unit-tests` suite (11 suites green).

closes #297

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/skyhook/blob/main/CONTRIBUTING.md).
- [x] My commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
