### PR TITLE
fix(ci): grant pull-requests: write to auto-assign author

### DIFF
--- a/.github/workflows/auto-assign-author.yaml
+++ b/.github/workflows/auto-assign-author.yaml
@@ -41,9 +41,11 @@ jobs:
     name: Assign author to their PR
     runs-on: ubuntu-latest
     permissions:
-      # Assigning goes through the Issues API (issues.addAssignees), so issues
-      # write is all this job needs.
+      # Assigning a PR needs pull-requests: write — the assignee endpoint
+      # returns 403 "Resource not accessible by integration" with issues:write
+      # alone. issues: write covers the pre-assignment issues.get read.
       issues: write
+      pull-requests: write
     timeout-minutes: 5
     steps:
       - name: Assign the author


### PR DESCRIPTION
## What

Adds `pull-requests: write` to the `auto-assign-author` job's permissions.

## Why

The workflow currently fails at runtime with a **403** when assigning the author:

```
Failed to assign <author> to PR #351: Resource not accessible by integration
```

(seen on [this run](https://github.com/NVIDIA/nodewright/actions/runs/29857777552/job/88726357791).) The job's token had `Issues: write` only. Despite `issues.addAssignees` being nominally an Issues-API method, **assigning a pull request requires `pull-requests: write`** — the endpoint returns 403 with `issues: write` alone.

The job caught the error and logged a warning (so it exited green), which is why this slipped through — the assignment silently never happened.

## Fix

Grant `pull-requests: write` alongside `issues: write` (the latter still covers the pre-assignment `issues.get` read). Corrected the now-wrong comment that claimed `issues: write` was sufficient.

A companion PR applies the same fix to the packages repo.