### PR TITLE
ci: add actionlint workflow for GitHub Actions linting

### DIFF
--- a/.github/workflows/actionlint.yaml
+++ b/.github/workflows/actionlint.yaml
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Lints the GitHub Actions workflow files with actionlint on any PR or push
+# that touches them, catching expression typos, bad `if:` conditions, and
+# invalid keys before they merge.
+
+name: Actionlint
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/**'
+      - '.github/actionlint.yaml'
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - '.github/actionlint.yaml'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  actionlint:
+    name: Run actionlint
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Install actionlint
+        # Pin both the version and the tarball's SHA256 here in the workflow, so
+        # verification does not depend on a fetched (mutable) checksums file from
+        # the same release. Bump ACTIONLINT_SHA256 alongside ACTIONLINT_VERSION.
+        env:
+          ACTIONLINT_VERSION: '1.7.11'
+          ACTIONLINT_SHA256: '900919a84f2229bac68ca9cd4103ea297abc35e9689ebb842c6e34a3d1b01b0a'
+        run: |
+          set -euo pipefail
+          BASE="https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}"
+          TAR="actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          TMP="$(mktemp -d)"
+          curl -fsSL -o "${TMP}/${TAR}" "${BASE}/${TAR}"
+          echo "${ACTIONLINT_SHA256}  ${TMP}/${TAR}" | sha256sum -c -
+          tar -xzf "${TMP}/${TAR}" -C "${TMP}" actionlint
+          mv "${TMP}/actionlint" "${PWD}/actionlint"
+      - name: Run actionlint
+        run: ./actionlint -color -shellcheck=


### PR DESCRIPTION
## What

Adds an `Actionlint` workflow that runs [actionlint](https://github.com/rhysd/actionlint) on any PR or push touching `.github/workflows/**`, catching workflow-expression typos, bad `if:` conditions, and invalid keys before merge.

## Why

We just hand-authored several new workflows (assign, conflict-check, codeql, this one). actionlint is the standard guard against the classes of mistakes that only surface at runtime otherwise.

## Design notes

- **Supply-chain safe install**: the actionlint binary is pinned (`v1.7.11`) and its SHA256 is verified against the upstream-published checksum file. This deliberately avoids `bash <(curl … main …)`, which runs a mutable script and downloads the binary with no verification.
- `-shellcheck=` disables the shellcheck integration to keep scope to workflow structure.
- **Verified locally**: ran actionlint over all existing workflows — they already pass, so this won't fail on pre-existing violations.

One of a set of community/CI-hygiene additions being ported from other NVIDIA OSS repos.