### PR TITLE
docs: update Skyhook wording to NodeWright in operator topic docs

### DIFF
--- a/docs/kubernetes-support.md
+++ b/docs/kubernetes-support.md
@@ -1,6 +1,6 @@
 # Kubernetes Version Support
 
-This document outlines Skyhook's approach to supporting different Kubernetes versions.
+This document outlines NodeWright's approach to supporting different Kubernetes versions.
 
 ## What Version Should I Use?
 
@@ -29,9 +29,9 @@ Currently tested: **1.36, 1.35, 1.34, 1.33** (kind v0.32.0). 1.32 and older drop
 
 ### What This Means
 
-- **✅ Fully Supported:** We test and support these K8s versions in the current Skyhook release
-- **⚠️ Use older Skyhook:** Your K8s version is supported, but use an older Skyhook release
-- **❌ Not Supported:** Upgrade your Kubernetes cluster or use a much older Skyhook version
+- **✅ Fully Supported:** We test and support these K8s versions in the current NodeWright release
+- **⚠️ Use older NodeWright:** Your K8s version is supported, but use an older NodeWright release
+- **❌ Not Supported:** Upgrade your Kubernetes cluster or use a much older NodeWright version
 
 ### When Versions Change
 
@@ -39,13 +39,13 @@ Currently tested: **1.36, 1.35, 1.34, 1.33** (kind v0.32.0). 1.32 and older drop
 
 1. Wait **4+ weeks** after K8s release for ecosystem stability
 2. Add to the CI testing matrix in `operator/versions.yaml`
-3. Include in next Skyhook release
+3. Include in next NodeWright release
 
 **For EOL Kubernetes versions:**
 
-1. Stop including in new Skyhook releases
-2. Existing Skyhook versions continue to work
-3. Users should upgrade K8s and then upgrade Skyhook
+1. Stop including in new NodeWright releases
+2. Existing NodeWright versions continue to work
+3. Users should upgrade K8s and then upgrade NodeWright
 
 ## Upgrade Strategy
 
@@ -60,7 +60,7 @@ Currently tested: **1.36, 1.35, 1.34, 1.33** (kind v0.32.0). 1.32 and older drop
 We understand many installations run slightly older Kubernetes versions. Our strategy balances staying current while giving users time to upgrade:
 
 - **6-week notice** before dropping support for a Kubernetes version
-- **Clear documentation** about which Skyhook version to use for your Kubernetes version
+- **Clear documentation** about which NodeWright version to use for your Kubernetes version
 - **Gradual transitions** rather than sudden jumps when possible
 
 ## Version Selection Guide
@@ -82,11 +82,11 @@ As a small project, we focus our efforts on actively maintained Kubernetes versi
 
 ### What if I'm stuck on an older Kubernetes version?
 
-**You can still use Skyhook!** Just use an older Skyhook version that was built for your K8s version:
+**You can still use NodeWright!** Just use an older NodeWright version that was built for your K8s version:
 
 - Older releases continue to work and don't disappear
-- Check our release notes for which Skyhook version supports your K8s version
-- Plan your Kubernetes upgrade timeline, then upgrade Skyhook afterward
+- Check our release notes for which NodeWright version supports your K8s version
+- Plan your Kubernetes upgrade timeline, then upgrade NodeWright afterward
 
 ### Why wait 4 weeks before supporting new Kubernetes versions?
 
@@ -100,7 +100,7 @@ Waiting 4+ weeks lets the ecosystem stabilize and gives us confidence in support
 
 ### How do you test compatibility?
 
-For each Skyhook release, we test against all supported Kubernetes versions using:
+For each NodeWright release, we test against all supported Kubernetes versions using:
 
 - GitHub Actions matrix builds with multiple K8s versions. The exact tested patch versions are owned by `ci.kindNodeImages` in `operator/versions.yaml`.
 - Local testing with [kind](https://kind.sigs.k8s.io/)

--- a/docs/operator-status-definitions.md
+++ b/docs/operator-status-definitions.md
@@ -1,10 +1,10 @@
 # Operator Status, State, Stage, and Condition Definitions
 
-This document provides concise definitions for the status, state, stage, and condition concepts used throughout the Skyhook operator to track package operations and node lifecycle management.
+This document provides concise definitions for the status, state, stage, and condition concepts used throughout the NodeWright operator to track package operations and node lifecycle management.
 
 ## Key Relationships
 
-- **Status** reflects the overall health and progress of nodes and the Skyhook resource
+- **Status** reflects the overall health and progress of nodes and the NodeWright resource
 - **State** tracks the execution status of individual package operations
 - **Stage** defines the specific lifecycle phase a package is currently in
 
@@ -21,7 +21,7 @@ This document provides concise definitions for the status, state, stage, and con
 
 ## Status
 
-**Scope**: Applied to the overall Skyhook resource and individual nodes  
+**Scope**: Applied to the overall NodeWright resource and individual nodes  
 **Purpose**: High-level operational status indicating the current condition
 
 | Status | Definition |
@@ -29,19 +29,19 @@ This document provides concise definitions for the status, state, stage, and con
 | `complete`    | All operations have finished successfully |
 | `blocked`     | Operations are prevented from proceeding due to taint toleration issues |
 | `waiting`     | Queued for execution but not yet started |
-| `disabled`    | Execution is disabled but will continue for other Skyhooks |
-| `paused`      | Execution is paused for this and all other Skyhooks supposed to be executed after this one |
+| `disabled`    | Execution is disabled but will continue for other NodeWrights |
+| `paused`      | Execution is paused for this and all other NodeWrights supposed to be executed after this one |
 | `in_progress` | Currently executing operations |
 | `erroring`    | Experiencing failures or errors |
 | `unknown`     | Status cannot be determined or is uninitialized |
 
 ## Conditions
 
-Skyhook publishes Kubernetes conditions on `.status.conditions`. The `Ready` condition is the standard user-facing summary for `kubectl wait --for=condition=Ready`, while other condition types report specific operator states that can coexist with `Ready`.
+NodeWright publishes Kubernetes conditions on `.status.conditions`. The `Ready` condition is the standard user-facing summary for `kubectl wait --for=condition=Ready`, while other condition types report specific operator states that can coexist with `Ready`.
 
 ### Ready Condition
 
-`Ready` is a boolean projection of the Skyhook's multivalued `.status.status` field:
+`Ready` is a boolean projection of the NodeWright's multivalued `.status.status` field:
 
 | `.status.status` | `Ready.status` | `Ready.reason` | Meaning |
 |------------------|----------------|----------------|---------|
@@ -83,7 +83,7 @@ The truncation cap exists to keep condition payloads bounded for etcd object siz
 
 The operator also sets additional condition types that may be useful for troubleshooting:
 
-- `TaintNotTolerable`: selected nodes are skipped because their taints are not tolerated by the Skyhook
+- `TaintNotTolerable`: selected nodes are skipped because their taints are not tolerated by the NodeWright
 - `NodesIgnored`: selected nodes are skipped because they have the ignore label set
 - `ApplyPackage`: the controller is applying a package to a node
 - `DeploymentPolicyNotFound`: the referenced `DeploymentPolicy` is missing at reconcile time
@@ -150,9 +150,9 @@ cordon → wait → drain → upgrade (if upgrading) → config → interrupt �
 
 **Note**: The cordon, wait, and drain phases ensure that workloads are safely removed from the node before any package operations that require interrupts (such as reboots or kernel module changes) are executed.
 
-## Skyhook Status Fields
+## NodeWright Status Fields
 
-The Skyhook resource's `.status` object includes fields that track batch rollout state. Two fields are particularly relevant for [batch stickiness](deployment_policy.md#batch-stickiness) and [node ordering](ordering_of_skyhooks.md#node-order-within-a-rollout):
+The NodeWright resource's `.status` object includes fields that track batch rollout state. Two fields are particularly relevant for [batch stickiness](deployment_policy.md#batch-stickiness) and [node ordering](ordering_of_skyhooks.md#node-order-within-a-rollout):
 
 | Field | Definition |
 |-------|------------|

--- a/docs/resource_management.md
+++ b/docs/resource_management.md
@@ -1,12 +1,12 @@
-# Resource Management in Skyhook
+# Resource Management in NodeWright
 
-Skyhook provides flexible and robust resource management for the pods it creates, allowing you to control CPU and memory usage at both the namespace and per-package level. This document explains how resource defaults and overrides work, and what validation rules are enforced.
+NodeWright provides flexible and robust resource management for the pods it creates, allowing you to control CPU and memory usage at both the namespace and per-package level. This document explains how resource defaults and overrides work, and what validation rules are enforced.
 
 ---
 
 ## 1. Namespace Defaults with LimitRange
 
-By default, Skyhook uses a [Kubernetes LimitRange](https://kubernetes.io/docs/concepts/policy/limit-range/) to set default CPU and memory requests/limits for all containers in the namespace where Skyhook operates.
+By default, NodeWright uses a [Kubernetes LimitRange](https://kubernetes.io/docs/concepts/policy/limit-range/) to set default CPU and memory requests/limits for all containers in the namespace where NodeWright operates.
 
 **Example LimitRange:**
 ```yaml
@@ -33,7 +33,7 @@ spec:
 
 ## 2. Per-Package Resource Overrides
 
-You can override the default resource requests/limits for each package in your Skyhook Custom Resource (CR). This is done in the `resources` field for each package:
+You can override the default resource requests/limits for each package in your NodeWright Custom Resource (CR). This is done in the `resources` field for each package:
 
 **Example:**
 ```yaml
@@ -56,7 +56,7 @@ spec:
 
 ## 3. Validation Rules
 
-Skyhook enforces the following validation rules (via webhook) for resource overrides:
+NodeWright enforces the following validation rules (via webhook) for resource overrides:
 
 - If any of the four resource fields are set, **all four must be set**.
 - All values must be **positive**.
@@ -73,7 +73,7 @@ Skyhook enforces the following validation rules (via webhook) for resource overr
 | ❌     | 200m      | 400m     | 128Mi        | 64Mi        | memoryLimit < memoryRequest |
 | ❌     | 0         | 400m     | 128Mi        | 256Mi       | Zero value |
 
-If a resource override is invalid, the Skyhook CR will be **rejected** by the webhook.
+If a resource override is invalid, the NodeWright CR will be **rejected** by the webhook.
 
 ---
 
@@ -88,7 +88,7 @@ If a resource override is invalid, the Skyhook CR will be **rejected** by the we
 
 ## 5. Troubleshooting
 
-- If your Skyhook CR is rejected, check that all four resource fields are set and valid if you are using overrides.
+- If your NodeWright CR is rejected, check that all four resource fields are set and valid if you are using overrides.
 - Use `kubectl describe limitrange -n <namespace>` to see the current defaults.
 - Use `kubectl describe skyhook <name>` to see the status and any error messages.
 
@@ -114,7 +114,7 @@ If there is **no LimitRange** and you do **not** set resource requests/limits in
 
 ## 7. Special Case: Uninstall Pod Resources
 
-Uninstall pods in Skyhook **do not use per-package resource overrides**.  
+Uninstall pods in NodeWright **do not use per-package resource overrides**.  
 Instead, their resource requests/limits are determined only by the namespace defaults:
 
 - If a LimitRange is present in the namespace, uninstall pods will use those default CPU and memory requests/limits.

--- a/docs/runtime_required.md
+++ b/docs/runtime_required.md
@@ -10,9 +10,9 @@ Runtime required is a special mode that packages can be run in. This mode is for
 1. That same taint must be set as the chart value `controllerManager.manager.env.runtimeRequiredTaint`
     1. The default value for this taint is `skyhook.nvidia.com=runtime-required:NoSchedule`
 
-## Required Skyhooks
+## Required NodeWrights
 
-Once the pre-requisites are satisfied any Skyhook Custom Resource (SCR) may be marked with `runtimeRequired: true`. This flag indicates that all packages within this SCR must complete
+Once the pre-requisites are satisfied any NodeWright Custom Resource (CR) may be marked with `runtimeRequired: true`. This flag indicates that all packages within this CR must complete
 before the nodes that it targets are considered available for general use.
 
 ## Auto-tainting new nodes
@@ -21,7 +21,7 @@ before the nodes that it targets are considered available for general use.
 
 If you cannot control node tainting at provisioning time, `autoTaintNewNodes` provides a fallback. Note that there is a small window between when a node joins the cluster and when the operator's reconcile loop applies the taint, during which workloads could theoretically be scheduled on the node.
 
-To enable, set `autoTaintNewNodes: true` alongside `runtimeRequired: true` on the Skyhook CR:
+To enable, set `autoTaintNewNodes: true` alongside `runtimeRequired: true` on the NodeWright CR:
 
 ```yaml
 spec:
@@ -31,28 +31,28 @@ spec:
 
 When enabled, the operator automatically applies the runtime-required taint to nodes that:
 
-1. Match the Skyhook's node selector
+1. Match the NodeWright's node selector
 2. Do not already have the runtime-required taint
-3. Have no `skyhook.nvidia.com/*` annotations (i.e., have never been touched by the Skyhook operator)
+3. Have no `skyhook.nvidia.com/*` annotations (i.e., have never been touched by the NodeWright operator)
 
-A node is considered "new" if it has no Skyhook annotations. This works for both initial cluster setup (day 0) and nodes joining an existing cluster (day 2+). Nodes that have already been processed by Skyhook (and had their taint removed after completion) will not be re-tainted because they retain their Skyhook annotations.
+A node is considered "new" if it has no NodeWright annotations. This works for both initial cluster setup (day 0) and nodes joining an existing cluster (day 2+). Nodes that have already been processed by NodeWright (and had their taint removed after completion) will not be re-tainted because they retain their NodeWright annotations.
 
-**Exception: reboot with `REAPPLY_ON_REBOOT=true`.** When the operator is configured with `REAPPLY_ON_REBOOT=true` and a Skyhook has both `runtimeRequired: true` and `autoTaintNewNodes: true`, a node whose boot ID changes is treated as new for taint purposes. The runtime-required taint is re-applied alongside the state reset in the same atomic operation, ensuring no workloads can schedule on the rebooted node before Skyhook finishes re-applying. The taint is removed again by the normal completion path once all runtime-required Skyhooks finish on that node.
+**Exception: reboot with `REAPPLY_ON_REBOOT=true`.** When the operator is configured with `REAPPLY_ON_REBOOT=true` and a NodeWright has both `runtimeRequired: true` and `autoTaintNewNodes: true`, a node whose boot ID changes is treated as new for taint purposes. The runtime-required taint is re-applied alongside the state reset in the same atomic operation, ensuring no workloads can schedule on the rebooted node before NodeWright finishes re-applying. The taint is removed again by the normal completion path once all runtime-required NodeWrights finish on that node.
 
 ## What runtimeRequired: true will NOT do
 
-1. Without `autoTaintNewNodes: true`, it will NOT add the taint to any nodes targeted by a SCR with `runtimeRequired: true`
+1. Without `autoTaintNewNodes: true`, it will NOT add the taint to any nodes targeted by a CR with `runtimeRequired: true`
 
 ## Details
 
 ## When is the runtime-required taint removed from a node
 
-The taint is removed from a node when all SCRs with `runtimeRequired: true` that target that node are complete **on that specific node**.
+The taint is removed from a node when all CRs with `runtimeRequired: true` that target that node are complete **on that specific node**.
 
 **Important**: Taint removal is per-node, not per-skyhook. This means:
 
-- Node A's taint is removed when all runtime-required skyhooks complete on Node A
-- Node A does NOT wait for Node B to complete those same skyhooks
+- Node A's taint is removed when all runtime-required nodewrights complete on Node A
+- Node A does NOT wait for Node B to complete those same nodewrights
 - If Node B is stuck or failing, Node A can still have its taint removed and become available
 
 This per-node behavior prevents deadlocks where a few bad nodes would block all other healthy nodes from becoming available.
@@ -63,6 +63,6 @@ This per-node behavior prevents deadlocks where a few bad nodes would block all 
 
 ## Why would you use runtime required
 
-This is useful when you want to gate other work behind the successful completion of some set of Skyhook Packages. This can be for security reasons or for scheduling.
+This is useful when you want to gate other work behind the successful completion of some set of NodeWright Packages. This can be for security reasons or for scheduling.
 
-**NOTE:** No additional toleration is required, skyhook auto tolerates this (env:`runtimeRequiredTaint`) taint.
+**NOTE:** No additional toleration is required, nodewright auto tolerates this (env:`runtimeRequiredTaint`) taint.

--- a/docs/uninstall.md
+++ b/docs/uninstall.md
@@ -83,9 +83,9 @@ Cancellation semantics depend on which stage the node is at when `apply` is flip
 
 ### CR Deletion (Finalizer)
 
-When a Skyhook CR is deleted (`kubectl delete skyhook my-skyhook`):
+When a NodeWright CR is deleted (`kubectl delete skyhook my-skyhook`):
 
-- **`enabled: true` packages**: The finalizer triggers uninstall pods, waits for completion on all nodes, then cleans up (uncordon nodes, remove SCR labels/annotations, remove finalizer).
+- **`enabled: true` packages**: The finalizer triggers uninstall pods, waits for completion on all nodes, then cleans up (uncordon nodes, remove CR labels/annotations, remove finalizer).
 - **`enabled: false` packages (or nil)**: No uninstall pods — state is cleaned up immediately. The package state remains on nodes so administrators can see what was previously applied.
 
 #### Deletion edge cases
@@ -95,14 +95,14 @@ The finalizer handles a few edge cases where the normal "wait for uninstall to c
 | State at deletion | Outcome | Condition / Event |
 |---|---|---|
 | `nodeState` annotation unreadable on any node | **Blocked.** The finalizer cannot safely decide what to preserve or what still needs uninstalling. Repair the annotation (or delete it) on the affected node, then reconciliation proceeds. | `DeletionBlocked` / `Reason: MalformedNodeState` |
-| Skyhook is **paused** AND at least one `uninstall.enabled=true` package is still tracked in `nodeState` | **Blocked.** A paused Skyhook can't drive uninstall (`processSkyhooksPerNode` short-circuits on pause). Unpause so uninstall can complete, then deletion proceeds. | `DeletionBlocked` / `Reason: PausedWithPendingUninstall` |
-| Skyhook is **disabled** AND at least one `uninstall.enabled=true` package is still tracked in `nodeState` | **Blocked.** A disabled Skyhook also can't drive uninstall (`processSkyhooksPerNode` short-circuits on disable). `uninstall.enabled=true` is an explicit request to run uninstall scripts before the CR is removed — silently deleting would leave host-side state the user asked to be cleaned. Re-enable the Skyhook so uninstall can run. | `DeletionBlocked` / `Reason: DisabledWithPendingUninstall` |
+| NodeWright is **paused** AND at least one `uninstall.enabled=true` package is still tracked in `nodeState` | **Blocked.** A paused NodeWright can't drive uninstall (`processSkyhooksPerNode` short-circuits on pause). Unpause so uninstall can complete, then deletion proceeds. | `DeletionBlocked` / `Reason: PausedWithPendingUninstall` |
+| NodeWright is **disabled** AND at least one `uninstall.enabled=true` package is still tracked in `nodeState` | **Blocked.** A disabled NodeWright also can't drive uninstall (`processSkyhooksPerNode` short-circuits on disable). `uninstall.enabled=true` is an explicit request to run uninstall scripts before the CR is removed — silently deleting would leave host-side state the user asked to be cleaned. Re-enable the NodeWright so uninstall can run. | `DeletionBlocked` / `Reason: DisabledWithPendingUninstall` |
 | Paused or disabled, but no uninstall-enabled packages are tracked in `nodeState` (all packages are `uninstall.enabled=false`, or their uninstall already completed) | **Deletion proceeds** normally — pause/disable only matter when there is uninstall work to drive. `uninstall.enabled=false` packages are treated as complete in the finalizer, and their `nodeState` entries are preserved by `CleanupSCRMetadata` (D2 semantics: non-absent entry means files remain on host). | — |
 
 Notes:
 
-- `DeletionBlocked` is cleared automatically once the blocking condition is resolved (annotation repaired, Skyhook unpaused, or the pending work is no longer present).
-- Forcing deletion of a blocked Skyhook requires manually removing the `skyhook.nvidia.com/skyhook` finalizer (`kubectl patch skyhook <name> --type=merge -p '{"metadata":{"finalizers":null}}'`). Doing this bypasses Phase 3 cleanup entirely: per-Skyhook labels/annotations/conditions are **not** removed and nodes are **not** uncordoned — the caller is responsible for any residual cleanup.
+- `DeletionBlocked` is cleared automatically once the blocking condition is resolved (annotation repaired, NodeWright unpaused, or the pending work is no longer present).
+- Forcing deletion of a blocked NodeWright requires manually removing the `skyhook.nvidia.com/skyhook` finalizer (`kubectl patch skyhook <name> --type=merge -p '{"metadata":{"finalizers":null}}'`). Doing this bypasses Phase 3 cleanup entirely: per-Skyhook labels/annotations/conditions are **not** removed and nodes are **not** uncordoned — the caller is responsible for any residual cleanup.
 
 ### Downgrade (version change)
 
@@ -175,7 +175,7 @@ kubectl get nodes -l skyhook.nvidia.com/test-node=skyhooke2e -o jsonpath='{.item
 
 ### Blocked dependency
 
-Check the Skyhook conditions:
+Check the NodeWright conditions:
 ```bash
 kubectl get skyhook <name> -o jsonpath='{.status.conditions}' | jq
 ```
@@ -194,7 +194,7 @@ If the webhook rejects removal of an `enabled: true` package:
 
 ### CR deletion deadlocks when an install is stuck at `erroring`
 
-**Symptom.** `kubectl delete skyhook <name>` hangs indefinitely. The Skyhook stays around with a `DeletionTimestamp` set and the `skyhook.nvidia.com/skyhook` finalizer attached. No uninstall pods are created for an `uninstall.enabled: true` package that's still tracked in `nodeState`.
+**Symptom.** `kubectl delete skyhook <name>` hangs indefinitely. The NodeWright stays around with a `DeletionTimestamp` set and the `skyhook.nvidia.com/skyhook` finalizer attached. No uninstall pods are created for an `uninstall.enabled: true` package that's still tracked in `nodeState`.
 
 **Why.** The finalizer drives uninstall through the same `HandleUninstallRequests` path as explicit uninstall. That path only transitions a package from an install stage (`apply`, `config`, `interrupt`, `post-interrupt`, `upgrade`) to `uninstall` when the package is in **`state: complete`** on the node. If the install never reached `complete` — e.g., `uninstall.sh` wasn't yet exercised because `apply.sh` is crash-looping in `state: erroring` — the uninstall trigger is skipped, so the finalizer's "wait for pending uninstall" phase never progresses.
 
@@ -216,7 +216,7 @@ Any rows returned are nodes the finalizer is waiting on.
 
 1. **Fix the underlying install.** Inspect `kubectl logs -n skyhook <pod> -c <pkg>-apply` and correct the script, config, or environment so the install completes. Once the node reaches `stage: config` / `state: complete` (or `post-interrupt/complete` if the package has an interrupt), the finalizer's next reconcile will transition it to `uninstall` and proceed.
 
-2. **Reset the affected node's Skyhook state.** Use the CLI:
+2. **Reset the affected node's NodeWright state.** Use the CLI:
 
     ```bash
     kubectl skyhook reset <skyhook-name> --node <node-name> --confirm
@@ -238,7 +238,7 @@ Any rows returned are nodes the finalizer is waiting on.
 
 **Rare.** Requires a specific sequence: the uninstall pod has already finished, the node has transitioned to `stage: uninstall-interrupt` / `state: in_progress`, the interrupt pod is **not currently running** (never fired, was manually deleted, or the kubelet evicted it), and the user then edits the package to remove the `interrupt:` block.
 
-**Symptom.** The node's `nodeState` entry for the package is pinned at `stage: uninstall-interrupt` / `state: in_progress`. No new pod is created, no state transition occurs, and the Skyhook never returns to `complete`. Reconciles are a no-op for this package.
+**Symptom.** The node's `nodeState` entry for the package is pinned at `stage: uninstall-interrupt` / `state: in_progress`. No new pod is created, no state transition occurs, and the NodeWright never returns to `complete`. Reconciles are a no-op for this package.
 
 **Why.** Once the uninstall pod succeeds, `HandleCompletePod` commits the node to `stage: uninstall-interrupt` only when `package.HasInterrupt()` was true at that moment. The next reconcile's `ProcessInterrupt` re-checks `HasInterrupt` from the *current* spec to decide whether to (re-)create the interrupt pod — if the user has since removed the `interrupt:` block, the check fails and no pod is spawned. `ApplyPackage` short-circuits `stage == uninstall-interrupt` to a no-op (the interrupt machinery is supposed to drive it), and `HandleUninstallRequests` only calls `RemoveState` once `state == complete` — which will never happen without a pod to succeed. The node is permanently stranded.
 
@@ -278,11 +278,11 @@ An entry from the first command with no rows from the second confirms the strand
 
 ### `uninstall.apply: true` on a package that was never installed is a silent no-op
 
-**Symptom.** A package with `uninstall.enabled: true` / `uninstall.apply: true` is in the spec of a newly-applied (or extended) Skyhook. Reconcile runs, no uninstall pod spawns, and the package is **never installed** either. The Skyhook looks idle for that package — no events, no error condition, nothing in the status to explain the silence.
+**Symptom.** A package with `uninstall.enabled: true` / `uninstall.apply: true` is in the spec of a newly-applied (or extended) NodeWright. Reconcile runs, no uninstall pod spawns, and the package is **never installed** either. The NodeWright looks idle for that package — no events, no error condition, nothing in the status to explain the silence.
 
 **Why.** The reconciler treats `IsUninstalling() && absent from nodeState` as the terminal "uninstalled" state (per D2). A brand-new package is also absent from nodeState, which collides with that signal: `shouldSkipApplyForUninstall` returns true (apply requested + absent), so the install pipeline is skipped. The package is interpreted as "already uninstalled, nothing to do." The webhook only validates `apply: true` requires `enabled: true` — it has no way to tell "never-installed" from "fully-uninstalled" at admission time.
 
-**Most common trigger.** Copy-pasting a working Skyhook YAML from one cluster to another and forgetting to flip `apply` back to `false` before applying. Also reachable by applying a Skyhook with `apply: true` set in a manifest generated by a tool that tracks "last known good" config.
+**Most common trigger.** Copy-pasting a working NodeWright YAML from one cluster to another and forgetting to flip `apply` back to `false` before applying. Also reachable by applying a NodeWright with `apply: true` set in a manifest generated by a tool that tracks "last known good" config.
 
 **How to confirm.** Package is in spec with `apply: true, enabled: true`, but no entry in any node's `nodeState_<skyhook-name>` annotation:
 
@@ -302,9 +302,9 @@ uninstall:
   apply: false
 ```
 
-Re-apply the Skyhook. The install pipeline will engage on the next reconcile.
+Re-apply the NodeWright. The install pipeline will engage on the next reconcile.
 
-**Long-term fix.** Either emit an admission warning for `apply: true` on a package where the webhook sees no node state, or raise an explicit Skyhook condition (`Skipped: apply=true on never-installed package`) so the silence is surfaced in `kubectl describe`.
+**Long-term fix.** Either emit an admission warning for `apply: true` on a package where the webhook sees no node state, or raise an explicit NodeWright condition (`Skipped: apply=true on never-installed package`) so the silence is surfaced in `kubectl describe`.
 
 ### Changing `version` while `uninstall.apply: true` is in flight leaves the new version uninstalled
 
@@ -338,23 +338,23 @@ If spec shows the new version and no node state references the new `name|version
 
 **Long-term fix.** `HandleCancelledUninstalls` should delete any in-flight uninstall pod when it resets the stage, instead of leaving cleanup to `ValidateRunningPackages`.
 
-### `CleanupSCRMetadata` can over-delete annotations when a Skyhook name collides with a taint-key suffix
+### `CleanupSCRMetadata` can over-delete annotations when a NodeWright name collides with a taint-key suffix
 
-**Unlikely, operational.** During CR-delete cleanup (`HandleFinalizer` Phase 3), `CleanupSCRMetadata` removes any `skyhook.nvidia.com/*` annotation or label whose key ends with `_<skyhookName>`. That suffix-match also catches the `skyhook.nvidia.com/autoTaint_<taintKey>` annotation written by `AutoTaintNewNodes` — **but only if the Skyhook's name exactly equals the taint key's value**. In practice both sides are user-chosen strings; a collision requires a Skyhook named to match a taint key (e.g., a Skyhook literally named `runtime-required` in a cluster where the runtime-required taint uses that string).
+**Unlikely, operational.** During CR-delete cleanup (`HandleFinalizer` Phase 3), `CleanupSCRMetadata` removes any `skyhook.nvidia.com/*` annotation or label whose key ends with `_<skyhookName>`. That suffix-match also catches the `skyhook.nvidia.com/autoTaint_<taintKey>` annotation written by `AutoTaintNewNodes` — **but only if the NodeWright's name exactly equals the taint key's value**. In practice both sides are user-chosen strings; a collision requires a NodeWright named to match a taint key (e.g., a NodeWright literally named `runtime-required` in a cluster where the runtime-required taint uses that string).
 
-**Impact if it happens.** The `autoTaint_*` annotation is removed when the Skyhook is deleted, losing the audit trail of which nodes were auto-tainted. The taint itself is a separate concern (managed by `HandleAutoTaint`) and is not affected. In real clusters this is almost never reachable because Skyhook names tend to be descriptive (`gpu-drivers`, `kernel-tune`) while taint keys tend to be namespaced (`nvidia.com/gpu`, `skyhook.nvidia.com`).
+**Impact if it happens.** The `autoTaint_*` annotation is removed when the NodeWright is deleted, losing the audit trail of which nodes were auto-tainted. The taint itself is a separate concern (managed by `HandleAutoTaint`) and is not affected. In real clusters this is almost never reachable because NodeWright names tend to be descriptive (`gpu-drivers`, `kernel-tune`) while taint keys tend to be namespaced (`nvidia.com/gpu`, `skyhook.nvidia.com`).
 
-**Avoidance.** Don't name Skyhooks to exactly match a taint key in use. If you have a clash, either rename the Skyhook or disable `AutoTaintNewNodes` on it before deletion.
+**Avoidance.** Don't name NodeWrights to exactly match a taint key in use. If you have a clash, either rename the NodeWright or disable `AutoTaintNewNodes` on it before deletion.
 
 **Long-term fix.** Replace the suffix match in `CleanupSCRMetadata` with an explicit list of cleanup keys (`status_`, `nodeState_`, `cordon_`, `version_`) so unrelated keys with a coincidentally-matching suffix are never touched.
 
-### Force-deleting a Skyhook mid-uninstall and recreating it can run a stray apply pod
+### Force-deleting a NodeWright mid-uninstall and recreating it can run a stray apply pod
 
-**Rare; requires `kubectl delete --force --grace-period=0` on a Skyhook with an active uninstall pod.** Under normal deletion the finalizer holds the CR until the uninstall pod completes, so this path isn't reachable. Force-delete bypasses the finalizer.
+**Rare; requires `kubectl delete --force --grace-period=0` on a NodeWright with an active uninstall pod.** Under normal deletion the finalizer holds the CR until the uninstall pod completes, so this path isn't reachable. Force-delete bypasses the finalizer.
 
-**Symptom.** After force-deleting a Skyhook whose uninstall pod was mid-run, then recreating a Skyhook with the same name and `uninstall.apply: true`, one of the affected nodes briefly runs an **apply** pod for the package before the controller transitions it back to uninstall. The end state is correct (the package eventually uninstalls), but operators see one unexpected install cycle.
+**Symptom.** After force-deleting a NodeWright whose uninstall pod was mid-run, then recreating a NodeWright with the same name and `uninstall.apply: true`, one of the affected nodes briefly runs an **apply** pod for the package before the controller transitions it back to uninstall. The end state is correct (the package eventually uninstalls), but operators see one unexpected install cycle.
 
-**Why.** When the uninstall pod completes, `HandleCompletePod` looks up the parent Skyhook via `dal.GetSkyhook`; if the CR is gone, it returns `(nil, nil)` and the function exits without writing the usual "remove state" or "advance to `uninstall-interrupt`" outcome. The caller `UpdateNodeState` then falls through to its default `Upsert(state=Complete, stage=packagePtr.Stage)` — persisting `stage: uninstall` / `state: complete` on the node annotation. Recreating the Skyhook surfaces that orphaned annotation. `HandleUninstallRequests`'s `StageUninstall` branch re-adds the package to `toUninstall` regardless of state. `ApplyPackage` then reads `packageStatus.Stage = uninstall` and calls `NextStage`, which (for a no-interrupt package at `state: complete`) maps `uninstall → apply` per `NodeState.NextStage` — so an apply pod is created. The apply pod completes, the node moves to `stage: apply` / `state: complete`, the next reconcile takes the install-cycle branch in `HandleUninstallRequests`, and Upserts the package back to `stage: uninstall` / `state: in_progress`. Self-corrects within one extra apply cycle.
+**Why.** When the uninstall pod completes, `HandleCompletePod` looks up the parent NodeWright via `dal.GetSkyhook`; if the CR is gone, it returns `(nil, nil)` and the function exits without writing the usual "remove state" or "advance to `uninstall-interrupt`" outcome. The caller `UpdateNodeState` then falls through to its default `Upsert(state=Complete, stage=packagePtr.Stage)` — persisting `stage: uninstall` / `state: complete` on the node annotation. Recreating the NodeWright surfaces that orphaned annotation. `HandleUninstallRequests`'s `StageUninstall` branch re-adds the package to `toUninstall` regardless of state. `ApplyPackage` then reads `packageStatus.Stage = uninstall` and calls `NextStage`, which (for a no-interrupt package at `state: complete`) maps `uninstall → apply` per `NodeState.NextStage` — so an apply pod is created. The apply pod completes, the node moves to `stage: apply` / `state: complete`, the next reconcile takes the install-cycle branch in `HandleUninstallRequests`, and Upserts the package back to `stage: uninstall` / `state: in_progress`. Self-corrects within one extra apply cycle.
 
 **How to confirm.** After the force-delete + recreate, look for the orphaned terminal-uninstall entry **before** the controller has had time to re-trigger:
 
@@ -370,8 +370,8 @@ kubectl get nodes -l <selector> -o json \
 
 Any rows are nodes the controller will run an unwanted apply pod on before retriggering uninstall.
 
-**Avoidance.** Don't `--force --grace-period=0` a Skyhook with active uninstall pods. Let the finalizer drive uninstall to completion, or use the documented workarounds for blocked-finalizer cases (`kubectl skyhook reset`, then plain `kubectl delete`).
+**Avoidance.** Don't `--force --grace-period=0` a NodeWright with active uninstall pods. Let the finalizer drive uninstall to completion, or use the documented workarounds for blocked-finalizer cases (`kubectl skyhook reset`, then plain `kubectl delete`).
 
-**Workaround if already in this state.** Before recreating the Skyhook, run `kubectl skyhook reset <skyhook-name> --node <node-name> --confirm` on each affected node to clear the orphaned annotation. Then recreate the Skyhook normally — the install pipeline engages cleanly with no spurious apply pod.
+**Workaround if already in this state.** Before recreating the NodeWright, run `kubectl skyhook reset <skyhook-name> --node <node-name> --confirm` on each affected node to clear the orphaned annotation. Then recreate the NodeWright normally — the install pipeline engages cleanly with no spurious apply pod.
 
 **Long-term fix.** In `HandleUninstallRequests`, special-case `stage: uninstall` / `state: complete`: call `RemoveState` (mirroring the existing `uninstall-interrupt / complete` branch) and skip the `toUninstall` append. The current "re-add defensively" comment predates the realisation that `NextStage` re-maps `uninstall → apply` for completed packages without an interrupt; the safe handling is to treat a completed uninstall as terminal-uninstalled per D2.


### PR DESCRIPTION
## What

Continues the Skyhook→NodeWright rename into the operator **topic docs**, updating the product/concept noun in prose. Five files, pure word swaps (68/68):

- `docs/uninstall.md`
- `docs/runtime_required.md`
- `docs/resource_management.md`
- `docs/operator-status-definitions.md`
- `docs/kubernetes-support.md`

## How it stays safe

Unlike the test READMEs, these docs are dense with **live commands** where `skyhook` is a frozen literal — the `-n skyhook` namespace, `kubectl get/delete/patch skyhook`, the `skyhook.nvidia.com/*` group / annotations / finalizer, `SKYHOOK_*` env vars, and YAML examples. Every one of those lives inside a backtick code span or a fenced code block.

So the swap runs **only in prose** — it skips fenced code blocks and inline-code spans entirely. That mechanically preserves every command, namespace, annotation key, finalizer, env var, YAML example, and Go identifier (`CleanupSCRMetadata`, `processSkyhooksPerNode`). Verified post-swap: zero `-n nodewright`, zero `nodewright.nvidia.com`, zero `NODEWRIGHT_`, no broken doc links, no shifted-heading anchors referenced elsewhere.

## SCR → CR

`SCR` ("Skyhook Custom Resource") no longer expands sensibly, so these docs now use plain `CR`. The `CleanupSCRMetadata` Go function name is left intact (word-boundary replace). Note `SCR` is still used elsewhere in the repo (code comments, other docs) — a broader `SCR`→`CR` sweep is a separate follow-up.

## Deliberately out of scope

- `docs/nodewright-migration.md` — intentionally discusses both names.
- `docs/cli.md`, `docs/metrics/README.md` — have version-matrix / metric-name nuance; deferred to focused follow-ups.
- Frozen surfaces everywhere (namespace, agent image/package, CRD group + kind, chart/config CRD+RBAC, metric names, examples).