### PR TITLE
feat(ci): add /assign self-service issue assignment workflow

### DIFF
--- a/.github/workflows/assign.yaml
+++ b/.github/workflows/assign.yaml
@@ -1,0 +1,167 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Lets contributors self-serve issue assignment by commenting on an issue:
+#   /assign          -> claims the issue (commenter), only if unassigned
+#   /assign @user    -> assigns the mentioned user, only if unassigned
+#   /unassign        -> releases the issue, only if assigned to the commenter
+#
+# Single-owner model: /assign is refused when the issue already has an
+# assignee (comment /unassign to release it first), and assigns exactly one
+# user at a time. /unassign only ever removes the commenter and is refused
+# when they are not currently assigned, so nobody can drop another's claim.
+#
+# issue_comment always runs in the base-repo context with the base-repo
+# token, so there is no fork/pwn-request exposure here: the job only needs
+# `issues: write` and never checks out untrusted code. GitHub's addAssignees
+# silently ignores users who are not assignable (only the commenter/self,
+# prior commenters on the issue, users with write access, or org members
+# with read access can be assigned); we detect and report those.
+
+name: Self-Assign Issues
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+
+  assign:
+    name: Handle /assign and /unassign
+    # Issues only (not PRs); comment starts with /assign or /unassign.
+    if: >-
+      !github.event.issue.pull_request &&
+      (startsWith(github.event.comment.body, '/assign') ||
+       startsWith(github.event.comment.body, '/unassign'))
+    runs-on: ubuntu-latest
+    permissions:
+      # Needed to update issue assignees and post status comments back.
+      issues: write
+    timeout-minutes: 5
+    steps:
+
+      - name: Apply assignment change
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        with:
+          script: |
+            const body = context.payload.comment.body.trim();
+            const commenter = context.payload.comment.user.login;
+
+            // Match the command exactly: the first whitespace-delimited token
+            // must be /assign or /unassign. A plain startsWith would also fire
+            // on /assign-anything and silently self-assign the commenter.
+            const tokens = body.split(/\s+/);
+            const command = tokens[0];
+            if (command !== '/assign' && command !== '/unassign') {
+              core.info(`Ignoring comment; not an assignment command: ${command}`);
+              return;
+            }
+            const unassign = command === '/unassign';
+
+            const common = {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            };
+
+            // Read assignees fresh rather than trusting context.payload: jobs
+            // are serialized (cancel-in-progress: false), so a queued job may
+            // run well after the webhook snapshot has gone stale.
+            const { data: freshIssue } = await github.rest.issues.get(common);
+            const current = (freshIssue.assignees || []).map(a => a.login);
+
+            if (unassign) {
+              // Self-only: a commenter may only release their own claim.
+              if (!current.includes(commenter)) {
+                core.info(`${commenter} is not assigned; nothing to unassign`);
+                await github.rest.issues.createComment({
+                  ...common,
+                  body: `@${commenter} you are not currently assigned to this issue, so there is nothing to release.`,
+                });
+                return;
+              }
+              await github.rest.issues.removeAssignees({
+                ...common,
+                assignees: [commenter],
+              });
+              core.info(`Unassigned ${commenter}`);
+              return;
+            }
+
+            // Assign only on an unassigned issue (single-owner model).
+            if (current.length) {
+              core.info(`Issue already assigned to ${current.join(', ')}; refusing`);
+              await github.rest.issues.createComment({
+                ...common,
+                body: [
+                  `This issue is already assigned to ${current.map(u => '@' + u).join(', ')}.`,
+                  'The assignee can comment `/unassign` to release it first.',
+                ].join('\n'),
+              });
+              return;
+            }
+
+            // Single-owner model: /assign takes an optional single @user as its
+            // only argument. Parse the command's own tokens, not the whole body:
+            // scanning for mentions would let "/assign\ncc @maintainer" assign
+            // the wrong person. No argument self-claims the commenter; anything
+            // other than one bare @user (extra text, multiple mentions) is
+            // refused so a claim can never land on an unintended user.
+            const args = tokens.slice(1);
+            const userArg = /^@([a-zA-Z0-9](?:[a-zA-Z0-9-]{0,37}[a-zA-Z0-9])?)$/;
+            let target;
+            if (args.length === 0) {
+              target = commenter;
+            } else if (args.length === 1 && userArg.test(args[0])) {
+              target = args[0].slice(1);
+            } else {
+              core.info(`Unrecognized /assign arguments; refusing: ${args.join(' ')}`);
+              await github.rest.issues.createComment({
+                ...common,
+                body: 'This issue uses a single-owner model. Comment `/assign` to claim it yourself, or `/assign @user` to assign one other person.',
+              });
+              return;
+            }
+            const targets = [target];
+
+            const { data: issue } = await github.rest.issues.addAssignees({
+              ...common,
+              assignees: targets,
+            });
+
+            // GitHub drops non-assignable users without erroring, so surface them.
+            const got = new Set(issue.assignees.map(a => a.login));
+            const skipped = targets.filter(u => !got.has(u));
+            if (skipped.length) {
+              core.warning(`Could not assign: ${skipped.join(', ')}`);
+              await github.rest.issues.createComment({
+                ...common,
+                body: [
+                  `Could not assign ${skipped.map(u => '@' + u).join(', ')}.`,
+                  '',
+                  'GitHub only lets you assign the commenter/self, someone who has',
+                  'commented on this issue, a user with write access, or an org',
+                  'member with read access.',
+                ].join('\n'),
+              });
+            }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,16 @@ Want to contribute to Skyhook (NodeWright)? We welcome bug reports, feature requ
 - **Questions**: Use [GitHub Discussions](https://github.com/NVIDIA/skyhook/discussions).
 - **Security vulnerabilities**: Do **not** file a public issue. See [SECURITY.md](SECURITY.md).
 
+## Claiming an Issue
+
+Want to work on an issue? Claim it so others know it is taken. Comment on the issue and a bot will handle the assignment:
+
+- `/assign`: assign the issue to yourself (only if it is currently unassigned).
+- `/assign @user`: assign one other person (only if the issue is unassigned).
+- `/unassign`: release your claim on the issue.
+
+We use a single-owner model: an issue is assigned to at most one person. `/assign` is refused while the issue already has an assignee, and `/unassign` only ever removes your own claim, so nobody can drop someone else's. GitHub only lets you assign the commenter/self, someone who has commented on the issue, a user with write access, or an org member with read access; if a requested user cannot be assigned, the bot replies to say so.
+
 ## Pull Requests
 
 1. Fork the repository and create a branch from `main`.
@@ -22,6 +32,14 @@ Want to contribute to Skyhook (NodeWright)? We welcome bug reports, feature requ
 4. When you bump a Go or Python dependency, run `make notices` and commit the refreshed `THIRD_PARTY_NOTICES.md` files alongside your change. See [`docs/release-process.md`](docs/release-process.md) for the workflow.
 5. Commit with a [Conventional Commits](https://www.conventionalcommits.org/) message and sign off (see below).
 6. Open a pull request against `main`. The PR template will guide you through the checklist.
+
+### AI-Assisted Contributions Policy
+
+We welcome the use of AI tools (e.g., Claude, GitHub Copilot, ChatGPT) to help you write code, brainstorm, or refactor. However, we maintain a strict human-in-the-loop policy for all submissions:
+
+- **Full accountability**: By submitting a PR, you (the human author) accept full responsibility for the code: its correctness, security, maintainability, and license compliance. "The AI wrote it" is not an acceptable explanation for bugs or security flaws.
+- **Understand what you submit**: Do not submit AI-generated code you do not fully understand. Reviewers expect you to explain and defend every line of code in your PR.
+- **Follow the project rules**: Coding assistants must follow the guidance in [`.claude/CLAUDE.md`](.claude/CLAUDE.md) (symlinked as [`AGENTS.md`](AGENTS.md)), including running `make fmt`, `make test`, and keeping `docs/` in sync.
 
 ## Developer Certificate of Origin (DCO)
 


### PR DESCRIPTION
## What

Adds a **Self-Assign Issues** GitHub Actions workflow so contributors can claim issues without maintainer intervention, and documents it (plus an AI-assisted contributions policy) in `CONTRIBUTING.md`.

Commands (comment on an issue):

- `/assign` — claim the issue yourself (only if unassigned)
- `/assign @user …` — assign the mentioned user(s) (only if unassigned)
- `/unassign` — release your own claim

## Why

Lowers the friction for contributors picking up work and makes ownership visible, mirroring the same feature we run in the AICR repo.

## Design notes

- **Single-owner model**: `/assign` is refused when the issue already has an assignee (comment `/unassign` to release first). `/unassign` only ever removes the commenter, so nobody can drop another person's claim.
- **Security**: `issue_comment` runs in the base-repo context with the base-repo token, so there is no fork/pwn-request exposure. The job only needs `issues: write` and never checks out untrusted code.
- **Non-assignable users**: GitHub silently ignores users who lack triage/write access or prior repo activity; the workflow detects that and comments back rather than failing silently.
- Matches repo conventions: SPDX license header and the same pinned `actions/github-script@…v9.0.0` SHA used by the other workflows.

## Docs

- `CONTRIBUTING.md`: new "Claiming an Issue" section and an "AI-Assisted Contributions Policy" section.