### PR TITLE
feat(agent): add commands and command runners with chroot for go rewrite

### DIFF
--- a/agent/go/internal/command/chroot_command_runner.go
+++ b/agent/go/internal/command/chroot_command_runner.go
@@ -1,0 +1,190 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package command
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+)
+
+type chrootCommandRunner struct {
+	root string
+}
+
+var _ Runner = (*chrootCommandRunner)(nil)
+
+func (runner *chrootCommandRunner) Run(
+	ctx context.Context,
+	command Command,
+) (result Result, err error) {
+	if err := validateRun(ctx, command); err != nil {
+		return Result{}, fmt.Errorf("validating chroot command execution: %w", err)
+	}
+	setup, err := prepareChroot(runner.root, command)
+	if err != nil {
+		return Result{}, fmt.Errorf("preparing chroot command execution: %w", err)
+	}
+	defer func() {
+		if closeErr := setup.close(); closeErr != nil {
+			err = errors.Join(err, closeErr)
+		}
+	}()
+	if command.Permissions != 0 {
+		relative := strings.TrimPrefix(filepath.Clean(command.Executable), string(filepath.Separator))
+		executableFile, openErr := setup.root.Open(relative)
+		if openErr != nil {
+			return Result{}, fmt.Errorf(
+				"applying chroot command executable permissions: opening command executable %q: %w",
+				command.Executable,
+				openErr,
+			)
+		}
+		permissionsErr := applyExecutablePermissions(ctx, command, executableFile)
+		closeErr := closeExecutable(command, executableFile)
+		if err := errors.Join(permissionsErr, closeErr); err != nil {
+			return Result{}, fmt.Errorf("applying chroot command executable permissions: %w", err)
+		}
+	}
+	result, err = executeCommand(
+		ctx,
+		command,
+		setup.executable,
+		setup.workingDirectory,
+		setup.rootPath,
+	)
+	if err != nil {
+		return result, fmt.Errorf("executing chroot command: %w", err)
+	}
+	return result, nil
+}
+
+type chrootSetup struct {
+	root             *os.Root
+	rootPath         string
+	executable       string
+	workingDirectory string
+}
+
+func (setup chrootSetup) close() error {
+	if setup.root == nil {
+		return nil
+	}
+	if err := setup.root.Close(); err != nil {
+		return fmt.Errorf("closing target root %q: %w", setup.rootPath, err)
+	}
+	return nil
+}
+
+func prepareChroot(rootPath string, command Command) (setup chrootSetup, err error) {
+	if rootPath == "" {
+		return chrootSetup{}, errors.New("command chroot is empty")
+	}
+	if strings.ContainsRune(rootPath, 0) {
+		return chrootSetup{}, errors.New("command chroot contains a NUL byte")
+	}
+	if !filepath.IsAbs(rootPath) {
+		return chrootSetup{}, fmt.Errorf("chroot %q is not absolute", rootPath)
+	}
+
+	configuredRoot := rootPath
+	rootPath, err = filepath.EvalSymlinks(rootPath)
+	if err != nil {
+		return chrootSetup{}, fmt.Errorf("resolving chroot %q: %w", configuredRoot, err)
+	}
+	root, err := os.OpenRoot(rootPath)
+	if err != nil {
+		return chrootSetup{}, fmt.Errorf("opening target root %q: %w", rootPath, err)
+	}
+	setup = chrootSetup{
+		root:             root,
+		rootPath:         rootPath,
+		executable:       command.Executable,
+		workingDirectory: command.WorkingDirectory,
+	}
+	openedRoot := setup
+	defer func() {
+		if err != nil {
+			err = errors.Join(err, openedRoot.close())
+		}
+	}()
+
+	if setup.workingDirectory == "" {
+		setup.workingDirectory = "/"
+	}
+	if strings.ContainsRune(setup.executable, filepath.Separator) {
+		return setup, nil
+	}
+
+	pathEnvironment, ok := command.Environment["PATH"]
+	if !ok {
+		pathEnvironment = os.Getenv("PATH")
+	}
+	setup.executable, err = lookPathInRoot(root, setup.workingDirectory, pathEnvironment, setup.executable)
+	if err != nil {
+		return chrootSetup{}, fmt.Errorf("resolving command executable: %w", err)
+	}
+	return setup, nil
+}
+
+// lookPathInRoot returns a child-visible executable path. It intentionally
+// leaves symlink resolution to the kernel after the child enters its chroot.
+func lookPathInRoot(
+	root *os.Root,
+	workingDirectory string,
+	pathEnvironment string,
+	executable string,
+) (string, error) {
+	directories := filepath.SplitList(pathEnvironment)
+
+	var permissionErr error
+	for _, directory := range directories {
+		if directory == "" {
+			directory = workingDirectory
+		} else if !filepath.IsAbs(directory) {
+			directory = filepath.Join(workingDirectory, directory)
+		}
+
+		candidate := filepath.Clean(filepath.Join(directory, executable))
+		relative := strings.TrimPrefix(candidate, string(filepath.Separator))
+		info, err := root.Lstat(relative)
+		if err != nil {
+			if errors.Is(err, fs.ErrNotExist) || errors.Is(err, syscall.ENOTDIR) {
+				continue
+			}
+			return "", fmt.Errorf("checking executable candidate %q: %w", candidate, err)
+		}
+		if info.Mode()&os.ModeSymlink != 0 || info.Mode().IsRegular() && info.Mode().Perm()&0o111 != 0 {
+			return candidate, nil
+		}
+		if permissionErr == nil {
+			permissionErr = fmt.Errorf("executable candidate %q is not executable: %w", candidate, fs.ErrPermission)
+		}
+	}
+
+	if permissionErr != nil {
+		return "", permissionErr
+	}
+	return "", fmt.Errorf("executable %q not found in PATH", executable)
+}

--- a/agent/go/internal/command/chroot_command_runner_test.go
+++ b/agent/go/internal/command/chroot_command_runner_test.go
@@ -1,0 +1,167 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package command
+
+import (
+	"context"
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Chroot command runner", func() {
+	It("wraps validation errors", func() {
+		_, err := NewRunner(WithChroot(GinkgoT().TempDir())).Run(context.Background(), Command{})
+
+		Expect(err).To(MatchError(ContainSubstring("validating chroot command execution")))
+	})
+
+	It("wraps executable permission errors", func() {
+		_, err := NewRunner(WithChroot(GinkgoT().TempDir())).Run(context.Background(), Command{
+			Executable:  "/missing",
+			Permissions: 0o755,
+		})
+
+		Expect(err).To(MatchError(ContainSubstring("applying chroot command executable permissions")))
+		Expect(errors.Is(err, fs.ErrNotExist)).To(BeTrue())
+	})
+
+	It("changes permissions relative to the chroot", func() {
+		root := GinkgoT().TempDir()
+		path := filepath.Join(root, "script")
+		Expect(os.WriteFile(path, []byte("not runnable in the test chroot"), 0o600)).To(Succeed())
+
+		_, err := NewRunner(WithChroot(root)).Run(context.Background(), Command{
+			Executable:  "/script",
+			Permissions: 0o755,
+		})
+
+		Expect(err).To(MatchError(ContainSubstring("executing chroot command")))
+		info, statErr := os.Stat(path)
+		Expect(statErr).NotTo(HaveOccurred())
+		Expect(info.Mode().Perm()).To(Equal(fs.FileMode(0o755)))
+	})
+})
+
+var _ = Describe("Chroot PATH lookup", func() {
+	It("searches every PATH entry inside the target root", func() {
+		rootPath := GinkgoT().TempDir()
+		Expect(os.Mkdir(filepath.Join(rootPath, "first"), 0o755)).To(Succeed())
+		Expect(os.Mkdir(filepath.Join(rootPath, "second"), 0o755)).To(Succeed())
+		writeExecutable(filepath.Join(rootPath, "second", "path-tool"))
+		root := openTestRoot(rootPath)
+
+		executable, err := lookPathInRoot(root, "/", "/first:/second", "path-tool")
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(executable).To(Equal("/second/path-tool"))
+	})
+
+	It("does not fall back to the host filesystem", func() {
+		rootPath := GinkgoT().TempDir()
+		Expect(os.Mkdir(filepath.Join(rootPath, "bin"), 0o755)).To(Succeed())
+
+		_, err := lookPathInRoot(openTestRoot(rootPath), "/", "/bin", "sh")
+
+		Expect(err).To(MatchError(ContainSubstring("executable \"sh\" not found in PATH")))
+	})
+
+	It("returns symlinks for the kernel to resolve inside the chroot", func() {
+		rootPath := GinkgoT().TempDir()
+		Expect(os.Mkdir(filepath.Join(rootPath, "bin"), 0o755)).To(Succeed())
+		Expect(os.Symlink("/real/tool", filepath.Join(rootPath, "bin", "tool"))).To(Succeed())
+
+		executable, err := lookPathInRoot(openTestRoot(rootPath), "/", "/bin", "tool")
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(executable).To(Equal("/bin/tool"))
+	})
+
+	It("resolves relative PATH entries against the working directory", func() {
+		rootPath := GinkgoT().TempDir()
+		Expect(os.MkdirAll(filepath.Join(rootPath, "work", "bin"), 0o755)).To(Succeed())
+		writeExecutable(filepath.Join(rootPath, "work", "bin", "tool"))
+
+		executable, err := lookPathInRoot(openTestRoot(rootPath), "/work", "bin", "tool")
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(executable).To(Equal("/work/bin/tool"))
+	})
+
+	It("does not search the working directory for an empty PATH", func() {
+		rootPath := GinkgoT().TempDir()
+		Expect(os.Mkdir(filepath.Join(rootPath, "work"), 0o755)).To(Succeed())
+		writeExecutable(filepath.Join(rootPath, "work", "tool"))
+
+		_, err := lookPathInRoot(openTestRoot(rootPath), "/work", "", "tool")
+
+		Expect(err).To(MatchError(ContainSubstring("executable \"tool\" not found in PATH")))
+	})
+
+	It("uses the working directory for an empty PATH component", func() {
+		rootPath := GinkgoT().TempDir()
+		Expect(os.Mkdir(filepath.Join(rootPath, "work"), 0o755)).To(Succeed())
+		writeExecutable(filepath.Join(rootPath, "work", "tool"))
+
+		executable, err := lookPathInRoot(openTestRoot(rootPath), "/work", ":", "tool")
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(executable).To(Equal("/work/tool"))
+	})
+
+	It("continues past non-executable candidates", func() {
+		rootPath := GinkgoT().TempDir()
+		Expect(os.Mkdir(filepath.Join(rootPath, "first"), 0o755)).To(Succeed())
+		Expect(os.Mkdir(filepath.Join(rootPath, "second"), 0o755)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(rootPath, "first", "tool"), nil, 0o600)).To(Succeed())
+		writeExecutable(filepath.Join(rootPath, "second", "tool"))
+
+		executable, err := lookPathInRoot(openTestRoot(rootPath), "/", "/first:/second", "tool")
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(executable).To(Equal("/second/tool"))
+	})
+
+	It("returns a permission error when no candidate is executable", func() {
+		rootPath := GinkgoT().TempDir()
+		Expect(os.Mkdir(filepath.Join(rootPath, "bin"), 0o755)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(rootPath, "bin", "tool"), nil, 0o600)).To(Succeed())
+
+		_, err := lookPathInRoot(openTestRoot(rootPath), "/", "/bin", "tool")
+
+		Expect(errors.Is(err, fs.ErrPermission)).To(BeTrue())
+	})
+})
+
+func openTestRoot(path string) *os.Root {
+	root, err := os.OpenRoot(path)
+	Expect(err).NotTo(HaveOccurred())
+	DeferCleanup(func() {
+		Expect(root.Close()).To(Succeed())
+	})
+	return root
+}
+
+func writeExecutable(path string) {
+	Expect(os.WriteFile(path, []byte("executable"), 0o755)).To(Succeed())
+}

--- a/agent/go/internal/command/command.go
+++ b/agent/go/internal/command/command.go
@@ -1,0 +1,198 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package command executes operating-system commands with caller-controlled
+// output handling and optional runner-level chroot isolation.
+//
+// Runner copies stdout and stderr concurrently into the writers supplied on
+// each Command. The package writes raw bytes without adding timestamps,
+// prefixes, or lifecycle policy, and it never closes caller-owned writers.
+// Passing a bytes.Buffer captures output in memory; passing os.Stdout or a
+// fan-out writer makes output visible as the process runs. Nil writers discard
+// their corresponding output.
+//
+// Paths in WorkingDirectory, Executable, and PATH are interpreted inside the
+// runner's chroot when it is constructed with WithChroot. A runner without
+// WithChroot executes against the caller's normal filesystem.
+//
+// Production support is Linux only. The package relies on chroot, Unix process
+// groups, and Unix signal semantics and does not provide a Windows implementation.
+package command
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"maps"
+	"path/filepath"
+	"slices"
+	"strings"
+)
+
+// Command describes one process invocation.
+//
+// Command is treated as caller-owned input. Run does not mutate Arguments or
+// Environment and does not close Stdout or Stderr.
+type Command struct {
+	// Executable is either a path or a name to resolve through PATH. The normal
+	// runner uses the agent's PATH through os/exec; a chroot runner resolves the
+	// name inside its configured root.
+	Executable string
+
+	// Arguments are passed to Executable without shell interpretation.
+	Arguments []string
+
+	// WorkingDirectory is the absolute directory in which the process starts.
+	// It is interpreted inside the runner's execution root. Empty uses the
+	// current directory for normal execution and "/" for chroot execution.
+	WorkingDirectory string
+
+	// Environment overrides variables inherited by the child process. The map is
+	// copied before use. As with os/exec, PATH does not affect normal-runner
+	// executable lookup; a chroot runner uses it for target-root lookup.
+	Environment map[string]string
+
+	// Stdout and Stderr receive raw process output as it is read. The two writers
+	// may be called concurrently, so a shared writer must be concurrency-safe.
+	// Nil writers discard their corresponding output.
+	Stdout io.Writer
+	Stderr io.Writer
+
+	// Permissions replaces the resolved executable's permission bits before
+	// starting it. Zero leaves its permissions unchanged. Executable must be
+	// absolute when Permissions is nonzero.
+	Permissions fs.FileMode
+}
+
+// CommandOption configures a Command created by NewCommand.
+type CommandOption func(*Command)
+
+// NewCommand returns a Command for executable with no arguments, inherited
+// environment, the current working directory, discarded output, and unchanged
+// executable permissions. A chrooted runner interprets the empty working
+// directory as "/" instead of the caller's current working directory.
+func NewCommand(executable string, options ...CommandOption) Command {
+	command := Command{
+		Executable:       executable,
+		Arguments:        []string{},
+		WorkingDirectory: "",
+		Environment:      map[string]string{},
+		Stdout:           io.Discard,
+		Stderr:           io.Discard,
+		Permissions:      0,
+	}
+	for _, option := range options {
+		option(&command)
+	}
+	return command
+}
+
+// WithArguments sets the arguments passed to the executable.
+func WithArguments(arguments ...string) CommandOption {
+	arguments = slices.Clone(arguments)
+	return func(command *Command) {
+		command.Arguments = slices.Clone(arguments)
+	}
+}
+
+// WithWorkingDirectory sets the command's initial working directory.
+func WithWorkingDirectory(directory string) CommandOption {
+	return func(command *Command) {
+		command.WorkingDirectory = directory
+	}
+}
+
+// WithEnvironment sets command-specific environment overrides.
+func WithEnvironment(environment map[string]string) CommandOption {
+	environment = maps.Clone(environment)
+	return func(command *Command) {
+		command.Environment = maps.Clone(environment)
+	}
+}
+
+// WithStdout sets the destination for the command's standard output.
+func WithStdout(writer io.Writer) CommandOption {
+	return func(command *Command) {
+		command.Stdout = writer
+	}
+}
+
+// WithStderr sets the destination for the command's standard error.
+func WithStderr(writer io.Writer) CommandOption {
+	return func(command *Command) {
+		command.Stderr = writer
+	}
+}
+
+// WithPermissions sets the executable's permission bits before it is run.
+func WithPermissions(permissions fs.FileMode) CommandOption {
+	return func(command *Command) {
+		command.Permissions = permissions
+	}
+}
+
+func (command Command) validate() error {
+	if command.Executable == "" {
+		return errors.New("command executable is empty")
+	}
+	if command.Permissions != command.Permissions.Perm() {
+		return errors.New("command permissions contain non-permission mode bits")
+	}
+	if command.Permissions != 0 && !filepath.IsAbs(command.Executable) {
+		return errors.New("command permissions require an absolute executable path")
+	}
+	if strings.ContainsRune(command.Executable, 0) {
+		return errors.New("command executable contains a NUL byte")
+	}
+	for index, argument := range command.Arguments {
+		if strings.ContainsRune(argument, 0) {
+			return fmt.Errorf("command argument %d contains a NUL byte", index)
+		}
+	}
+	if command.WorkingDirectory != "" {
+		if strings.ContainsRune(command.WorkingDirectory, 0) {
+			return errors.New("command working directory contains a NUL byte")
+		}
+		if !filepath.IsAbs(command.WorkingDirectory) {
+			return fmt.Errorf("working directory %q is not absolute", command.WorkingDirectory)
+		}
+	}
+	for _, name := range sortedEnvironmentNames(command.Environment) {
+		value := command.Environment[name]
+		if name == "" {
+			return errors.New("command environment contains an empty name")
+		}
+		if strings.ContainsRune(name, '=') {
+			return fmt.Errorf("command environment name %q contains '='", name)
+		}
+		if strings.ContainsRune(name, 0) || strings.ContainsRune(value, 0) {
+			return fmt.Errorf("command environment variable %q contains a NUL byte", name)
+		}
+	}
+	return nil
+}
+
+func sortedEnvironmentNames(environment map[string]string) []string {
+	names := make([]string, 0, len(environment))
+	for name := range environment {
+		names = append(names, name)
+	}
+	slices.Sort(names)
+	return names
+}

--- a/agent/go/internal/command/command_runner.go
+++ b/agent/go/internal/command/command_runner.go
@@ -1,0 +1,56 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package command
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+)
+
+type commandRunner struct{}
+
+var _ Runner = (*commandRunner)(nil)
+
+func (*commandRunner) Run(ctx context.Context, command Command) (Result, error) {
+	if err := validateRun(ctx, command); err != nil {
+		return Result{}, fmt.Errorf("validating command execution: %w", err)
+	}
+	if command.Permissions != 0 {
+		executableFile, err := os.Open(command.Executable)
+		if err != nil {
+			return Result{}, fmt.Errorf(
+				"applying command executable permissions: opening command executable %q: %w",
+				command.Executable,
+				err,
+			)
+		}
+		permissionsErr := applyExecutablePermissions(ctx, command, executableFile)
+		closeErr := closeExecutable(command, executableFile)
+		if err := errors.Join(permissionsErr, closeErr); err != nil {
+			return Result{}, fmt.Errorf("applying command executable permissions: %w", err)
+		}
+	}
+	result, err := executeCommand(ctx, command, command.Executable, command.WorkingDirectory, "")
+	if err != nil {
+		return result, fmt.Errorf("executing command: %w", err)
+	}
+	return result, nil
+}

--- a/agent/go/internal/command/command_runner_test.go
+++ b/agent/go/internal/command/command_runner_test.go
@@ -1,0 +1,99 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package command
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Command runner executable permissions", func() {
+	It("requires an absolute executable path", func() {
+		_, err := NewRunner().Run(context.Background(), Command{
+			Executable:  "script",
+			Permissions: 0o755,
+		})
+
+		Expect(err).To(MatchError(ContainSubstring("validating command execution")))
+		Expect(err).To(MatchError(ContainSubstring("permissions require an absolute executable path")))
+	})
+
+	It("wraps executable permission errors", func() {
+		path := filepath.Join(GinkgoT().TempDir(), "missing")
+
+		_, err := NewRunner().Run(context.Background(), Command{
+			Executable:  path,
+			Permissions: 0o755,
+		})
+
+		Expect(err).To(MatchError(ContainSubstring("applying command executable permissions")))
+		Expect(errors.Is(err, fs.ErrNotExist)).To(BeTrue())
+	})
+
+	It("preserves executable permissions by default", func() {
+		path := filepath.Join(GinkgoT().TempDir(), "script")
+		Expect(os.WriteFile(path, []byte("#!/bin/sh\nexit 0"), 0o555)).To(Succeed())
+		Expect(os.Chmod(path, 0o555)).To(Succeed())
+
+		result, err := NewRunner().Run(context.Background(), NewCommand(path))
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.ExitCode).To(Equal(SuccessExitCode))
+		info, err := os.Stat(path)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(info.Mode().Perm()).To(Equal(fs.FileMode(0o555)))
+	})
+
+	It("sets the requested executable permissions", func() {
+		path := filepath.Join(GinkgoT().TempDir(), "script")
+		Expect(os.WriteFile(path, []byte("#!/bin/sh\nprintf executable"), 0o640)).To(Succeed())
+		var stdout bytes.Buffer
+
+		result, err := NewRunner().Run(context.Background(), Command{
+			Executable:  path,
+			Stdout:      &stdout,
+			Permissions: 0o755,
+		})
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.ExitCode).To(Equal(SuccessExitCode))
+		Expect(stdout.String()).To(Equal("executable"))
+		info, err := os.Stat(path)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(info.Mode().Perm()).To(Equal(fs.FileMode(0o755)))
+	})
+
+	It("returns a permission error when execute bits are required but absent", func() {
+		path := filepath.Join(GinkgoT().TempDir(), "script")
+		Expect(os.WriteFile(path, []byte("#!/bin/sh\nexit 0"), 0o600)).To(Succeed())
+
+		_, err := NewRunner().Run(context.Background(), Command{Executable: path})
+
+		Expect(err).To(MatchError(ContainSubstring("executing command")))
+		Expect(err).To(HaveOccurred())
+		Expect(errors.Is(err, fs.ErrPermission)).To(BeTrue())
+	})
+})

--- a/agent/go/internal/command/command_test.go
+++ b/agent/go/internal/command/command_test.go
@@ -1,0 +1,153 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package command
+
+import (
+	"bytes"
+	"io"
+	"io/fs"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestCommand(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Command Suite")
+}
+
+var _ = Describe("Command constructor", func() {
+	It("sets every command default", func() {
+		command := NewCommand("test")
+
+		Expect(command).To(Equal(Command{
+			Executable:       "test",
+			Arguments:        []string{},
+			WorkingDirectory: "",
+			Environment:      map[string]string{},
+			Stdout:           io.Discard,
+			Stderr:           io.Discard,
+			Permissions:      0,
+		}))
+	})
+
+	It("applies every option without retaining caller-owned data", func() {
+		arguments := []string{"first", "second"}
+		environment := map[string]string{"NAME": "value"}
+		argumentOption := WithArguments(arguments...)
+		environmentOption := WithEnvironment(environment)
+		stdout := &bytes.Buffer{}
+		stderr := &bytes.Buffer{}
+
+		command := NewCommand(
+			"test",
+			argumentOption,
+			WithWorkingDirectory("/work"),
+			environmentOption,
+			WithStdout(stdout),
+			WithStderr(stderr),
+			WithPermissions(0o700),
+		)
+
+		arguments[0] = "changed"
+		environment["NAME"] = "changed"
+		Expect(command.Arguments).To(Equal([]string{"first", "second"}))
+		Expect(command.WorkingDirectory).To(Equal("/work"))
+		Expect(command.Environment).To(Equal(map[string]string{"NAME": "value"}))
+		Expect(command.Stdout).To(BeIdenticalTo(stdout))
+		Expect(command.Stderr).To(BeIdenticalTo(stderr))
+		Expect(command.Permissions).To(Equal(fs.FileMode(0o700)))
+
+		second := NewCommand("test", argumentOption, environmentOption)
+		command.Arguments[0] = "mutated"
+		command.Environment["NAME"] = "mutated"
+		Expect(second.Arguments).To(Equal([]string{"first", "second"}))
+		Expect(second.Environment).To(Equal(map[string]string{"NAME": "value"}))
+	})
+})
+
+var _ = Describe("Command validation", func() {
+	DescribeTable("rejects invalid fields",
+		func(command Command, expected string) {
+			Expect(command.validate()).To(MatchError(ContainSubstring(expected)))
+		},
+		Entry("empty executable", Command{}, "command executable is empty"),
+		Entry(
+			"non-permission mode bits",
+			Command{Executable: "/bin/true", Permissions: fs.ModeDir | 0o755},
+			"permissions contain non-permission mode bits",
+		),
+		Entry(
+			"relative executable with permissions",
+			Command{Executable: "script", Permissions: 0o755},
+			"permissions require an absolute executable path",
+		),
+		Entry("NUL executable", Command{Executable: "bad\x00name"}, "executable contains a NUL byte"),
+		Entry(
+			"NUL argument",
+			Command{Executable: "/bin/true", Arguments: []string{"bad\x00value"}},
+			"argument 0 contains a NUL byte",
+		),
+		Entry(
+			"NUL working directory",
+			Command{Executable: "/bin/true", WorkingDirectory: "/bad\x00directory"},
+			"working directory contains a NUL byte",
+		),
+		Entry(
+			"relative working directory",
+			Command{Executable: "/bin/true", WorkingDirectory: "tmp"},
+			"working directory \"tmp\" is not absolute",
+		),
+		Entry(
+			"empty environment name",
+			Command{Executable: "/bin/true", Environment: map[string]string{"": "value"}},
+			"environment contains an empty name",
+		),
+		Entry(
+			"environment name containing equals",
+			Command{Executable: "/bin/true", Environment: map[string]string{"BAD=NAME": "value"}},
+			"environment name \"BAD=NAME\" contains '='",
+		),
+		Entry(
+			"NUL environment name",
+			Command{Executable: "/bin/true", Environment: map[string]string{"BAD\x00NAME": "value"}},
+			"environment variable \"BAD\\x00NAME\" contains a NUL byte",
+		),
+		Entry(
+			"NUL environment value",
+			Command{Executable: "/bin/true", Environment: map[string]string{"NAME": "bad\x00value"}},
+			"environment variable \"NAME\" contains a NUL byte",
+		),
+	)
+
+	It("reports invalid environment variables in name order", func() {
+		command := Command{
+			Executable: "test",
+			Environment: map[string]string{
+				"BAD=NAME": "value",
+				"":         "value",
+			},
+		}
+
+		err := command.validate()
+
+		Expect(err).To(MatchError("command environment contains an empty name"))
+	})
+})

--- a/agent/go/internal/command/execution.go
+++ b/agent/go/internal/command/execution.go
@@ -1,0 +1,139 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package command
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"os/exec"
+	"syscall"
+	"time"
+)
+
+// processWaitDelay bounds cleanup when a descendant keeps an inherited pipe
+// open after the command exits or context cancellation begins.
+const processWaitDelay = 2 * time.Second
+
+func validateRun(ctx context.Context, command Command) error {
+	if ctx == nil {
+		return errors.New("validating command context: command context is nil")
+	}
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("validating command context: command context is not runnable: %w", err)
+	}
+	if err := command.validate(); err != nil {
+		return fmt.Errorf("validating command %q: %w", command.Executable, err)
+	}
+	return nil
+}
+
+func applyExecutablePermissions(
+	ctx context.Context,
+	command Command,
+	file *os.File,
+) error {
+	info, err := file.Stat()
+	if err != nil {
+		return fmt.Errorf("checking command executable %q: %w", command.Executable, err)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("command executable %q is not a regular file: %w", command.Executable, fs.ErrPermission)
+	}
+	if info.Mode().Perm() == command.Permissions {
+		return nil
+	}
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("running command %q: %w", command.Executable, err)
+	}
+	if err := file.Chmod(command.Permissions); err != nil {
+		return fmt.Errorf("setting permissions on %q: %w", command.Executable, err)
+	}
+	return nil
+}
+
+func closeExecutable(command Command, file *os.File) error {
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("closing command executable %q: %w", command.Executable, err)
+	}
+	return nil
+}
+
+func executeCommand(
+	ctx context.Context,
+	command Command,
+	executable string,
+	workingDirectory string,
+	chroot string,
+) (result Result, err error) {
+	if err := ctx.Err(); err != nil {
+		return Result{}, fmt.Errorf("running command %q: %w", command.Executable, err)
+	}
+
+	process := exec.CommandContext(ctx, executable, command.Arguments...)
+	process.Args[0] = command.Executable
+	process.Dir = workingDirectory
+	process.Env = process.Environ()
+	for _, name := range sortedEnvironmentNames(command.Environment) {
+		process.Env = append(process.Env, name+"="+command.Environment[name])
+	}
+	process.Stdout = command.Stdout
+	process.Stderr = command.Stderr
+	process.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if chroot != "" {
+		process.SysProcAttr.Chroot = chroot
+	}
+	process.Cancel = func() error {
+		if process.Process == nil {
+			return os.ErrProcessDone
+		}
+		if err := syscall.Kill(-process.Process.Pid, syscall.SIGKILL); err != nil {
+			if errors.Is(err, syscall.ESRCH) {
+				return os.ErrProcessDone
+			}
+			return fmt.Errorf("killing process group %d: %w", process.Process.Pid, err)
+		}
+		return nil
+	}
+	process.WaitDelay = processWaitDelay
+
+	runErr := process.Run()
+	if process.ProcessState != nil {
+		result.ExitCode = ExitCode(process.ProcessState.ExitCode())
+		if waitStatus, ok := process.ProcessState.Sys().(syscall.WaitStatus); ok && waitStatus.Signaled() {
+			result.Signal = waitStatus.Signal()
+		}
+	}
+	if runErr == nil {
+		return result, nil
+	}
+	if err := ctx.Err(); err != nil {
+		return result, fmt.Errorf("running command %q: %w", command.Executable, err)
+	}
+	var exitErr *exec.ExitError
+	if errors.As(runErr, &exitErr) {
+		return result, nil
+	}
+	if process.Process == nil {
+		return result, fmt.Errorf("starting command %q: %w", command.Executable, runErr)
+	}
+	return result, fmt.Errorf("waiting for command %q: %w", command.Executable, runErr)
+}

--- a/agent/go/internal/command/execution_test.go
+++ b/agent/go/internal/command/execution_test.go
@@ -1,0 +1,333 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package command
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"maps"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+type errorWriter struct {
+	err error
+}
+
+func (w errorWriter) Write(_ []byte) (int, error) {
+	return 0, w.err
+}
+
+type observingWriter struct {
+	writes chan<- string
+}
+
+func (w observingWriter) Write(data []byte) (int, error) {
+	w.writes <- string(data)
+	return len(data), nil
+}
+
+var _ = Describe("Command execution validation", func() {
+	It("rejects a nil context", func() {
+		var ctx context.Context
+		_, err := NewRunner().Run(ctx, Command{Executable: "/bin/true"})
+		Expect(err).To(MatchError(ContainSubstring("validating command execution")))
+		Expect(err).To(MatchError(ContainSubstring("command context is nil")))
+	})
+
+	It("preserves cancellation as an error cause", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		_, err := NewRunner().Run(ctx, Command{Executable: "/bin/true"})
+
+		Expect(err).To(MatchError(ContainSubstring("command context is not runnable")))
+		Expect(errors.Is(err, context.Canceled)).To(BeTrue())
+	})
+
+	It("returns a start error for a missing working directory", func() {
+		_, err := NewRunner().Run(context.Background(), Command{
+			Executable:       "/bin/true",
+			WorkingDirectory: filepath.Join(GinkgoT().TempDir(), "missing"),
+		})
+
+		Expect(err).To(MatchError(ContainSubstring("executing command")))
+		Expect(err).To(MatchError(ContainSubstring("starting command")))
+		Expect(errors.Is(err, fs.ErrNotExist)).To(BeTrue())
+	})
+})
+
+var _ = Describe("Command execution environment and process setup", func() {
+	It("uses os/exec lookup and passes the command PATH to the child", func() {
+		var stdout bytes.Buffer
+
+		result, err := NewRunner().Run(context.Background(), NewCommand(
+			"sh",
+			WithArguments("-c", "printf %s \"$PATH\""),
+			WithEnvironment(map[string]string{"PATH": "/command/path"}),
+			WithStdout(&stdout),
+		))
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(Result{ExitCode: SuccessExitCode}))
+		Expect(stdout.String()).To(Equal("/command/path"))
+	})
+
+	It("merges inherited values with overrides without mutating caller data", func() {
+		const inheritedName = "NODEWRIGHT_COMMAND_INHERITED"
+		const overriddenName = "NODEWRIGHT_COMMAND_OVERRIDDEN"
+		setEnvironment(inheritedName, "inherited")
+		setEnvironment(overriddenName, "parent")
+
+		environment := map[string]string{overriddenName: "command", "COMMAND_ONLY": "only"}
+		arguments := []string{"-c", fmt.Sprintf("printf '%%s|%%s|%%s' \"$%s\" \"$%s\" \"$COMMAND_ONLY\"", inheritedName, overriddenName)}
+		expectedEnvironment := maps.Clone(environment)
+		expectedArguments := append([]string(nil), arguments...)
+		var stdout bytes.Buffer
+
+		result, err := NewRunner().Run(context.Background(), Command{
+			Executable:  "/bin/sh",
+			Arguments:   arguments,
+			Environment: environment,
+			Stdout:      &stdout,
+		})
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(Result{ExitCode: 0}))
+		Expect(stdout.String()).To(Equal("inherited|command|only"))
+		Expect(environment).To(Equal(expectedEnvironment))
+		Expect(arguments).To(Equal(expectedArguments))
+	})
+
+	It("uses the requested working directory", func() {
+		workingDirectory := GinkgoT().TempDir()
+		var stdout bytes.Buffer
+
+		_, err := NewRunner().Run(context.Background(), Command{
+			Executable:       "/bin/pwd",
+			WorkingDirectory: workingDirectory,
+			Stdout:           &stdout,
+		})
+
+		Expect(err).NotTo(HaveOccurred())
+		resolvedWorkingDirectory, err := filepath.Abs(workingDirectory)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(strings.TrimSpace(stdout.String())).To(Equal(resolvedWorkingDirectory))
+	})
+
+	It("builds the environment after setting the working directory", func() {
+		workingDirectory := GinkgoT().TempDir()
+		var stdout bytes.Buffer
+
+		_, err := NewRunner().Run(context.Background(), Command{
+			Executable:       "/bin/sh",
+			Arguments:        []string{"-c", "printf %s \"$PWD\""},
+			WorkingDirectory: workingDirectory,
+			Stdout:           &stdout,
+		})
+
+		Expect(err).NotTo(HaveOccurred())
+		resolvedWorkingDirectory, err := filepath.Abs(workingDirectory)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(stdout.String()).To(Equal(resolvedWorkingDirectory))
+	})
+})
+
+var _ = Describe("Command execution streaming", func() {
+	It("copies raw stdout and stderr", func() {
+		var stdout, stderr bytes.Buffer
+
+		result, err := NewRunner().Run(context.Background(), Command{
+			Executable: "/bin/sh",
+			Arguments:  []string{"-c", "printf 'stdout\\nraw'; printf 'stderr\\nraw' >&2"},
+			Stdout:     &stdout,
+			Stderr:     &stderr,
+		})
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.ExitCode).To(Equal(SuccessExitCode))
+		Expect(stdout.String()).To(Equal("stdout\nraw"))
+		Expect(stderr.String()).To(Equal("stderr\nraw"))
+	})
+
+	It("writes output before the process exits", func() {
+		release := filepath.Join(GinkgoT().TempDir(), "release")
+		writes := make(chan string, 2)
+		done := make(chan error, 1)
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		go func() {
+			_, err := NewRunner().Run(ctx, Command{
+				Executable: "/bin/sh",
+				Arguments: []string{
+					"-c",
+					"printf first; while [ ! -e \"$1\" ]; do sleep 0.01; done; printf second",
+					"sh",
+					release,
+				},
+				Stdout: observingWriter{writes: writes},
+			})
+			done <- err
+		}()
+
+		Eventually(writes).Should(Receive(Equal("first")))
+		Consistently(done, 100*time.Millisecond).ShouldNot(Receive())
+		Expect(os.WriteFile(release, nil, 0o600)).To(Succeed())
+		Eventually(done).Should(Receive(BeNil()))
+		Eventually(writes).Should(Receive(Equal("second")))
+	})
+
+	It("discards streams when writers are nil", func() {
+		result, err := NewRunner().Run(context.Background(), Command{
+			Executable: "/bin/sh",
+			Arguments:  []string{"-c", "printf output; printf error >&2"},
+		})
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.ExitCode).To(Equal(SuccessExitCode))
+	})
+
+	DescribeTable("returns writer errors from os/exec",
+		func(failStdout, failStderr bool) {
+			writerError := errors.New("writer failed")
+			command := Command{
+				Executable: "/bin/sh",
+				Arguments:  []string{"-c", "printf stdout; printf stderr >&2"},
+			}
+			if failStdout {
+				command.Stdout = errorWriter{err: writerError}
+			}
+			if failStderr {
+				command.Stderr = errorWriter{err: writerError}
+			}
+
+			_, err := NewRunner().Run(context.Background(), command)
+
+			Expect(errors.Is(err, writerError)).To(BeTrue())
+		},
+		Entry("stdout", true, false),
+		Entry("stderr", false, true),
+	)
+
+	It("uses os/exec's exit-error precedence when output and execution both fail", func() {
+		writerError := errors.New("writer failed")
+
+		result, err := NewRunner().Run(context.Background(), Command{
+			Executable: "/bin/sh",
+			Arguments:  []string{"-c", "printf stdout; exit 23"},
+			Stdout:     errorWriter{err: writerError},
+		})
+
+		Expect(result).To(Equal(Result{ExitCode: 23}))
+		Expect(err).NotTo(HaveOccurred())
+	})
+})
+
+var _ = Describe("Command execution results", func() {
+	It("returns zero for successful execution", func() {
+		result, err := NewRunner().Run(context.Background(), Command{
+			Executable: "/bin/sh",
+			Arguments:  []string{"-c", "exit 0"},
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(Result{ExitCode: 0}))
+	})
+
+	It("returns normal nonzero exit codes without a runner error", func() {
+		result, err := NewRunner().Run(context.Background(), Command{
+			Executable: "/bin/sh",
+			Arguments:  []string{"-c", "exit 23"},
+		})
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(Result{ExitCode: 23}))
+	})
+
+	It("reports the Go exit code and terminating signal", func() {
+		result, err := NewRunner().Run(context.Background(), Command{
+			Executable: "/bin/sh",
+			Arguments:  []string{"-c", "kill -TERM $$"},
+		})
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(Result{ExitCode: -1, Signal: syscall.SIGTERM}))
+	})
+
+	It("returns context cancellation as a runner error", func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+		defer cancel()
+
+		_, err := NewRunner().Run(ctx, Command{
+			Executable: "/bin/sh",
+			Arguments:  []string{"-c", "sleep 10"},
+		})
+
+		Expect(err).To(HaveOccurred())
+		Expect(errors.Is(err, context.DeadlineExceeded)).To(BeTrue())
+	})
+
+	It("bounds cancellation when a background child retains output pipes", func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+		defer cancel()
+		started := time.Now()
+
+		_, err := NewRunner().Run(ctx, Command{
+			Executable: "/bin/sh",
+			Arguments:  []string{"-c", "sleep 10 & wait"},
+			Stdout:     io.Discard,
+			Stderr:     io.Discard,
+		})
+
+		Expect(errors.Is(err, context.DeadlineExceeded)).To(BeTrue())
+		Expect(time.Since(started)).To(BeNumerically("<", processWaitDelay))
+	})
+
+	It("returns start failures as runner errors", func() {
+		path := filepath.Join(GinkgoT().TempDir(), "invalid-binary")
+		Expect(os.WriteFile(path, []byte("not an executable format"), 0o755)).To(Succeed())
+
+		_, err := NewRunner().Run(context.Background(), Command{Executable: path})
+
+		Expect(err).To(MatchError(ContainSubstring("starting command")))
+	})
+
+})
+
+func setEnvironment(name, value string) {
+	original, existed := os.LookupEnv(name)
+	Expect(os.Setenv(name, value)).To(Succeed())
+	DeferCleanup(func() {
+		if existed {
+			Expect(os.Setenv(name, original)).To(Succeed())
+		} else {
+			Expect(os.Unsetenv(name)).To(Succeed())
+		}
+	})
+}

--- a/agent/go/internal/command/runner.go
+++ b/agent/go/internal/command/runner.go
@@ -1,0 +1,84 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package command
+
+import (
+	"context"
+	"os"
+)
+
+// ExitCode is a process exit status.
+type ExitCode int
+
+// SuccessExitCode indicates that the process exited successfully.
+const SuccessExitCode ExitCode = 0
+
+// Result reports how a started process completed.
+//
+// A nonzero ExitCode does not by itself cause Runner.Run to return an error.
+type Result struct {
+	// ExitCode uses os.ProcessState.ExitCode semantics. It contains the process
+	// exit status, or -1 when the process was terminated by a signal.
+	ExitCode ExitCode
+
+	// Signal identifies the signal that terminated the process. It is nil when
+	// the process exited normally.
+	Signal os.Signal
+}
+
+// Runner executes commands and copies their output to caller-provided writers.
+//
+// Errors report failures in validation, path resolution, permission changes,
+// process setup, cancellation, output copying, or waiting. Once a process
+// starts and exits normally, its status is returned through Result even when
+// that status is nonzero.
+type Runner interface {
+	Run(context.Context, Command) (Result, error)
+}
+
+type runnerConfig struct {
+	chroot *string
+}
+
+// RunnerOption configures a Runner created by NewRunner.
+type RunnerOption func(*runnerConfig)
+
+// NewRunner returns a Runner for the requested execution environment. With no
+// options, commands execute against the caller's normal filesystem.
+func NewRunner(options ...RunnerOption) Runner {
+	config := runnerConfig{
+		chroot: nil,
+	}
+
+	for _, option := range options {
+		option(&config)
+	}
+
+	if config.chroot != nil {
+		return &chrootCommandRunner{root: *config.chroot}
+	}
+	return &commandRunner{}
+}
+
+// WithChroot configures a Runner to execute every command inside root.
+func WithChroot(root string) RunnerOption {
+	return func(config *runnerConfig) {
+		config.chroot = &root
+	}
+}

--- a/agent/go/internal/command/runner_test.go
+++ b/agent/go/internal/command/runner_test.go
@@ -1,0 +1,87 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package command
+
+import (
+	"context"
+	"errors"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+type fakeRunner struct {
+	command Command
+	result  Result
+	err     error
+}
+
+var _ Runner = (*fakeRunner)(nil)
+
+func (f *fakeRunner) Run(_ context.Context, command Command) (Result, error) {
+	f.command = command
+	return f.result, f.err
+}
+
+var _ = Describe("Runner", func() {
+	It("constructs a non-nil interface implementation", func() {
+		runner := NewRunner()
+		Expect(runner).NotTo(BeNil())
+	})
+
+	It("applies options to shared configuration in order", func() {
+		var observedChroot string
+		observeChroot := func(config *runnerConfig) {
+			if config.chroot != nil {
+				observedChroot = *config.chroot
+			}
+		}
+
+		runner := NewRunner(WithChroot("/target"), observeChroot)
+
+		Expect(runner).NotTo(BeNil())
+		Expect(observedChroot).To(Equal("/target"))
+	})
+
+	DescribeTable("validates the chroot configured by WithChroot",
+		func(root, expected string) {
+			_, err := NewRunner(WithChroot(root)).Run(
+				context.Background(),
+				NewCommand("/bin/true"),
+			)
+
+			Expect(err).To(MatchError(ContainSubstring("preparing chroot command execution")))
+			Expect(err).To(MatchError(ContainSubstring(expected)))
+		},
+		Entry("empty", "", "command chroot is empty"),
+		Entry("relative", "tmp", "chroot \"tmp\" is not absolute"),
+		Entry("NUL", "/tmp/bad\x00root", "command chroot contains a NUL byte"),
+	)
+
+	It("permits downstream substitution through the interface", func() {
+		command := NewCommand("test")
+		fake := &fakeRunner{result: Result{ExitCode: 7}, err: errors.New("failed")}
+
+		result, err := fake.Run(context.Background(), command)
+
+		Expect(result).To(Equal(Result{ExitCode: 7}))
+		Expect(err).To(MatchError("failed"))
+		Expect(fake.command).To(Equal(command))
+	})
+})

--- a/agent/go/internal/flags/flags_test.go
+++ b/agent/go/internal/flags/flags_test.go
@@ -23,6 +23,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/NVIDIA/nodewright/agent/internal/command"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -50,7 +52,7 @@ var _ = Describe("flag store", func() {
 		value = step.NewRegularStep(
 			"scripts/apply.sh",
 			step.WithArguments([]string{"--mode", "fast"}),
-			step.WithReturncodes([]int{0, 2}),
+			step.WithReturncodes([]command.ExitCode{0, 2}),
 		)
 
 		var err error
@@ -91,9 +93,9 @@ var _ = Describe("flag store", func() {
 		hostExecutionChanged.OnHost = false
 
 		cases := []step.RegularStep{
-			step.NewRegularStep("scripts/other.sh", step.WithArguments([]string{"--mode", "fast"}), step.WithReturncodes([]int{0, 2})),
-			step.NewRegularStep("scripts/apply.sh", step.WithArguments([]string{"--mode", "slow"}), step.WithReturncodes([]int{0, 2})),
-			step.NewRegularStep("scripts/apply.sh", step.WithArguments([]string{"--mode", "fast"}), step.WithReturncodes([]int{0})),
+			step.NewRegularStep("scripts/other.sh", step.WithArguments([]string{"--mode", "fast"}), step.WithReturncodes([]command.ExitCode{0, 2})),
+			step.NewRegularStep("scripts/apply.sh", step.WithArguments([]string{"--mode", "slow"}), step.WithReturncodes([]command.ExitCode{0, 2})),
+			step.NewRegularStep("scripts/apply.sh", step.WithArguments([]string{"--mode", "fast"}), step.WithReturncodes([]command.ExitCode{command.SuccessExitCode})),
 			environmentChanged,
 			hostExecutionChanged,
 		}

--- a/agent/go/internal/step/regular_step.go
+++ b/agent/go/internal/step/regular_step.go
@@ -23,6 +23,8 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+
+	"github.com/NVIDIA/nodewright/agent/internal/command"
 )
 
 // RegularStep is the default Step implementation. Its fields are
@@ -31,21 +33,22 @@ import (
 // codec, so no custom marshaler is needed here.
 //
 // applyDefaults makes Name fall back to ScriptPath, Arguments to []string{},
-// Returncodes to []int{0}, Env to map[string]string{}, and Idempotence to Auto.
+// Returncodes to command.SuccessExitCode, Env to map[string]string{}, and
+// Idempotence to Auto.
 // NewRegularStep additionally defaults OnHost to true.
 //
 // ScriptPath carries the json:"path" wire name and IdempotenceMode the
 // json:"idempotence" wire name; both fields are named distinctly so
 // RegularStep can expose Path() and Idempotence() to satisfy Step.
 type RegularStep struct {
-	Name            string            `json:"name"`
-	ScriptPath      string            `json:"path"`
-	Arguments       []string          `json:"arguments"`
-	Returncodes     []int             `json:"returncodes"`
-	OnHost          bool              `json:"on_host"`
-	IdempotenceMode Idempotence       `json:"idempotence"`
-	UpgradeStep     bool              `json:"upgrade_step"`
-	Env             map[string]string `json:"env,omitempty"`
+	Name            string             `json:"name"`
+	ScriptPath      string             `json:"path"`
+	Arguments       []string           `json:"arguments"`
+	Returncodes     []command.ExitCode `json:"returncodes"`
+	OnHost          bool               `json:"on_host"`
+	IdempotenceMode Idempotence        `json:"idempotence"`
+	UpgradeStep     bool               `json:"upgrade_step"`
+	Env             map[string]string  `json:"env,omitempty"`
 
 	// RequiresInterrupt round-trips via the wire as "requires_interrupt",
 	// emitted only when true; it stays schema-valid because the step schema
@@ -71,18 +74,18 @@ func (s RegularStep) Fingerprint() (string, error) {
 	}
 	returnCodes := s.Returncodes
 	if returnCodes == nil {
-		returnCodes = []int{}
+		returnCodes = []command.ExitCode{}
 	}
 	env := s.Env
 	if env == nil {
 		env = map[string]string{}
 	}
 	payload, err := json.Marshal(struct {
-		Path        string            `json:"path"`
-		Arguments   []string          `json:"arguments"`
-		ReturnCodes []int             `json:"returnCodes"`
-		Env         map[string]string `json:"env"`
-		OnHost      bool              `json:"onHost"`
+		Path        string             `json:"path"`
+		Arguments   []string           `json:"arguments"`
+		ReturnCodes []command.ExitCode `json:"returnCodes"`
+		Env         map[string]string  `json:"env"`
+		OnHost      bool               `json:"onHost"`
 	}{
 		Path:        s.ScriptPath,
 		Arguments:   arguments,
@@ -137,7 +140,7 @@ func WithArguments(args []string) RegularStepOption {
 }
 
 // WithReturncodes sets the accepted return codes (default: [0]).
-func WithReturncodes(codes []int) RegularStepOption {
+func WithReturncodes(codes []command.ExitCode) RegularStepOption {
 	return func(s *RegularStep) { s.Returncodes = codes }
 }
 
@@ -191,7 +194,7 @@ func (s *RegularStep) applyDefaults() {
 		s.Arguments = []string{}
 	}
 	if len(s.Returncodes) == 0 {
-		s.Returncodes = []int{0}
+		s.Returncodes = []command.ExitCode{command.SuccessExitCode}
 	}
 	if s.Env == nil {
 		s.Env = map[string]string{}

--- a/agent/go/internal/step/regular_step_test.go
+++ b/agent/go/internal/step/regular_step_test.go
@@ -19,6 +19,8 @@
 package step
 
 import (
+	"github.com/NVIDIA/nodewright/agent/internal/command"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -45,7 +47,7 @@ var _ = Describe("RegularStep.applyDefaults", func() {
 	It("defaults returncodes to [0]", func() {
 		s := RegularStep{ScriptPath: "foo.sh"}
 		s.applyDefaults()
-		Expect(s.Returncodes).To(Equal([]int{0}))
+		Expect(s.Returncodes).To(Equal([]command.ExitCode{command.SuccessExitCode}))
 	})
 
 	It("defaults env to an empty map", func() {
@@ -97,7 +99,7 @@ var _ = Describe("NewRegularStep", func() {
 		Expect(s.ScriptPath).To(Equal("foo.sh"))
 		Expect(s.Name).To(Equal("foo.sh"))
 		Expect(s.Arguments).To(Equal([]string{}))
-		Expect(s.Returncodes).To(Equal([]int{0}))
+		Expect(s.Returncodes).To(Equal([]command.ExitCode{command.SuccessExitCode}))
 		Expect(s.Env).To(Equal(map[string]string{}))
 		Expect(s.OnHost).To(BeTrue())
 		Expect(s.Idempotence()).To(Equal(Auto))
@@ -119,7 +121,7 @@ var _ = Describe("NewRegularStep", func() {
 			"foo.sh",
 			WithName("custom"),
 			WithArguments([]string{"-x", "y"}),
-			WithReturncodes([]int{0, 2}),
+			WithReturncodes([]command.ExitCode{0, 2}),
 			WithEnv(map[string]string{"K": "V"}),
 			WithOnHost(false),
 			WithIdempotence(Disabled),
@@ -127,7 +129,7 @@ var _ = Describe("NewRegularStep", func() {
 		)
 		Expect(s.Name).To(Equal("custom"))
 		Expect(s.Arguments).To(Equal([]string{"-x", "y"}))
-		Expect(s.Returncodes).To(Equal([]int{0, 2}))
+		Expect(s.Returncodes).To(Equal([]command.ExitCode{0, 2}))
 		Expect(s.Env).To(Equal(map[string]string{"K": "V"}))
 		Expect(s.OnHost).To(BeFalse())
 		Expect(s.Idempotence()).To(Equal(Disabled))

--- a/agent/go/internal/step/step_test.go
+++ b/agent/go/internal/step/step_test.go
@@ -22,6 +22,8 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/NVIDIA/nodewright/agent/internal/command"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -52,7 +54,7 @@ var _ = Describe("Step interface", func() {
 			Name:            "explicit-name",
 			ScriptPath:      "foo.sh",
 			Arguments:       []string{},
-			Returncodes:     []int{0},
+			Returncodes:     []command.ExitCode{command.SuccessExitCode},
 			Env:             map[string]string{"K": "V"},
 			OnHost:          true,
 			IdempotenceMode: Auto,
@@ -62,7 +64,7 @@ var _ = Describe("Step interface", func() {
 		Expect(u.Name).To(Equal("explicit-name"))
 		Expect(u.ScriptPath).To(Equal("foo.sh"))
 		Expect(u.Arguments).To(Equal([]string{}))
-		Expect(u.Returncodes).To(Equal([]int{0}))
+		Expect(u.Returncodes).To(Equal([]command.ExitCode{command.SuccessExitCode}))
 		Expect(u.Env).To(Equal(map[string]string{"K": "V"}))
 		Expect(u.OnHost).To(BeTrue())
 		Expect(u.Idempotence()).To(Equal(Auto))
@@ -112,7 +114,7 @@ var _ = Describe("Decode", func() {
 		Expect(rs.Name).To(Equal("foo.sh"))
 		Expect(rs.ScriptPath).To(Equal("foo.sh"))
 		Expect(rs.Arguments).To(Equal([]string{}))
-		Expect(rs.Returncodes).To(Equal([]int{0}))
+		Expect(rs.Returncodes).To(Equal([]command.ExitCode{command.SuccessExitCode}))
 		Expect(rs.OnHost).To(BeTrue())
 		Expect(rs.Env).To(Equal(map[string]string{}))
 		Expect(rs.Idempotence()).To(Equal(Auto))
@@ -163,7 +165,7 @@ var _ = Describe("Encode/Decode round-trip", func() {
 			Name:            "foo",
 			ScriptPath:      "foo",
 			Arguments:       []string{},
-			Returncodes:     []int{0},
+			Returncodes:     []command.ExitCode{command.SuccessExitCode},
 			OnHost:          true,
 			IdempotenceMode: Disabled,
 		}
@@ -183,7 +185,7 @@ var _ = Describe("Encode/Decode round-trip", func() {
 		start, err := NewUpgradeStep(
 			"upgrade",
 			WithName("upgrade"),
-			WithReturncodes([]int{0}),
+			WithReturncodes([]command.ExitCode{command.SuccessExitCode}),
 			WithOnHost(true),
 			WithIdempotence(Auto),
 		)
@@ -204,7 +206,7 @@ var _ = Describe("Encode/Decode round-trip", func() {
 			"foo.sh",
 			WithName("custom"),
 			WithArguments([]string{"-x"}),
-			WithReturncodes([]int{0, 2}),
+			WithReturncodes([]command.ExitCode{0, 2}),
 			WithEnv(map[string]string{"K": "V"}),
 			WithOnHost(false),
 			WithIdempotence(Disabled),
@@ -229,7 +231,7 @@ var _ = Describe("Encode/Decode round-trip", func() {
 		rs := round.(RegularStep)
 		Expect(rs.Name).To(Equal("foo.sh"))
 		Expect(rs.Arguments).To(Equal([]string{}))
-		Expect(rs.Returncodes).To(Equal([]int{0}))
+		Expect(rs.Returncodes).To(Equal([]command.ExitCode{command.SuccessExitCode}))
 		Expect(rs.Idempotence()).To(Equal(Auto))
 	})
 })
@@ -240,7 +242,7 @@ var _ = Describe("Encode env handling", func() {
 			Name:            "a",
 			ScriptPath:      "a",
 			Arguments:       []string{},
-			Returncodes:     []int{0},
+			Returncodes:     []command.ExitCode{command.SuccessExitCode},
 			OnHost:          true,
 			IdempotenceMode: Auto,
 		}

--- a/agent/go/internal/step/upgrade_step_test.go
+++ b/agent/go/internal/step/upgrade_step_test.go
@@ -21,6 +21,8 @@ package step
 import (
 	"strings"
 
+	"github.com/NVIDIA/nodewright/agent/internal/command"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -47,14 +49,14 @@ var _ = Describe("NewUpgradeStep", func() {
 		u, err := NewUpgradeStep(
 			"upgrade.sh",
 			WithName("custom"),
-			WithReturncodes([]int{0, 2}),
+			WithReturncodes([]command.ExitCode{0, 2}),
 			WithEnv(map[string]string{"K": "V"}),
 			WithOnHost(false),
 			WithIdempotence(Disabled),
 		)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(u.Name).To(Equal("custom"))
-		Expect(u.Returncodes).To(Equal([]int{0, 2}))
+		Expect(u.Returncodes).To(Equal([]command.ExitCode{0, 2}))
 		Expect(u.Env).To(Equal(map[string]string{"K": "V"}))
 		Expect(u.OnHost).To(BeFalse())
 		Expect(u.Idempotence()).To(Equal(Disabled))
@@ -84,7 +86,7 @@ var _ = Describe("UpgradeStep fields", func() {
 		rs := RegularStep{
 			Name:            "explicit",
 			ScriptPath:      "upgrade.sh",
-			Returncodes:     []int{0},
+			Returncodes:     []command.ExitCode{command.SuccessExitCode},
 			Env:             map[string]string{"K": "V"},
 			OnHost:          true,
 			IdempotenceMode: Disabled,
@@ -93,7 +95,7 @@ var _ = Describe("UpgradeStep fields", func() {
 
 		Expect(u.Name).To(Equal("explicit"))
 		Expect(u.ScriptPath).To(Equal("upgrade.sh"))
-		Expect(u.Returncodes).To(Equal([]int{0}))
+		Expect(u.Returncodes).To(Equal([]command.ExitCode{command.SuccessExitCode}))
 		Expect(u.Env).To(Equal(map[string]string{"K": "V"}))
 		Expect(u.OnHost).To(BeTrue())
 		Expect(u.Idempotence()).To(Equal(Disabled))


### PR DESCRIPTION
## Description

Adds an internal Go agent command-execution package with an interface-only downstream API. Callers create a `command.Runner`, construct a `command.Command`, and execute it without depending on the concrete runner implementation.

Closes #216.

The command runner:

- supports normal and chrooted execution through `NewRunner()` and `NewRunner(WithChroot(root))`;
- resolves executables and `PATH` entries inside the configured target root, including chroot-relative symbolic links;
- rejects paths that escape the target root and detects symbolic-link loops;
- merges inherited environment variables with command-specific overrides without mutating caller-owned data;
- optionally adds missing execute permissions before starting a command;
- streams raw stdout and stderr to caller-provided writers without owning or closing them; and
- returns normal exit statuses without runner errors while representing signal termination as a negative signal number, including SIGTERM as `-15`.

The package includes focused coverage for construction and validation, environment handling, path and symbolic-link resolution, permissions, live stdout/stderr streaming, writer failures, cancellation, start failures, nonzero exits, and signal termination.

Validation completed:

- `go test -race ./internal/command`
- `make fmt vet unit-tests lint build`

## Checklist

- [X] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/skyhook/blob/main/CONTRIBUTING.md).
- [X] My commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

