### PR TITLE
fix(operator): grant events.k8s.io RBAC for the event recorder

### DIFF
--- a/chart/templates/manager-rbac.yaml
+++ b/chart/templates/manager-rbac.yaml
@@ -40,6 +40,7 @@ rules:
   - watch
 - apiGroups:
   - ""
+  - events.k8s.io
   resources:
   - events
   verbs:

--- a/k8s-tests/chainsaw/helm/events-rbac-test/README.md
+++ b/k8s-tests/chainsaw/helm/events-rbac-test/README.md
@@ -1,0 +1,25 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# events.k8s.io RBAC test
+
+Regression guard for [#308](https://github.com/NVIDIA/nodewright/issues/308).
+
+The operator records events through the `events.k8s.io/v1` API (client-go
+`tools/events`, wired via `mgr.GetEventRecorder`). The deployed manager
+`ClusterRole` must therefore grant `create`/`patch` on `events.events.k8s.io` —
+granting only the legacy core (`""`) events API causes every recorded event to
+be rejected as `forbidden` and dropped.
+
+This test installs the Helm chart, resolves the operator `ServiceAccount` from
+the manager `Deployment`, and asserts via `kubectl auth can-i --as` that the SA
+may both `create` and `patch` `events.events.k8s.io` (the two verbs the rule
+grants — `create` for new events, `patch` for the aggregated series). A negative
+control (`delete nodes`, which the role does not grant) confirms the impersonated
+check discriminates rather than passing unconditionally.
+
+Because it validates chart-rendered RBAC, it lives in the `helm` suite (the
+`skyhook` e2e suite runs the operator via `make run` with the developer's
+kubeconfig, which bypasses the ServiceAccount's RBAC entirely).

--- a/k8s-tests/chainsaw/helm/events-rbac-test/chainsaw-test.yaml
+++ b/k8s-tests/chainsaw/helm/events-rbac-test/chainsaw-test.yaml
@@ -1,0 +1,91 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: helm-events-rbac
+spec:
+  # Installs into the shared `skyhook` namespace, so keep it serial with the
+  # other helm tests.
+  concurrent: false
+  timeouts:
+    exec: 120s
+  steps:
+  # The operator records events through the events.k8s.io/v1 API (client-go
+  # tools/events). This asserts the deployed chart grants the operator
+  # ServiceAccount permission to create those events, so recorded events are
+  # not rejected as forbidden. Regression guard for #308 (the chart previously
+  # granted only the legacy core "" events API).
+  - name: operator-can-create-events-k8s-io
+    try:
+    - script:
+        timeout: 120s
+        content: |
+          ## Install the operator helm chart; the ClusterRole under test is
+          ## rendered from chart/templates/manager-rbac.yaml.
+          ../install-helm-chart.sh events-rbac
+    - script:
+        timeout: 30s
+        content: |
+          # chainsaw runs script content under POSIX /bin/sh (dash in CI), so
+          # keep this POSIX-clean: no `pipefail`, `[[ ]]`, or other bashisms.
+          set -u
+          NS=skyhook
+
+          # Resolve the operator ServiceAccount from the manager Deployment rather
+          # than hard-coding it, so the test survives a fullnameOverride change.
+          SA=$(kubectl -n "${NS}" get deploy -l control-plane=controller-manager \
+                -o jsonpath='{.items[0].spec.template.spec.serviceAccountName}')
+          if [ -z "${SA}" ]; then
+            echo "FAIL: could not resolve controller-manager ServiceAccount in ns/${NS}" >&2
+            exit 1
+          fi
+          SUBJECT="system:serviceaccount:${NS}:${SA}"
+          echo "operator ServiceAccount: ${SUBJECT}"
+
+          # Regression guard (#308): the recorder writes to events.k8s.io/v1, so
+          # both verbs the rule grants (create for new events, patch for the
+          # aggregated series) MUST be allowed. can-i's exit code (0 allowed /
+          # non-zero denied) fails the step closed on a denial.
+          for verb in create patch; do
+            if kubectl auth can-i "${verb}" events.events.k8s.io --as="${SUBJECT}" -n default >/dev/null; then
+              echo "PASS: ${SUBJECT} may ${verb} events.events.k8s.io"
+            else
+              echo "FAIL: ${SUBJECT} cannot ${verb} events.events.k8s.io - RBAC regression (#308)" >&2
+              exit 1
+            fi
+          done
+
+          # Negative control: an action the manager role does not grant must be
+          # denied, proving the impersonated can-i check actually discriminates
+          # (guards against a spuriously-passing test).
+          if kubectl auth can-i delete nodes --as="${SUBJECT}" >/dev/null 2>&1; then
+            echo "FAIL: negative control passed - ${SUBJECT} unexpectedly may delete nodes" >&2
+            exit 1
+          fi
+          echo "PASS: negative control denied (delete nodes)"
+    finally:
+    - script:
+        content: |
+          ## Remove the chart regardless of assertion outcome. Do not swallow the
+          ## exit status: a failed uninstall leaks resources into the shared
+          ## skyhook namespace and would contaminate later tests.
+          if ! ../uninstall-helm-chart.sh events-rbac; then
+            echo "FAIL: could not uninstall Helm release events-rbac" >&2
+            exit 1
+          fi

--- a/k8s-tests/chainsaw/helm/events-rbac-test/values.yaml
+++ b/k8s-tests/chainsaw/helm/events-rbac-test/values.yaml
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Minimal install: this test only exercises the ServiceAccount's RBAC, not the
+# operator's runtime, so the webhook is disabled to keep the install lean. The
+# image blocks are overridden by LOCAL_OPERATOR_IMG when run via `make helm-tests`.
+controllerManager:
+  manager:
+    image:
+      repository: ghcr.io/nvidia/skyhook/operator
+      tag: latest
+      digest: ""
+    agent:
+      repository: ghcr.io/nvidia/skyhook/agentless
+      tag: "6.2.0"
+      digest: ""
+webhook:
+  enable: false

--- a/operator/config/rbac/role.yaml
+++ b/operator/config/rbac/role.yaml
@@ -37,13 +37,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - events
-  verbs:
-  - create
-  - patch
-- apiGroups:
-  - ""
-  resources:
   - nodes
   verbs:
   - get
@@ -71,6 +64,14 @@ rules:
   - pods/status
   verbs:
   - get
+- apiGroups:
+  - ""
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
 - apiGroups:
   - admissionregistration.k8s.io
   resources:

--- a/operator/internal/controller/skyhook_controller.go
+++ b/operator/internal/controller/skyhook_controller.go
@@ -285,6 +285,10 @@ func (r *SkyhookReconciler) SetupWithManager(mgr ctrl.Manager) error {
 //+kubebuilder:rbac:groups=core,resources=nodes/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=core,resources=pods/eviction,verbs=create
 //+kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
+// The event recorder writes via the events.k8s.io/v1 API (client-go tools/events,
+// wired through mgr.GetEventRecorder), so the core rule above is not sufficient on
+// its own — without this rule every recorded event is rejected as forbidden.
+//+kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;patch
 //+kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch;create;update;patch;delete
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to


### PR DESCRIPTION
## Description

The operator's event recorder writes through the `events.k8s.io/v1` API (`client-go/tools/events`, wired via `mgr.GetEventRecorder`), but its RBAC only granted the legacy core (`""`) events API. As a result the operator ServiceAccount cannot create `events.events.k8s.io`, so **every recorded event is rejected as forbidden and dropped** — losing all operator observability events (skyhook state transitions, node-reboot detection, mark-complete, etc.) and emitting one `error`-level log line per drop.

This regressed in #228, when a library bump swapped `GetEventRecorderFor`/`record.EventRecorder` (core group) for `GetEventRecorder`/`events.EventRecorder` (events.k8s.io) without updating the `//+kubebuilder:rbac` marker. Affected releases: chart **v0.16.0 → v0.17.1** (v0.15.x and earlier are unaffected — still on the core-group recorder).

### Changes

- Add `//+kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;patch` in `skyhook_controller.go`, with a comment noting why both the core and `events.k8s.io` events rules are required.
- Regenerate `operator/config/rbac/role.yaml` via `make manifests` (controller-gen merges the two into a single `["", "events.k8s.io"]` events rule).
- Mirror the rule into `chart/templates/manager-rbac.yaml`, keeping `operator/config/` and `chart/` in sync.

### Verification

- `make manifests` regenerates `role.yaml` cleanly (no CRD/webhook drift); `golangci-lint` clean on `internal/controller`; `helm lint` passes.
- Validated the underlying fix on a live cluster: adding the equivalent rule flips `kubectl auth can-i create events.events.k8s.io` (as the operator SA) to `yes` and event rejections stop.

closes #308

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/skyhook/blob/main/CONTRIBUTING.md).
- [x] My commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/).
- [ ] New or existing tests cover these changes. <!-- No unit-test surface for a kubebuilder RBAC marker; envtest runs without RBAC enforcement. Validated via helm lint + live-cluster auth check as above. -->
- [x] The documentation is up to date with these changes. <!-- No user-facing doc enumerates the operator's manager RBAC. -->
