### PR TITLE
fix(chart): coerce PDB/replicas to int before comparing in validations

### DIFF
--- a/chart/templates/validations.yaml
+++ b/chart/templates/validations.yaml
@@ -9,9 +9,15 @@
 {{- end }}
 
 {{- /* Validate PodDisruptionBudget: minAvailable must be < replicas */ -}}
+{{- /* Skip comparison only for percentage strings (e.g. "50%") — Kubernetes accepts them   */ -}}
+{{- /* but they cannot be meaningfully compared to an integer replica count at render time.  */ -}}
+{{- /* Numeric strings (--set-string minAvailable=2) are still coerced and compared.        */ -}}
 {{- if ((.Values.controllerManager.podDisruptionBudget).minAvailable) -}}
-  {{- if ge .Values.controllerManager.podDisruptionBudget.minAvailable .Values.controllerManager.replicas -}}
-    {{- fail "Error: controllerManager.podDisruptionBudget.minAvailable must be less than controllerManager.replicas" -}}
+  {{- $minAvail := .Values.controllerManager.podDisruptionBudget.minAvailable -}}
+  {{- if not (and (kindIs "string" $minAvail) (hasSuffix "%" $minAvail)) -}}
+    {{- if ge (int $minAvail) (int .Values.controllerManager.replicas) -}}
+      {{- fail "Error: controllerManager.podDisruptionBudget.minAvailable must be less than controllerManager.replicas" -}}
+    {{- end -}}
   {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
## Summary

- Wraps both operands of the `ge` comparison in `validations.yaml` with `int` to normalize the Helm type mismatch between `float64` (default values) and `int64` (`--set` overrides).

Closes #314

## Test plan

- [ ] `helm template nodewright . --set controllerManager.replicas=1` renders without error
- [ ] `helm template nodewright . --set controllerManager.replicas=1 --set controllerManager.podDisruptionBudget.minAvailable=1` still fails validation as expected (minAvailable not < replicas)
- [ ] `helm template nodewright . --set controllerManager.replicas=2 --set controllerManager.podDisruptionBudget.minAvailable=1` passes validation