### PR TITLE
refactor(operator): package annotation helpers accept any client.Object (#300)

### DIFF
--- a/operator/internal/controller/annotations.go
+++ b/operator/internal/controller/annotations.go
@@ -23,7 +23,7 @@ import (
 	"fmt"
 
 	"github.com/NVIDIA/nodewright/operator/api/nodewright/v1alpha1"
-	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type PackageSkyhook struct {
@@ -35,12 +35,14 @@ type PackageSkyhook struct {
 	Invalid             bool           `json:"invalid,omitempty"`
 }
 
-// GetPackage returns the package from the pod annotations
-func GetPackage(pod *corev1.Pod) (*PackageSkyhook, error) {
-	if pod == nil {
+// GetPackage returns the package from the object's annotations. The object is any
+// executor carrying the package annotation — a package Pod or, once package stages
+// run as Jobs, a batch/v1 Job (and its pod template). Only metadata is touched.
+func GetPackage(obj client.Object) (*PackageSkyhook, error) {
+	if obj == nil {
 		return nil, nil
 	}
-	s, ok := pod.Annotations[fmt.Sprintf("%s/package", v1alpha1.METADATA_PREFIX)]
+	s, ok := obj.GetAnnotations()[fmt.Sprintf("%s/package", v1alpha1.METADATA_PREFIX)]
 	if !ok {
 		return nil, nil
 	}
@@ -53,9 +55,9 @@ func GetPackage(pod *corev1.Pod) (*PackageSkyhook, error) {
 	return ret, nil
 }
 
-// SetPackages sets the package in the pod annotations
-func SetPackages(pod *corev1.Pod, skyhook *v1alpha1.NodeWright, image string, stage v1alpha1.Stage, _package *v1alpha1.Package) error {
-	if pod == nil || _package == nil {
+// SetPackages sets the package in the object's annotations
+func SetPackages(obj client.Object, skyhook *v1alpha1.NodeWright, image string, stage v1alpha1.Stage, _package *v1alpha1.Package) error {
+	if obj == nil || _package == nil {
 		return nil
 	}
 
@@ -72,21 +74,23 @@ func SetPackages(pod *corev1.Pod, skyhook *v1alpha1.NodeWright, image string, st
 		return fmt.Errorf("error marshalling package: %w", err)
 	}
 
-	if pod.Annotations == nil {
-		pod.Annotations = map[string]string{}
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		annotations = map[string]string{}
 	}
-	pod.Annotations[fmt.Sprintf("%s/package", v1alpha1.METADATA_PREFIX)] = string(data)
+	annotations[fmt.Sprintf("%s/package", v1alpha1.METADATA_PREFIX)] = string(data)
+	obj.SetAnnotations(annotations)
 
 	return nil
 }
 
-// InvalidatePackage invalidates a package and updates the pod, which will trigger the pod to be deleted
-func InvalidatePackage(pod *corev1.Pod) error {
-	if pod == nil {
+// InvalidatePackage invalidates a package and updates the object, which will trigger the executor to be deleted
+func InvalidatePackage(obj client.Object) error {
+	if obj == nil {
 		return nil
 	}
 
-	pkg, err := GetPackage(pod)
+	pkg, err := GetPackage(obj)
 	if err != nil {
 		return fmt.Errorf("error getting package: %w", err)
 	}
@@ -98,18 +102,23 @@ func InvalidatePackage(pod *corev1.Pod) error {
 		return fmt.Errorf("error marshalling package: %w", err)
 	}
 
-	pod.Annotations[fmt.Sprintf("%s/package", v1alpha1.METADATA_PREFIX)] = string(data)
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+	annotations[fmt.Sprintf("%s/package", v1alpha1.METADATA_PREFIX)] = string(data)
+	obj.SetAnnotations(annotations)
 
 	return nil
 }
 
 // IsInvalidPackage returns true if the package is invalid
-func IsInvalidPackage(pod *corev1.Pod) (bool, error) {
-	if pod == nil {
+func IsInvalidPackage(obj client.Object) (bool, error) {
+	if obj == nil {
 		return false, nil
 	}
 
-	pkg, err := GetPackage(pod)
+	pkg, err := GetPackage(obj)
 	if err != nil {
 		return false, fmt.Errorf("error getting package: %w", err)
 	}

--- a/operator/internal/controller/annotations.go
+++ b/operator/internal/controller/annotations.go
@@ -28,7 +28,7 @@ import (
 )
 
 // packageAnnotationKey is the annotation every package executor carries to round-trip
-// the package it runs — a Pod today, and a batch/v1 Job plus its pod template once
+// the package it runs: a Pod today, and a batch/v1 Job plus its pod template once
 // stages run as Jobs.
 const packageAnnotationKey = v1alpha1.METADATA_PREFIX + "/package"
 
@@ -54,7 +54,7 @@ type PackageSkyhook struct {
 
 // GetPackage returns the package from the object's annotations. These helpers take
 // metav1.Object rather than client.Object because they only touch metadata and must
-// also accept a *corev1.PodTemplateSpec (the Job pod template) — which satisfies
+// also accept a *corev1.PodTemplateSpec (the Job pod template), which satisfies
 // metav1.Object but not client.Object (it has no runtime.Object methods).
 func GetPackage(obj metav1.Object) (*PackageSkyhook, error) {
 	if isNil(obj) {

--- a/operator/internal/controller/annotations.go
+++ b/operator/internal/controller/annotations.go
@@ -21,6 +21,7 @@ package controller
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
 
 	"github.com/NVIDIA/nodewright/operator/api/nodewright/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -30,6 +31,17 @@ import (
 // the package it runs — a Pod today, and a batch/v1 Job plus its pod template once
 // stages run as Jobs.
 const packageAnnotationKey = v1alpha1.METADATA_PREFIX + "/package"
+
+// isNil reports whether obj is nil, catching both a nil interface and a typed-nil
+// pointer (e.g. a (*corev1.Pod)(nil)). These helpers take an interface, so a plain
+// obj == nil misses the typed-nil case, which would then panic in GetAnnotations.
+func isNil(obj metav1.Object) bool {
+	if obj == nil {
+		return true
+	}
+	v := reflect.ValueOf(obj)
+	return v.Kind() == reflect.Pointer && v.IsNil()
+}
 
 type PackageSkyhook struct {
 	v1alpha1.PackageRef `json:",inline"`
@@ -45,7 +57,7 @@ type PackageSkyhook struct {
 // also accept a *corev1.PodTemplateSpec (the Job pod template) — which satisfies
 // metav1.Object but not client.Object (it has no runtime.Object methods).
 func GetPackage(obj metav1.Object) (*PackageSkyhook, error) {
-	if obj == nil {
+	if isNil(obj) {
 		return nil, nil
 	}
 	s, ok := obj.GetAnnotations()[packageAnnotationKey]
@@ -63,7 +75,7 @@ func GetPackage(obj metav1.Object) (*PackageSkyhook, error) {
 
 // SetPackages sets the package in the object's annotations
 func SetPackages(obj metav1.Object, skyhook *v1alpha1.NodeWright, image string, stage v1alpha1.Stage, _package *v1alpha1.Package) error {
-	if obj == nil || _package == nil {
+	if isNil(obj) || _package == nil {
 		return nil
 	}
 
@@ -92,7 +104,7 @@ func SetPackages(obj metav1.Object, skyhook *v1alpha1.NodeWright, image string, 
 
 // InvalidatePackage invalidates a package and updates the object, which will trigger the executor to be deleted
 func InvalidatePackage(obj metav1.Object) error {
-	if obj == nil {
+	if isNil(obj) {
 		return nil
 	}
 
@@ -120,7 +132,7 @@ func InvalidatePackage(obj metav1.Object) error {
 
 // IsInvalidPackage returns true if the package is invalid
 func IsInvalidPackage(obj metav1.Object) (bool, error) {
-	if obj == nil {
+	if isNil(obj) {
 		return false, nil
 	}
 

--- a/operator/internal/controller/annotations.go
+++ b/operator/internal/controller/annotations.go
@@ -23,8 +23,13 @@ import (
 	"fmt"
 
 	"github.com/NVIDIA/nodewright/operator/api/nodewright/v1alpha1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+// packageAnnotationKey is the annotation every package executor carries to round-trip
+// the package it runs — a Pod today, and a batch/v1 Job plus its pod template once
+// stages run as Jobs.
+const packageAnnotationKey = v1alpha1.METADATA_PREFIX + "/package"
 
 type PackageSkyhook struct {
 	v1alpha1.PackageRef `json:",inline"`
@@ -35,14 +40,15 @@ type PackageSkyhook struct {
 	Invalid             bool           `json:"invalid,omitempty"`
 }
 
-// GetPackage returns the package from the object's annotations. The object is any
-// executor carrying the package annotation — a package Pod or, once package stages
-// run as Jobs, a batch/v1 Job (and its pod template). Only metadata is touched.
-func GetPackage(obj client.Object) (*PackageSkyhook, error) {
+// GetPackage returns the package from the object's annotations. These helpers take
+// metav1.Object rather than client.Object because they only touch metadata and must
+// also accept a *corev1.PodTemplateSpec (the Job pod template) — which satisfies
+// metav1.Object but not client.Object (it has no runtime.Object methods).
+func GetPackage(obj metav1.Object) (*PackageSkyhook, error) {
 	if obj == nil {
 		return nil, nil
 	}
-	s, ok := obj.GetAnnotations()[fmt.Sprintf("%s/package", v1alpha1.METADATA_PREFIX)]
+	s, ok := obj.GetAnnotations()[packageAnnotationKey]
 	if !ok {
 		return nil, nil
 	}
@@ -56,7 +62,7 @@ func GetPackage(obj client.Object) (*PackageSkyhook, error) {
 }
 
 // SetPackages sets the package in the object's annotations
-func SetPackages(obj client.Object, skyhook *v1alpha1.NodeWright, image string, stage v1alpha1.Stage, _package *v1alpha1.Package) error {
+func SetPackages(obj metav1.Object, skyhook *v1alpha1.NodeWright, image string, stage v1alpha1.Stage, _package *v1alpha1.Package) error {
 	if obj == nil || _package == nil {
 		return nil
 	}
@@ -78,14 +84,14 @@ func SetPackages(obj client.Object, skyhook *v1alpha1.NodeWright, image string, 
 	if annotations == nil {
 		annotations = map[string]string{}
 	}
-	annotations[fmt.Sprintf("%s/package", v1alpha1.METADATA_PREFIX)] = string(data)
+	annotations[packageAnnotationKey] = string(data)
 	obj.SetAnnotations(annotations)
 
 	return nil
 }
 
 // InvalidatePackage invalidates a package and updates the object, which will trigger the executor to be deleted
-func InvalidatePackage(obj client.Object) error {
+func InvalidatePackage(obj metav1.Object) error {
 	if obj == nil {
 		return nil
 	}
@@ -106,14 +112,14 @@ func InvalidatePackage(obj client.Object) error {
 	if annotations == nil {
 		annotations = map[string]string{}
 	}
-	annotations[fmt.Sprintf("%s/package", v1alpha1.METADATA_PREFIX)] = string(data)
+	annotations[packageAnnotationKey] = string(data)
 	obj.SetAnnotations(annotations)
 
 	return nil
 }
 
 // IsInvalidPackage returns true if the package is invalid
-func IsInvalidPackage(obj client.Object) (bool, error) {
+func IsInvalidPackage(obj metav1.Object) (bool, error) {
 	if obj == nil {
 		return false, nil
 	}

--- a/operator/internal/controller/annotations.go
+++ b/operator/internal/controller/annotations.go
@@ -112,6 +112,10 @@ func InvalidatePackage(obj metav1.Object) error {
 	if err != nil {
 		return fmt.Errorf("error getting package: %w", err)
 	}
+	// No package annotation to invalidate: GetPackage returns nil when absent.
+	if pkg == nil {
+		return nil
+	}
 
 	pkg.Invalid = true
 
@@ -139,6 +143,10 @@ func IsInvalidPackage(obj metav1.Object) (bool, error) {
 	pkg, err := GetPackage(obj)
 	if err != nil {
 		return false, fmt.Errorf("error getting package: %w", err)
+	}
+	// No package annotation: an object without one is not an invalid package.
+	if pkg == nil {
+		return false, nil
 	}
 	return pkg.Invalid, nil
 }

--- a/operator/internal/controller/annotations_test.go
+++ b/operator/internal/controller/annotations_test.go
@@ -19,7 +19,6 @@
 package controller
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/NVIDIA/nodewright/operator/api/nodewright/v1alpha1"
@@ -48,26 +47,34 @@ var _ = Describe("package annotation helpers", func() {
 		image = "ghcr.io/nvidia/skyhook-packages/tuning:1.2.3"
 	})
 
-	It("round-trips the package annotation identically on a Pod and a Job", func() {
+	It("round-trips the package annotation identically on a Pod, a Job, and a Job pod template", func() {
 		pod := &corev1.Pod{}
 		job := &batchv1.Job{}
+		// the Job path sets the annotation on both the Job and its pod template
+		// (the in-flight erroring path reads it off the child pod), so the pod
+		// template — a *corev1.PodTemplateSpec — must round-trip too.
+		tmpl := &job.Spec.Template
 
 		Expect(SetPackages(pod, nw, image, v1alpha1.StageApply, pkg)).To(Succeed())
 		Expect(SetPackages(job, nw, image, v1alpha1.StageApply, pkg)).To(Succeed())
+		Expect(SetPackages(tmpl, nw, image, v1alpha1.StageApply, pkg)).To(Succeed())
 
 		fromPod, err := GetPackage(pod)
 		Expect(err).ToNot(HaveOccurred())
 		fromJob, err := GetPackage(job)
 		Expect(err).ToNot(HaveOccurred())
+		fromTmpl, err := GetPackage(tmpl)
+		Expect(err).ToNot(HaveOccurred())
 
 		Expect(fromJob).To(Equal(fromPod))
-		Expect(fromJob.Skyhook).To(Equal("gpu-init"))
-		Expect(fromJob.Stage).To(Equal(v1alpha1.StageApply))
-		Expect(fromJob.Name).To(Equal("tuning"))
+		Expect(fromTmpl).To(Equal(fromPod))
+		Expect(fromPod.Skyhook).To(Equal("gpu-init"))
+		Expect(fromPod.Stage).To(Equal(v1alpha1.StageApply))
+		Expect(fromPod.Name).To(Equal("tuning"))
 
-		key := fmt.Sprintf("%s/package", v1alpha1.METADATA_PREFIX)
-		Expect(job.GetAnnotations()).To(HaveKey(key))
-		Expect(job.GetAnnotations()[key]).To(Equal(pod.GetAnnotations()[key]))
+		Expect(job.GetAnnotations()).To(HaveKey(packageAnnotationKey))
+		Expect(job.GetAnnotations()[packageAnnotationKey]).To(Equal(pod.GetAnnotations()[packageAnnotationKey]))
+		Expect(tmpl.GetAnnotations()[packageAnnotationKey]).To(Equal(pod.GetAnnotations()[packageAnnotationKey]))
 	})
 
 	It("marks a Job's package invalid via InvalidatePackage/IsInvalidPackage", func() {

--- a/operator/internal/controller/annotations_test.go
+++ b/operator/internal/controller/annotations_test.go
@@ -1,0 +1,87 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controller
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/NVIDIA/nodewright/operator/api/nodewright/v1alpha1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("package annotation helpers", func() {
+
+	var (
+		nw    *v1alpha1.NodeWright
+		pkg   *v1alpha1.Package
+		image string
+	)
+
+	BeforeEach(func() {
+		nw = &v1alpha1.NodeWright{ObjectMeta: metav1.ObjectMeta{Name: "gpu-init"}}
+		pkg = &v1alpha1.Package{
+			PackageRef:   v1alpha1.PackageRef{Name: "tuning", Version: "1.2.3"},
+			Image:        "ghcr.io/nvidia/skyhook-packages/tuning",
+			ContainerSHA: "sha256:" + strings.Repeat("a", 64),
+		}
+		image = "ghcr.io/nvidia/skyhook-packages/tuning:1.2.3"
+	})
+
+	It("round-trips the package annotation identically on a Pod and a Job", func() {
+		pod := &corev1.Pod{}
+		job := &batchv1.Job{}
+
+		Expect(SetPackages(pod, nw, image, v1alpha1.StageApply, pkg)).To(Succeed())
+		Expect(SetPackages(job, nw, image, v1alpha1.StageApply, pkg)).To(Succeed())
+
+		fromPod, err := GetPackage(pod)
+		Expect(err).ToNot(HaveOccurred())
+		fromJob, err := GetPackage(job)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(fromJob).To(Equal(fromPod))
+		Expect(fromJob.Skyhook).To(Equal("gpu-init"))
+		Expect(fromJob.Stage).To(Equal(v1alpha1.StageApply))
+		Expect(fromJob.Name).To(Equal("tuning"))
+
+		key := fmt.Sprintf("%s/package", v1alpha1.METADATA_PREFIX)
+		Expect(job.GetAnnotations()).To(HaveKey(key))
+		Expect(job.GetAnnotations()[key]).To(Equal(pod.GetAnnotations()[key]))
+	})
+
+	It("marks a Job's package invalid via InvalidatePackage/IsInvalidPackage", func() {
+		job := &batchv1.Job{}
+		Expect(SetPackages(job, nw, image, v1alpha1.StageApply, pkg)).To(Succeed())
+
+		invalid, err := IsInvalidPackage(job)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(invalid).To(BeFalse())
+
+		Expect(InvalidatePackage(job)).To(Succeed())
+
+		invalid, err = IsInvalidPackage(job)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(invalid).To(BeTrue())
+	})
+})

--- a/operator/internal/controller/annotations_test.go
+++ b/operator/internal/controller/annotations_test.go
@@ -71,10 +71,29 @@ var _ = Describe("package annotation helpers", func() {
 		Expect(fromPod.Skyhook).To(Equal("gpu-init"))
 		Expect(fromPod.Stage).To(Equal(v1alpha1.StageApply))
 		Expect(fromPod.Name).To(Equal("tuning"))
+		Expect(fromPod.Version).To(Equal(pkg.Version))
+		Expect(fromPod.Image).To(Equal(image))
+		Expect(fromPod.ContainerSHA).To(Equal(pkg.ContainerSHA))
 
 		Expect(job.GetAnnotations()).To(HaveKey(packageAnnotationKey))
 		Expect(job.GetAnnotations()[packageAnnotationKey]).To(Equal(pod.GetAnnotations()[packageAnnotationKey]))
 		Expect(tmpl.GetAnnotations()[packageAnnotationKey]).To(Equal(pod.GetAnnotations()[packageAnnotationKey]))
+	})
+
+	It("treats a typed-nil object as absent instead of panicking", func() {
+		var pod *corev1.Pod // typed nil: non-nil interface wrapping a nil pointer
+
+		pkgOut, err := GetPackage(pod)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(pkgOut).To(BeNil())
+
+		Expect(SetPackages(pod, nw, image, v1alpha1.StageApply, pkg)).To(Succeed())
+
+		invalid, err := IsInvalidPackage(pod)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(invalid).To(BeFalse())
+
+		Expect(InvalidatePackage(pod)).To(Succeed())
 	})
 
 	It("marks a Job's package invalid via InvalidatePackage/IsInvalidPackage", func() {

--- a/operator/internal/controller/annotations_test.go
+++ b/operator/internal/controller/annotations_test.go
@@ -110,4 +110,20 @@ var _ = Describe("package annotation helpers", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(invalid).To(BeTrue())
 	})
+
+	It("treats an object without a package annotation as absent, not invalid", func() {
+		obj := &batchv1.Job{} // non-nil, but carries no package annotation
+
+		pkgOut, err := GetPackage(obj)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(pkgOut).To(BeNil())
+
+		invalid, err := IsInvalidPackage(obj)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(invalid).To(BeFalse())
+
+		// must be a no-op rather than a nil-package panic
+		Expect(InvalidatePackage(obj)).To(Succeed())
+		Expect(obj.GetAnnotations()).ToNot(HaveKey(packageAnnotationKey))
+	})
 })


### PR DESCRIPTION
Second PR of the #223 series (closes #300). Targets `feature/package-as-jobs`, which now sits on the #311 API-rename base.

## What

`GetPackage` / `SetPackages` / `InvalidatePackage` / `IsInvalidPackage` in `operator/internal/controller/annotations.go` only ever touch an object's annotations, but were typed to `*corev1.Pod`. This widens them to `client.Object` — switching from the `.Annotations` field to `GetAnnotations()` / `SetAnnotations()` — so the same package metadata can ride on `batch/v1` Jobs and their pod templates.

This is the first code step of the Jobs migration (design in #307): the Job builders (#301) will set the package annotation on both the Job and its pod template (the in-flight erroring path reads it off the child pod).

## No behavior change

Every existing call site passes a `*corev1.Pod`, which already satisfies `client.Object`, so the call sites are unchanged and compile as-is. The defensive `nil` guard stays as an interface-nil check; no caller passes a typed-nil pod.

## Tests

New `annotations_test.go` (TDD — written first, watched fail to compile against the `*corev1.Pod` signature, then made to pass):

- round-trips `SetPackages` → `GetPackage` on a `*batchv1.Job` and asserts it is identical to the same round-trip on a `*corev1.Pod` (same annotation key, same decoded value);
- exercises `InvalidatePackage` / `IsInvalidPackage` on a `*batchv1.Job`.

## Verification

- `go build ./...` + `go vet ./internal/controller/`: clean.
- Controller suite in isolation: **185/185 specs pass** (the 2 new specs plus every existing caller-exercising spec — no regressions).
- `make lint` (golangci-lint + license check): **0 issues**; `gofmt` clean.

**Heads-up (unrelated to this PR):** the full `make unit-tests` (`ginkgo ./...`, shared `--timeout=180s`) does not complete on this base — the `cmd/cli/app/package` suite is slow (individual `package rerun` specs take ~30s each; e.g. `should accept multiple --node flags` passes in isolation but in ~33s), so the aggregate run trips the ginkgo timeout before the controller suite runs. This branch has **zero CLI diff** — the slowness is pre-existing on the `fix/api-rename` base and worth a separate look.
