### PR TITLE
ci: add DCO bot configuration

### DIFF
--- a/.github/dco.yml
+++ b/.github/dco.yml
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Configuration for the DCO bot (https://github.com/probot/dco), which enforces
+# the Developer Certificate of Origin sign-off documented in CONTRIBUTING.md.
+
+# Require all commits to be signed off, except organization members and bots.
+require:
+  members: false


### PR DESCRIPTION
## What

Adds `.github/dco.yml` configuring the [probot/dco](https://github.com/probot/dco) app: all commits must carry a `Signed-off-by` line, except organization members and bots (`require.members: false`).

## Why

`CONTRIBUTING.md` already **requires** DCO sign-off, but nothing enforces it on incoming PRs today. This config makes the DCO check a first-class gate, matching other NVIDIA OSS repos.

## Caveat

The config file is inert until the **DCO GitHub App is installed on the org** (an admin action). Merging this alone changes nothing; it makes the repo ready for the app. Flagging so a maintainer can enable the app.

One of a set of community/CI-hygiene additions being ported from other NVIDIA OSS repos.