### PR TITLE
ci: add CodeQL static analysis workflow

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# CodeQL static analysis for the Go (operator + CLI + agent/go) and Python
+# (agent) sources. Runs weekly and on demand. Go uses manual build-mode with an
+# explicit vendored build of both modules (CodeQL has no build-mode: none for
+# Go); Python needs no build.
+
+name: "CodeQL"
+
+on:
+  schedule:
+    - cron: '0 5 * * 1'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: go
+            build-mode: manual
+          - language: python
+            build-mode: none
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          persist-credentials: false
+      - if: matrix.language == 'go'
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: operator/go.mod
+      - uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9  # v4.37.0
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+      # Manual build for Go: compile both modules so CodeQL can trace the build.
+      # The operator and the agent rewrite are separate modules. agent/go's
+      # vendor/ is currently out of sync with its go.mod, so it builds from the
+      # module cache (-mod=mod) rather than the vendor tree.
+      - if: matrix.language == 'go'
+        run: |
+          set -euo pipefail
+          (cd operator && GOFLAGS=-mod=vendor go build ./...)
+          (cd agent/go && GOFLAGS=-mod=mod go build ./...)
+      - uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9  # v4.37.0
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## What

Adds a weekly (and `workflow_dispatch`) CodeQL scan over the repo's two analyzable languages:

- **Go** — operator, CLI, and `agent/go`
- **Python** — `agent/skyhook-agent`

## Why

The repo has `security-checkov` (IaC scanning) but no code-level SAST. CodeQL fills that gap for the Go and Python sources.

## Design notes

- Uses **`build-mode: none`** for Go so the scan doesn't have to compile the vendored, multi-module tree (`operator/`, `agent/go/`) — avoids brittle build setup while still extracting a database.
- Matrix per language with `fail-fast: false` so one language's result doesn't mask the other.
- `codeql-action` pinned by SHA (v4.37.0); `checkout@v6` matches the repo's existing usage.
- Results surface in the repo's Security tab (needs `security-events: write`, already scoped to the job).

One of a set of community/CI-hygiene additions being ported from other NVIDIA OSS repos.