### PR TITLE
docs: add GitHub Copilot instructions pointing at AGENTS.md

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,27 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Copilot Instructions for Skyhook (NodeWright)
+
+GitHub Copilot should follow this project's canonical coding-agent rules. Those
+rules (repository architecture, the Status / State / Stage vocabulary, the
+level-triggered reconcile pattern, error/context/logging conventions, required
+`make` targets, commit signing, and the pull request process) live in one place
+and are mirrored for every tool that reads this directory.
+
+Do not duplicate that content here. Read the canonical sources directly:
+
+- **[AGENTS.md](../AGENTS.md)** is the canonical agent guide (a symlink to
+  `.claude/CLAUDE.md`); treat it as authoritative for code style, architecture,
+  and the working rules.
+- **[CONTRIBUTING.md](../CONTRIBUTING.md)** covers DCO sign-off, commit signing,
+  the AI-assisted contributions policy, and how to open a PR.
+- **[docs/README.md](../docs/README.md)** indexes the domain docs (interrupt
+  flow, deployment policy, versioning, and the behavioral contracts that most
+  bugs in this codebase come from ignoring).
+
+When in doubt, prefer the existing patterns in the package you are editing over
+introducing new ones, and keep `docs/` in sync with any behavior change in the
+same PR.


### PR DESCRIPTION
## What

Adds `.github/copilot-instructions.md` so GitHub Copilot picks up the project's canonical coding-agent rules.

## Why

We already maintain `AGENTS.md` (a mirror of `.claude/CLAUDE.md`) for Claude/Codex/Cursor, and just added an AI-assisted contributions policy to `CONTRIBUTING.md`. GitHub Copilot reads `.github/copilot-instructions.md` specifically; without it, Copilot ignores our conventions. This file carries no duplicated content: it points at `AGENTS.md`, `CONTRIBUTING.md`, and `docs/README.md` as the single sources of truth.

One of a set of community/CI-hygiene additions being ported from other NVIDIA OSS repos.