### PR TITLE
feat(operator): cascade pause to Job suspension (#303 part 2)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -519,6 +519,16 @@ kubectl nodewright pause my-skyhook --confirm
 kubectl nodewright disable my-skyhook --confirm
 ```
 
+> **How hard pause stops depends on the operator version.** On operators that run
+> package stages as Jobs, pause suspends the stage that is *currently executing* —
+> its pod is signaled to stop and nothing new starts until you `resume`, at which
+> point the stage re-runs from the start of its current phase (the agent skips
+> already-completed steps). On earlier operators — and, briefly, for a stage still
+> running as a pre-upgrade pod during an operator upgrade — a stage already in
+> flight finishes its current run before pause takes hold; pause still blocks all
+> *new* stage scheduling. If you need a running stage to stop immediately, confirm
+> the operator executes packages as Jobs.
+
 ## Output Formats
 
 All status commands support multiple output formats:

--- a/k8s-tests/chainsaw/nodewright/pause-suspends-jobs/README.md
+++ b/k8s-tests/chainsaw/nodewright/pause-suspends-jobs/README.md
@@ -1,0 +1,26 @@
+# pause-suspends-jobs
+
+Validates that pausing a NodeWright suspends its in-flight package Jobs, and that resuming restarts the interrupted stage.
+
+## Why this needs a real cluster
+
+The unit tests in `swap_test.go` cover the decision to set `spec.suspend` — which Jobs are selected, that finished and invalid Jobs are skipped, that it is idempotent. They run against a fake client, where **nothing acts on the field**. Everything the feature actually promises is Job-controller behavior and can only be observed here:
+
+- suspension SIGTERMs the running pod
+- node state stays `in_progress` rather than flipping to `erroring`
+- resume starts a fresh pod that re-runs the stage
+
+## Test Scenario
+
+1. Install a package with `SLEEP_LEN=300` so its apply stage is still running when paused, and wait for a Running apply pod
+2. Pause via the `nodewright.nvidia.com/pause` annotation
+3. Verify the Job is `spec.suspend: true` (suspended, not deleted, so it can resume)
+4. Verify no apply pod survives
+5. **Verify node state is not `erroring`** — see below
+6. Unpause, verify `spec.suspend: false` and a fresh apply pod appears
+
+## The assertion that matters
+
+Step 5 is the reason this test exists. A pod deleted by suspension is, to the pod watch, indistinguishable from a pod that failed — same absent container statuses, same terminal-looking state. Only the `DeletionTimestamp` guard in `PodReconcile` separates them. Without it, **every pause would mark its packages erroring**, which would in turn count against DeploymentPolicy failure budgets.
+
+That guard is exercised by no other test, and a fake client cannot produce the situation: it has no Job controller to delete the pod in the first place.

--- a/k8s-tests/chainsaw/nodewright/pause-suspends-jobs/chainsaw-test.yaml
+++ b/k8s-tests/chainsaw/nodewright/pause-suspends-jobs/chainsaw-test.yaml
@@ -47,7 +47,13 @@ spec:
           ../nodewright-cli reset pause-suspends-jobs --confirm 2>/dev/null || true
     - create:
         file: nodewright.yaml
-    ## Wait for a running apply pod: pausing before the Job exists would prove nothing.
+    ## Wait until the apply stage is genuinely executing. Without this the negative assertion
+    ## after the pause passes vacuously against a pod that never started.
+    ##
+    ## Do NOT assert status.phase here: package work runs in init containers, so the pod stays
+    ## Pending for the whole stage and only reaches Running once apply has finished — the
+    ## opposite of the state this test needs. Init containers run one at a time, so exactly one
+    ## running entry means a step is in flight.
     - assert:
         resource:
           apiVersion: v1
@@ -56,10 +62,10 @@ spec:
             namespace: skyhook
             labels:
               nodewright.nvidia.com/name: pause-suspends-jobs
-              nodewright.nvidia.com/package: slowpoke-1.0.0
+              nodewright.nvidia.com/package: slowpoke-1.2.3
               nodewright.nvidia.com/stage: apply
           status:
-            phase: Running
+            (length(initContainerStatuses[?state.running != null])): 1
 
   - name: pause-suspends-the-job-and-kills-the-pod
     description: >
@@ -80,7 +86,7 @@ spec:
             namespace: skyhook
             labels:
               nodewright.nvidia.com/name: pause-suspends-jobs
-              nodewright.nvidia.com/package: slowpoke-1.0.0
+              nodewright.nvidia.com/package: slowpoke-1.2.3
               nodewright.nvidia.com/stage: apply
           spec:
             suspend: true
@@ -93,7 +99,7 @@ spec:
             namespace: skyhook
             labels:
               nodewright.nvidia.com/name: pause-suspends-jobs
-              nodewright.nvidia.com/package: slowpoke-1.0.0
+              nodewright.nvidia.com/package: slowpoke-1.2.3
               nodewright.nvidia.com/stage: apply
     - script:
         ## The regression this test exists for. A pod deleted by suspension looks exactly
@@ -126,7 +132,7 @@ spec:
             namespace: skyhook
             labels:
               nodewright.nvidia.com/name: pause-suspends-jobs
-              nodewright.nvidia.com/package: slowpoke-1.0.0
+              nodewright.nvidia.com/package: slowpoke-1.2.3
               nodewright.nvidia.com/stage: apply
           spec:
             ## Cleared, not merely absent: resume writes false rather than dropping the field.
@@ -140,5 +146,5 @@ spec:
             namespace: skyhook
             labels:
               nodewright.nvidia.com/name: pause-suspends-jobs
-              nodewright.nvidia.com/package: slowpoke-1.0.0
+              nodewright.nvidia.com/package: slowpoke-1.2.3
               nodewright.nvidia.com/stage: apply

--- a/k8s-tests/chainsaw/nodewright/pause-suspends-jobs/chainsaw-test.yaml
+++ b/k8s-tests/chainsaw/nodewright/pause-suspends-jobs/chainsaw-test.yaml
@@ -1,0 +1,144 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: pause-suspends-jobs
+  labels:
+    pool: lifecycle
+spec:
+  timeouts:
+    assert: 240s
+  catch:
+    - get:
+        apiVersion: nodewright.nvidia.com/v1alpha1
+        kind: NodeWright
+        name: pause-suspends-jobs
+        format: yaml
+    - script:
+        content: |
+          kubectl get jobs -n skyhook -l nodewright.nvidia.com/name=pause-suspends-jobs -o yaml || true
+          kubectl get pods -n skyhook -l nodewright.nvidia.com/name=pause-suspends-jobs -o yaml || true
+          kubectl get nodes -l nodewright.nvidia.com/test-node=skyhooke2e -o yaml || true
+  steps:
+  - name: start-a-long-stage
+    description: >
+      Install a package whose apply stage runs long enough to still be executing when we
+      pause. Unit tests cover the decision to set spec.suspend; only a real cluster runs
+      the Job controller, so only here can we observe what suspension actually does.
+    try:
+    - script:
+        content: |
+          ../nodewright-cli reset pause-suspends-jobs --confirm 2>/dev/null || true
+    - create:
+        file: nodewright.yaml
+    ## Wait for a running apply pod: pausing before the Job exists would prove nothing.
+    - assert:
+        resource:
+          apiVersion: v1
+          kind: Pod
+          metadata:
+            namespace: skyhook
+            labels:
+              nodewright.nvidia.com/name: pause-suspends-jobs
+              nodewright.nvidia.com/package: slowpoke-1.0.0
+              nodewright.nvidia.com/stage: apply
+          status:
+            phase: Running
+
+  - name: pause-suspends-the-job-and-kills-the-pod
+    description: >
+      Pausing sets spec.suspend=true, which makes the Job controller delete the running
+      pod. Node state must stay in_progress: the killed pod carries a DeletionTimestamp,
+      and PodReconcile skips those, so a pause must never be recorded as a package failure.
+    try:
+    - script:
+        content: |
+          kubectl annotate nodewright pause-suspends-jobs \
+            nodewright.nvidia.com/pause=true --overwrite
+    - assert:
+        ## The Job itself is suspended rather than deleted, so resume can restart it.
+        resource:
+          apiVersion: batch/v1
+          kind: Job
+          metadata:
+            namespace: skyhook
+            labels:
+              nodewright.nvidia.com/name: pause-suspends-jobs
+              nodewright.nvidia.com/package: slowpoke-1.0.0
+              nodewright.nvidia.com/stage: apply
+          spec:
+            suspend: true
+    - error:
+        ## The Job controller SIGTERMs the pod on suspend; no apply pod may survive.
+        resource:
+          apiVersion: v1
+          kind: Pod
+          metadata:
+            namespace: skyhook
+            labels:
+              nodewright.nvidia.com/name: pause-suspends-jobs
+              nodewright.nvidia.com/package: slowpoke-1.0.0
+              nodewright.nvidia.com/stage: apply
+    - script:
+        ## The regression this test exists for. A pod deleted by suspension looks exactly
+        ## like a failed attempt to the pod watch, so without the DeletionTimestamp guard
+        ## every pause would mark its packages erroring. Assert the negative directly.
+        content: |
+          state=$(kubectl get nodes -l nodewright.nvidia.com/test-node=skyhooke2e \
+            -o jsonpath='{.items[*].metadata.annotations.nodewright\.nvidia\.com/nodeState_pause-suspends-jobs}')
+          echo "node state: $state"
+          if echo "$state" | grep -q "erroring"; then
+            echo "FAIL: pausing recorded the package as erroring; the suspension-killed pod was treated as a failure"
+            exit 1
+          fi
+          echo "OK: no package marked erroring by the pause"
+
+  - name: resume-restarts-the-stage
+    description: >
+      Clearing pause clears spec.suspend, and the Job controller starts a fresh pod that
+      re-runs the interrupted stage through to completion.
+    try:
+    - script:
+        content: |
+          kubectl annotate nodewright pause-suspends-jobs \
+            nodewright.nvidia.com/pause- --overwrite
+    - assert:
+        resource:
+          apiVersion: batch/v1
+          kind: Job
+          metadata:
+            namespace: skyhook
+            labels:
+              nodewright.nvidia.com/name: pause-suspends-jobs
+              nodewright.nvidia.com/package: slowpoke-1.0.0
+              nodewright.nvidia.com/stage: apply
+          spec:
+            ## Cleared, not merely absent: resume writes false rather than dropping the field.
+            suspend: false
+    - assert:
+        ## A fresh attempt pod exists again for the same stage.
+        resource:
+          apiVersion: v1
+          kind: Pod
+          metadata:
+            namespace: skyhook
+            labels:
+              nodewright.nvidia.com/name: pause-suspends-jobs
+              nodewright.nvidia.com/package: slowpoke-1.0.0
+              nodewright.nvidia.com/stage: apply

--- a/k8s-tests/chainsaw/nodewright/pause-suspends-jobs/chainsaw-test.yaml
+++ b/k8s-tests/chainsaw/nodewright/pause-suspends-jobs/chainsaw-test.yaml
@@ -50,22 +50,33 @@ spec:
     ## Wait until the apply stage is genuinely executing. Without this the negative assertion
     ## after the pause passes vacuously against a pod that never started.
     ##
-    ## Do NOT assert status.phase here: package work runs in init containers, so the pod stays
-    ## Pending for the whole stage and only reaches Running once apply has finished — the
-    ## opposite of the state this test needs. Init containers run one at a time, so exactly one
-    ## running entry means a step is in flight.
-    - assert:
-        resource:
-          apiVersion: v1
-          kind: Pod
-          metadata:
-            namespace: skyhook
-            labels:
-              nodewright.nvidia.com/name: pause-suspends-jobs
-              nodewright.nvidia.com/package: slowpoke-1.2.3
-              nodewright.nvidia.com/stage: apply
-          status:
-            (length(initContainerStatuses[?state.running != null])): 1
+    ## A polling script rather than an assert, matching the event poll in
+    ## delete-blocked-when-paused. An assert here has to wait for a resource that does not
+    ## exist yet — the operator must reconcile first — and a resource assert carrying a status
+    ## expression has nothing to evaluate against an empty match, so it fails on the first poll
+    ## instead of retrying. That passed locally only because a warm empty cluster produced the
+    ## pod before the first poll.
+    ##
+    ## Do NOT check status.phase: package work runs in init containers, so the pod stays Pending
+    ## for the whole stage and only reaches Running once apply has finished — the opposite of
+    ## the state this test needs. Init containers run one at a time, so a running entry means a
+    ## step is in flight.
+    - script:
+        timeout: 240s
+        content: |
+          for i in $(seq 1 80); do
+            running=$(kubectl get pods -n skyhook \
+              -l nodewright.nvidia.com/name=pause-suspends-jobs,nodewright.nvidia.com/package=slowpoke-1.2.3,nodewright.nvidia.com/stage=apply \
+              -o jsonpath='{.items[*].status.initContainerStatuses[*].state.running.startedAt}' 2>/dev/null)
+            if [ -n "$running" ]; then
+              echo "apply stage is executing (startedAt: $running)"
+              exit 0
+            fi
+            sleep 3
+          done
+          echo "no apply pod reached a running init container within timeout"
+          kubectl get jobs,pods -n skyhook -l nodewright.nvidia.com/name=pause-suspends-jobs -o wide || true
+          exit 1
 
   - name: pause-suspends-the-job-and-kills-the-pod
     description: >

--- a/k8s-tests/chainsaw/nodewright/pause-suspends-jobs/nodewright.yaml
+++ b/k8s-tests/chainsaw/nodewright/pause-suspends-jobs/nodewright.yaml
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: nodewright.nvidia.com/v1alpha1
+kind: NodeWright
+metadata:
+  name: pause-suspends-jobs
+spec:
+  nodeSelectors:
+    matchLabels:
+      nodewright.nvidia.com/test-node: skyhooke2e
+  interruptionBudget:
+    count: 1
+  packages:
+    ## SLEEP_LEN holds apply open long enough to pause mid-stage. The whole test turns on
+    ## catching this package while its Job is running, so this must outlast the pause step.
+    slowpoke:
+      version: "1.0.0"
+      image: ghcr.io/nvidia/skyhook/agentless
+      env:
+      - name: SLEEP_LEN
+        value: "300"

--- a/k8s-tests/chainsaw/nodewright/pause-suspends-jobs/nodewright.yaml
+++ b/k8s-tests/chainsaw/nodewright/pause-suspends-jobs/nodewright.yaml
@@ -28,7 +28,8 @@ spec:
     ## SLEEP_LEN holds apply open long enough to pause mid-stage. The whole test turns on
     ## catching this package while its Job is running, so this must outlast the pause step.
     slowpoke:
-      version: "1.0.0"
+      ## version is the agentless image tag; only published tags work here.
+      version: "1.2.3"
       image: ghcr.io/nvidia/skyhook/agentless
       env:
       - name: SLEEP_LEN

--- a/operator/internal/controller/skyhook_controller.go
+++ b/operator/internal/controller/skyhook_controller.go
@@ -999,8 +999,15 @@ func (r *SkyhookReconciler) resumeSuspendedJobs(ctx context.Context, skyhook Sky
 }
 
 // setSuspendOnUnfinishedJobs sets spec.suspend to the given value on every unfinished, valid Job of
-// the Skyhook, skipping Jobs already in the desired state. suspend is a mutable Job field, so an
-// Update touching only it is accepted where a full spec Update would be rejected as immutable.
+// the Skyhook, skipping Jobs already in the desired state. suspend is a mutable Job field, so a
+// write touching only it is accepted where a full spec write would be rejected as immutable.
+//
+// Merge-patched rather than Updated, and deliberately without an optimistic lock: these Jobs come
+// from a cached list, and the Job controller rewrites Job status constantly — flipping suspend
+// itself deletes the pod and produces more status writes — so a full Update would carry a
+// resourceVersion that is already stale and 409 for no reason. The operator is the only writer of
+// spec.suspend and sets it to an absolute value rather than a read-modify-write, so last-write-wins
+// is the correct semantic here. Same tradeoff the Node patches document in TrackReboots below.
 func (r *SkyhookReconciler) setSuspendOnUnfinishedJobs(ctx context.Context, skyhook SkyhookNodes, suspend bool) error {
 	jobs, err := r.dal.GetJobs(ctx,
 		client.InNamespace(r.opts.Namespace),
@@ -1032,8 +1039,9 @@ func (r *SkyhookReconciler) setSuspendOnUnfinishedJobs(ctx context.Context, skyh
 		if current == suspend {
 			continue
 		}
+		patch := client.MergeFrom(job.DeepCopy())
 		job.Spec.Suspend = ptr(suspend)
-		if err := r.Update(ctx, job); err != nil {
+		if err := r.Patch(ctx, job, patch); err != nil {
 			return fmt.Errorf("setting suspend=%t on job %s: %w", suspend, job.Name, err)
 		}
 	}

--- a/operator/internal/controller/skyhook_controller.go
+++ b/operator/internal/controller/skyhook_controller.go
@@ -443,6 +443,9 @@ func (r *SkyhookReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		}
 
 		if skyhook.IsPaused() {
+			if err := r.suspendUnfinishedJobs(ctx, skyhook); err != nil {
+				return ctrl.Result{RequeueAfter: time.Second * 2}, fmt.Errorf("suspending jobs for paused skyhook %s: %w", skyhook.GetSkyhook().Name, err)
+			}
 			if yes, result, err := shouldReturn(r.UpdatePauseStatus(ctx, clusterState, skyhook)); yes {
 				return result, err
 			}
@@ -453,6 +456,12 @@ func (r *SkyhookReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			return result, err
 		} else if pendingSync {
 			configSyncPending = true
+		}
+
+		// Resume: validation above invalidated any Job whose spec changed while paused; now clear
+		// suspend on the survivors. Ordered after validation so no stale-spec attempt launches first.
+		if err := r.resumeSuspendedJobs(ctx, skyhook); err != nil {
+			return ctrl.Result{RequeueAfter: time.Second * 2}, fmt.Errorf("resuming suspended jobs for skyhook %s: %w", skyhook.GetSkyhook().Name, err)
 		}
 
 		changed := IntrospectSkyhook(skyhook, clusterState.skyhooks, logger)
@@ -967,6 +976,68 @@ func (r *SkyhookReconciler) UpdatePauseStatus(ctx context.Context, clusterState 
 	}
 
 	return false, nil
+}
+
+// suspendUnfinishedJobs gives the Emergency Stop teeth: while a Skyhook is paused every one of its
+// unfinished Jobs is set spec.suspend=true, so the Job controller SIGTERMs the running pod (honoring
+// terminationGracePeriodSeconds) and starts nothing until resume. Idempotent; already-suspended Jobs
+// and invalid ones (mid-reap) are skipped. The killed pod carries a DeletionTimestamp, so
+// erroring-evidence guard (c) keeps node state at in_progress. Legacy raw pods have no Job to suspend
+// and keep today's let-finish semantics until the migration window closes.
+func (r *SkyhookReconciler) suspendUnfinishedJobs(ctx context.Context, skyhook SkyhookNodes) error {
+	return r.setSuspendOnUnfinishedJobs(ctx, skyhook, true)
+}
+
+// resumeSuspendedJobs clears spec.suspend on a non-paused Skyhook's surviving unfinished Jobs. It
+// must run AFTER validation (ValidateRunningPackages), which invalidates any Job whose spec changed
+// while paused — clearing suspend first could launch one stale-spec attempt before validation caught
+// it. On resume the Job controller starts a fresh pod that re-runs the interrupted stage (the same
+// recovery shape as an eviction mid-stage), and because suspension cleared the Job's start time the
+// stage deadline restarts from full.
+func (r *SkyhookReconciler) resumeSuspendedJobs(ctx context.Context, skyhook SkyhookNodes) error {
+	return r.setSuspendOnUnfinishedJobs(ctx, skyhook, false)
+}
+
+// setSuspendOnUnfinishedJobs sets spec.suspend to the given value on every unfinished, valid Job of
+// the Skyhook, skipping Jobs already in the desired state. suspend is a mutable Job field, so an
+// Update touching only it is accepted where a full spec Update would be rejected as immutable.
+func (r *SkyhookReconciler) setSuspendOnUnfinishedJobs(ctx context.Context, skyhook SkyhookNodes, suspend bool) error {
+	jobs, err := r.dal.GetJobs(ctx,
+		client.InNamespace(r.opts.Namespace),
+		client.MatchingLabels{
+			fmt.Sprintf("%s/name", v1alpha1.METADATA_PREFIX): skyhook.GetSkyhook().Name,
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("listing jobs to set suspend=%t for skyhook %s: %w", suspend, skyhook.GetSkyhook().Name, err)
+	}
+	if jobs == nil {
+		return nil
+	}
+
+	for i := range jobs.Items {
+		job := &jobs.Items[i]
+		if jobFinished(job) {
+			continue
+		}
+		// An invalid Job is already being foreground-deleted; neither suspend nor resume it.
+		invalid, err := IsInvalidPackage(job)
+		if err != nil {
+			return fmt.Errorf("checking invalid marker on job %s: %w", job.Name, err)
+		}
+		if invalid {
+			continue
+		}
+		current := job.Spec.Suspend != nil && *job.Spec.Suspend
+		if current == suspend {
+			continue
+		}
+		job.Spec.Suspend = ptr(suspend)
+		if err := r.Update(ctx, job); err != nil {
+			return fmt.Errorf("setting suspend=%t on job %s: %w", suspend, job.Name, err)
+		}
+	}
+	return nil
 }
 
 func (r *SkyhookReconciler) TrackReboots(ctx context.Context, clusterState *clusterState) (bool, error) {

--- a/operator/internal/controller/swap_test.go
+++ b/operator/internal/controller/swap_test.go
@@ -279,4 +279,116 @@ var _ = Describe("Jobs execution swap", func() {
 			Expect(r.shouldDeleteFinishedJob(parked, pkgSky, erroringEntry)).To(BeFalse())
 		})
 	})
+
+	Describe("pause suspend cascade", func() {
+		// buildSkyhookNodes wraps a NodeWright (with no packages, so any Job is stale) as the
+		// SkyhookNodes the suspend/resume helpers take. The nodes matter only for the
+		// ValidateRunningPackages ordering test; the plain helpers read only the Skyhook name.
+		buildSkyhookNodes := func(nodes ...corev1.Node) SkyhookNodes {
+			scr := v1alpha1.NodeWright{ObjectMeta: metav1.ObjectMeta{Name: skyhookName, Namespace: namespace}}
+			state, err := BuildState(
+				&v1alpha1.NodeWrightList{Items: []v1alpha1.NodeWright{scr}},
+				&corev1.NodeList{Items: nodes},
+				&v1alpha1.DeploymentPolicyList{},
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(state.skyhooks).To(HaveLen(1))
+			return state.skyhooks[0]
+		}
+
+		suspendVal := func(c client.WithWatch, name string) *bool {
+			var got batchv1.Job
+			Expect(c.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, &got)).To(Succeed())
+			return got.Spec.Suspend
+		}
+
+		invalidate := func(job *batchv1.Job) {
+			Expect(SetPackages(job, &v1alpha1.NodeWright{ObjectMeta: metav1.ObjectMeta{Name: skyhookName}}, image, v1alpha1.StageApply, pkg)).To(Succeed())
+			Expect(InvalidatePackage(job)).To(Succeed())
+		}
+
+		It("suspends an unfinished Job when the Skyhook is paused", func() {
+			job := stageJob(v1alpha1.StageApply)
+			r, c := newReconciler(job)
+			Expect(r.suspendUnfinishedJobs(ctx, buildSkyhookNodes())).To(Succeed())
+			Expect(suspendVal(c, job.Name)).To(HaveValue(BeTrue()))
+		})
+
+		It("does not suspend a finished Job", func() {
+			job := stageJob(v1alpha1.StageApply, batchv1.JobCondition{Type: batchv1.JobComplete, Status: corev1.ConditionTrue})
+			r, c := newReconciler(job)
+			Expect(r.suspendUnfinishedJobs(ctx, buildSkyhookNodes())).To(Succeed())
+			Expect(suspendVal(c, job.Name)).To(BeNil())
+		})
+
+		It("does not suspend an invalid Job (already being reaped)", func() {
+			job := stageJob(v1alpha1.StageApply)
+			invalidate(job)
+			r, c := newReconciler(job)
+			Expect(r.suspendUnfinishedJobs(ctx, buildSkyhookNodes())).To(Succeed())
+			Expect(suspendVal(c, job.Name)).To(BeNil())
+		})
+
+		It("is idempotent — leaves an already-suspended Job unchanged", func() {
+			job := stageJob(v1alpha1.StageApply)
+			job.Spec.Suspend = ptr(true)
+			r, c := newReconciler(job)
+			Expect(r.suspendUnfinishedJobs(ctx, buildSkyhookNodes())).To(Succeed())
+			Expect(suspendVal(c, job.Name)).To(HaveValue(BeTrue()))
+		})
+
+		It("resumes a suspended Job when the Skyhook is no longer paused", func() {
+			job := stageJob(v1alpha1.StageApply)
+			job.Spec.Suspend = ptr(true)
+			r, c := newReconciler(job)
+			Expect(r.resumeSuspendedJobs(ctx, buildSkyhookNodes())).To(Succeed())
+			Expect(suspendVal(c, job.Name)).To(HaveValue(BeFalse()))
+		})
+
+		It("leaves an invalid suspended Job suspended (validation reaps it before resume clears it)", func() {
+			job := stageJob(v1alpha1.StageApply)
+			job.Spec.Suspend = ptr(true)
+			invalidate(job)
+			r, c := newReconciler(job)
+			Expect(r.resumeSuspendedJobs(ctx, buildSkyhookNodes())).To(Succeed())
+			// still suspended — resume must not un-suspend a stale-spec Job before it is reaped
+			Expect(suspendVal(c, job.Name)).To(HaveValue(BeTrue()))
+		})
+
+		It("is a no-op with only a legacy pod present (legacy pods cannot suspend)", func() {
+			legacy := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "legacy-tuning", Namespace: namespace,
+					Labels: map[string]string{nameLabel: skyhookName, packageLabel: "tuning-1.0.0"},
+				},
+				Spec: corev1.PodSpec{NodeName: nodeName},
+			}
+			r, _ := newReconciler(legacy)
+			Expect(r.suspendUnfinishedJobs(ctx, buildSkyhookNodes())).To(Succeed())
+		})
+
+		It("invalidates a stale suspended Job without clearing suspend (resume ordering guard)", func() {
+			// A suspended Job whose package is no longer in spec (edited while paused). Validation must
+			// mark it invalid and return update=true — which makes the reconcile loop early-return
+			// BEFORE resumeSuspendedJobs runs — and must not clear suspend, so no stale-spec attempt
+			// launches before JobReconcile reaps it.
+			job := stageJob(v1alpha1.StageApply)
+			job.Spec.Suspend = ptr(true)
+			Expect(SetPackages(job, &v1alpha1.NodeWright{ObjectMeta: metav1.ObjectMeta{Name: skyhookName}}, image, v1alpha1.StageApply, pkg)).To(Succeed())
+
+			node := corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: nodeName}}
+			r, c := newReconciler(job)
+			// empty Packages spec => the Job matches nothing => stale
+			update, err := r.ValidateRunningPackages(ctx, buildSkyhookNodes(node))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(update).To(BeTrue())
+
+			var got batchv1.Job
+			Expect(c.Get(ctx, types.NamespacedName{Namespace: namespace, Name: job.Name}, &got)).To(Succeed())
+			invalid, err := IsInvalidPackage(&got)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(invalid).To(BeTrue())                     // validation marked it invalid...
+			Expect(got.Spec.Suspend).To(HaveValue(BeTrue())) // ...and left suspend untouched
+		})
+	})
 })


### PR DESCRIPTION
Second increment of #303 (**part 2** — pause as a real stop). **Stacked on #350** (base `jobs-migration/303a-swap`) so the diff stays focused; will re-point to `feature/package-as-jobs` as the stack lands.

Part 1 swapped package execution to Jobs. This makes the `skyhook.nvidia.com/pause` annotation (the Emergency Stop) actually **stop a running stage**: while a Skyhook is paused the operator sets `spec.suspend: true` on all of its unfinished Jobs — the Job controller SIGTERMs the running pod and starts nothing until resume — and clears it on resume. Before this, pause only blocked *new* stage scheduling; an in-flight stage ran to completion, so pause couldn't stop it.

## The cascade

- **`suspendUnfinishedJobs`** runs in the paused branch. **`resumeSuspendedJobs`** runs in the non-paused branch **after `validateAndUpsertSkyhookData`**. The ordering is load-bearing: validation invalidates any Job whose spec changed while paused (returning `update=true`, which early-returns the loop), so resume only clears `suspend` on the survivors — clearing first could launch one stale-spec attempt before validation caught it.
- **Shared worker** (`setSuspendOnUnfinishedJobs`) skips: finished Jobs (`Suspended` is not terminal — an unfinished suspended Job still gates existence via `JobExists` and never records completion), invalid Jobs (mid-reap), and Jobs already at the desired `suspend` state. `suspend` is a mutable Job field, so an Update touching only it is accepted.
- **The deadline pauses with the Job** (native behavior, no code): suspension clears the Job's start time, so `activeDeadlineSeconds` stops ticking and a resumed stage gets a full timeout.
- **Node state stays `in_progress` across a suspend:** the killed pod carries a `DeletionTimestamp`, so erroring-evidence guard (c) keeps pod evidence silent.
- **Legacy raw pods can't suspend** — pause keeps today's let-finish semantics for them until the migration window closes; `docs/cli.md` notes the version-dependent stop strength (the design's CLI-docs note).

## Verification

- New specs (`swap_test.go` "pause suspend cascade", 8): suspend sets / skips-finished / skips-invalid / idempotent; resume clears / leaves-invalid-suspended-alone; legacy-pod no-op; and a **`ValidateRunningPackages` ordering guard** — a stale suspended Job is invalidated with `suspend` preserved and `update=true` (which is what early-returns the loop before resume).
- Controller suite **256/256**; `make lint` **0 issues**; `gofmt` clean; `go build` clean.
- Adversarial review (opus, xhigh): verdict **SHIP, no blockers** — it verified the ordering holds across reconciles, `jobFinished` gates correctly (a Complete-but-unprocessed Job is skipped), the completion race is safe, guard (c) holds, and `MaxConcurrentReconciles: 1` serializes the Job Updates. The one MAJOR was the reconcile-level ordering being under-tested; the `ValidateRunningPackages` guard test above folds it in.

### Known limitations (from review; not blocking, no code change)

- **A suspend-kill looks like a failed attempt to backoff accounting / the archive pruner** (the deleted pod exits non-zero with no `DisruptionTarget`). Node state is unaffected (guard c); this is observability-only — a pause/resume cycle can bump `status.Failed` and may leave one archive pod that wasn't a real failure.
- **Job-level spec edits that `jobMatchesPackage` doesn't compare** (`stageTimeout`→`activeDeadlineSeconds`, `additionalTolerations`, `podFailurePolicy`) made while paused won't invalidate the suspended Job, so resume un-suspends it with the stale value. Pre-existing `jobMatchesPackage` scope; `activeDeadlineSeconds` is a safety bound that converges next stage.
- **First-pass latency:** `ReportState` runs before the pause branch and can early-return once, so on the first reconcile after pausing, suspend may be deferred one 2s requeue. The docs say "signaled to stop," not instantaneous.
- **Pause during CR deletion** now suspends in-flight uninstall Jobs — consistent with the existing rule that a paused Skyhook with pending uninstall blocks deletion until resumed (not a new deadlock).

Same inherited-base caveat as the rest of the stack: the full `make unit-tests` aborts on a pre-existing, unrelated CLI test hang before the controller suite runs; the controller suite was run directly and passes.



---

### e2e status (correction)

**Correction:** an earlier revision of this description claimed the failing `e2e/*` and `helm-tests` checks were inherited from the `fix/api-rename` base. That was wrong — the base (#348) is fully green. The swap introduced them.

- The **`e2e/*` (chainsaw) failures are migrated to the Jobs model in #353** (sub-issue #304): package/interrupt pods are now owned by their `batch/v1` Job rather than the NodeWright CR, and completed-stage pods linger under the Job TTL. This PR's `e2e/*` stays red until #353 lands above it in the stack.
- The **`helm-tests` (`helm-chart-webhook`) failure is a separate functional regression** (skyhook stays `in_progress` under the helm-deployed operator) — not an assertion issue, tracked separately.
- `unit-tests` remains the gate for this PR and passes.