### PR TITLE
docs: rename Skyhook to NodeWright in remaining docs + chart README

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -1,12 +1,12 @@
-# Skyhook Helm Chart
+# NodeWright Helm Chart
 
-Skyhook was developed for modifying the underlying host OS in Kubernetes clusters. Think of it as a package manager like apt/yum for linux but for whole cluster management. The package manager (Skyhook Operator) manages the lifecycle (install/configure/uninstall/upgrade) of the packages (Skyhook Custom Resource, often SCR for short). It is Kubernetes aware, making cluster modifications easy. This enables Skyhook to schedule updates around important workloads and do rolling updates. It can be used in any cluster environment: self-managed clusters, on-prem clusters, cloud clusters, etc. 
+NodeWright was developed for modifying the underlying host OS in Kubernetes clusters. Think of it as a package manager like apt/yum for linux but for whole cluster management. The package manager (NodeWright Operator) manages the lifecycle (install/configure/uninstall/upgrade) of the packages (NodeWright Custom Resource, often CR for short). It is Kubernetes aware, making cluster modifications easy. This enables NodeWright to schedule updates around important workloads and do rolling updates. It can be used in any cluster environment: self-managed clusters, on-prem clusters, cloud clusters, etc. 
 
 ## Benefits
 
  - The requested changes (the Packages) are native Kubernetes resources they can be combined and applied with common tools like ArgoCD, Helm, Flux etc. This means that all the tooling to manage applications can package customizations right alongside them to get applied, removed and upgraded as the applications themselves are.
- - Autoscaling, with skyhook if you want to enable autoscaling on your cluster but need to modify all Nodes added to a cluster, you need something that is kubernetes aware. Skyhook as feature to make sure you nodes are ready before then enter the cluster.
- - Upgrades are first class, with skyhook you can make deploy changes to your cluster and can wait for running workloads to finish before applying changes.
+ - Autoscaling: with NodeWright, if you want to enable autoscaling on your cluster but need to modify all Nodes added to a cluster, you need something that is Kubernetes-aware. NodeWright has a feature to make sure your nodes are ready before they enter the cluster.
+ - Upgrades are first class: with NodeWright you can make deploy changes to your cluster and can wait for running workloads to finish before applying changes.
 
 ## Key Features
 
@@ -33,7 +33,7 @@ Settings | Description | Default |
 | controllerManager.manager.env.leaderElection | Enable leader election for the operator controller. Default is "true" and is required for production. | "true" |
 | controllerManager.manager.env.logLevel | Log level for the operator controller. If you want more or less logs, change this value to "debug" or "error". | "info" |
 | controllerManager.manager.env.reapplyOnReboot | Reapply the packages on reboot. This is useful for systems that are read-only. | "false" |
-| controllerManager.manager.env.runtimeRequiredTaint | This feature assumes nodes are added to the cluster with `--register-with-taints` kubelet flag. This taint is assume to be all new nodes, and skyhook pods will tolerate this taint, and remove it one the nodes packages are complete. | skyhook.nvidia.com=runtime-required:NoSchedule | 
+| controllerManager.manager.env.runtimeRequiredTaint | This feature assumes nodes are added to the cluster with `--register-with-taints` kubelet flag. This taint is assumed to be on all new nodes; NodeWright pods tolerate it, and the operator removes it from a node once every `runtimeRequired: true` NodeWright targeting that node has completed on it (completion on other nodes does not affect removal). | skyhook.nvidia.com=runtime-required:NoSchedule | 
 | controllerManager.manager.image.repository | Where to get the image from | "ghcr.io/nvidia/nodewright/operator" |
 | controllerManager.manager.image.tag | what version of the operator to run | defaults to appVersion |
 | controllerManager.manager.image.digest | content-addressable pin for the operator image. If set, the digest determines the pulled image. If both tag and digest are provided, the digest takes precedence; the rendered image may include `tag@digest` but the digest controls selection. | "" |
@@ -44,11 +44,11 @@ Settings | Description | Default |
 | useHostNetwork | run the operator pods with `hostNetwork: true`. Required in environments where the apiserver is only reachable on the host network. | false |
 | estimatedPackageCount | estimated number of packages to be installed on the cluster, this is used to calculate the resources for the operator controller. | 1 |
 | estimatedNodeCount | estimated number of nodes in the cluster, this is used to calculate the resources for the operator controller | 1 |
-| rbac.createSkyhookViewerRole | create a `ClusterRole` that grants read-only access to Skyhook and DeploymentPolicy resources. Aggregate-bind to your own users/groups. | false |
-| rbac.createSkyhookEditorRole | create a `ClusterRole` that grants read/write access to Skyhook and DeploymentPolicy resources. Aggregate-bind to your own users/groups. | false |
+| rbac.createSkyhookViewerRole | create a `ClusterRole` that grants read-only access to NodeWright and DeploymentPolicy resources. Aggregate-bind to your own users/groups. | false |
+| rbac.createSkyhookEditorRole | create a `ClusterRole` that grants read/write access to NodeWright and DeploymentPolicy resources. Aggregate-bind to your own users/groups. | false |
 | limitRange.default | namespace-wide default CPU/memory **limits** applied to every container that doesn't set its own. Set both `default` and `defaultRequest` (or omit `limitRange` entirely to disable). See [../docs/resource_management.md](../docs/resource_management.md). | cpu: 500m, memory: 512Mi |
 | limitRange.defaultRequest | namespace-wide default CPU/memory **requests** applied to every container that doesn't set its own. | cpu: 250m, memory: 256Mi |
-| cleanup.enabled | Automatically delete all Skyhook and DeploymentPolicy resources during helm uninstall. Recommended to prevent orphaned CRs. | true |
+| cleanup.enabled | Automatically delete all NodeWright and DeploymentPolicy resources during helm uninstall. Recommended to prevent orphaned CRs. | true |
 | cleanup.jobTimeoutSeconds | Hard deadline for the entire cleanup job during uninstall. The job will be killed if it exceeds this time. | 120 |
 
 ### NOTES
@@ -76,7 +76,7 @@ If you use public images (default operator `ghcr.io/nvidia/nodewright/operator` 
 
 ### Resource Management
 
-Skyhook uses Kubernetes LimitRange to set default CPU/memory requests/limits for all containers in the namespace. You can override these per-package in your Skyhook CR. Strict validation is enforced. See [../docs/resource_management.md](../docs/resource_management.md) for details and examples.
+NodeWright uses Kubernetes LimitRange to set default CPU/memory requests/limits for all containers in the namespace. You can override these per-package in your NodeWright CR. Strict validation is enforced. See [../docs/resource_management.md](../docs/resource_management.md) for details and examples.
 
 ## Versioning
 
@@ -91,7 +91,7 @@ This Helm chart follows independent versioning from the operator and agent compo
 
 ### Automatic Cleanup (Default Behavior)
 
-By default, the Helm chart includes a pre-delete hook that automatically cleans up all Skyhook and DeploymentPolicy custom resources before uninstalling. This prevents orphaned resources that could cause issues during reinstallation.
+By default, the Helm chart includes a pre-delete hook that automatically cleans up all NodeWright and DeploymentPolicy custom resources before uninstalling. This prevents orphaned resources that could cause issues during reinstallation.
 
 ```bash
 # Uninstall with automatic cleanup (default)
@@ -100,14 +100,14 @@ helm uninstall nodewright --namespace skyhook
 
 The pre-delete hook will:
 
-- Delete all Skyhook resources cluster-wide
+- Delete all NodeWright resources cluster-wide
 - Delete all DeploymentPolicy resources cluster-wide
 - Wait for finalizers to be processed
 - Proceed with uninstall even if cleanup times out (job deadline: 2 minutes, configurable via `cleanup.jobTimeoutSeconds`)
 
 ### Disabling Automatic Cleanup
 
-If you need to preserve Skyhook resources during uninstall (e.g., for backup/migration scenarios), disable the cleanup feature:
+If you need to preserve NodeWright resources during uninstall (e.g., for backup/migration scenarios), disable the cleanup feature:
 
 ```yaml
 # values.yaml

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,34 +1,34 @@
-# Skyhook Documentation
+# NodeWright Documentation
 
-This directory contains user and operator documentation for Skyhook. Here you'll find guides, examples, and reference material to help you deploy, configure, and secure Skyhook in your Kubernetes cluster.
+This directory contains user and operator documentation for NodeWright. Here you'll find guides, examples, and reference material to help you deploy, configure, and secure NodeWright in your Kubernetes cluster.
 
 ## Available Documentation
 
 - [Kyverno Policy Examples](kyverno/README.md):
-  Example Kyverno policies for restricting images or packages in Skyhook resources.
+  Example Kyverno policies for restricting images or packages in NodeWright resources.
 
 - **Features**
   - [Providing Secrets to Packages](providing_secrets_to_packages.md):
-    How to securely provide secrets to Skyhook-managed packages.
+    How to securely provide secrets to NodeWright-managed packages.
 
   - [Runtime Required](runtime_required.md):
-    How to use the runtime required taint and feature in Skyhook.
+    How to use the runtime required taint and feature in NodeWright.
 
   - [Interrupt Flow and Ordering](interrupt_flow.md):
-    Detailed explanation of how Skyhook handles packages with interrupts, including the interrupt sequence.
+    Detailed explanation of how NodeWright handles packages with interrupts, including the interrupt sequence.
 
-  - [Strict Ordering](ordering_of_skyhooks.md): How and why the operator applies each Skyhook Custom Resource in a deterministic sequential order.
+  - [Strict Ordering](ordering_of_skyhooks.md): How and why the operator applies each NodeWright Custom Resource in a deterministic sequential order.
 
   - [Deployment Policy and Compartments](deployment_policy.md): 
     Fine-grained rollout control with compartments, budgets, and strategies. Includes overlap resolution, safety mechanisms, and migration from interruptionBudget.
 
 - **Resources**
   - [Resource Management](resource_management.md):
-  How Skyhook manages CPU/memory resources using LimitRange, per-package overrides, and validation rules.
+  How NodeWright manages CPU/memory resources using LimitRange, per-package overrides, and validation rules.
 
-  - [Operator Resources At Scale](operator_resources_at_scale.md): Considerations for how cpu and memory have to change for the Operator pods as cluster nodes and skyhook packages change.
+  - [Operator Resources At Scale](operator_resources_at_scale.md): Considerations for how cpu and memory have to change for the Operator pods as cluster nodes and nodewright packages change.
 
-  - [Operator Status Definitions](operator-status-definitions.md): Definitions of Status, State, Stage, and Condition concepts used throughout the Skyhook operator.
+  - [Operator Status Definitions](operator-status-definitions.md): Definitions of Status, State, Stage, and Condition concepts used throughout the NodeWright operator.
 
   - [Webhook Bootstrap Lease](designs/webhook-bootstrap-lease.md): Why the admission-webhook cert bootstrap runs on a dedicated leader-election lease, and the runbook for upgrading from v0.7.x (where the new lease does not yet exist).
 
@@ -37,6 +37,6 @@ This directory contains user and operator documentation for Skyhook. Here you'll
       Developer workflow notes, including local kind clusters and Kubernetes test version ownership.
 
   - [Releases](releases.md):
-      Release notes and upgrade information for Skyhook.
+      Release notes and upgrade information for NodeWright.
 
   - [CI test pools](ci-test-pools.md) — how the chainsaw e2e suite is partitioned across parallel CI jobs.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -130,7 +130,7 @@ kubectl nodewright version --timeout 10s
 
 ### Pause/Resume Commands
 
-Control Skyhook processing state.
+Control NodeWright processing state.
 
 > **Note:** Requires operator v0.8.0+. See [Compatibility](#compatibility) for details.
 
@@ -145,7 +145,7 @@ kubectl nodewright resume my-skyhook
 
 ### Disable/Enable Commands
 
-Completely disable or re-enable a Skyhook.
+Completely disable or re-enable a NodeWright.
 
 > **Note:** Requires operator v0.8.0+. See [Compatibility](#compatibility) for details.
 
@@ -160,7 +160,7 @@ kubectl nodewright enable my-skyhook
 
 ### Reset Command
 
-Reset all package state for a Skyhook, causing re-execution from the beginning.
+Reset all package state for a NodeWright, causing re-execution from the beginning.
 
 ```bash
 # Reset all nodes for a Skyhook (also resets batch state by default)
@@ -216,7 +216,7 @@ prompts.
 kubectl nodewright update-state <skyhook-name> <package> <version> <stage> <state>
 ```
 
-> **⚠️ Pause the Skyhook before running `update-state`.**
+> **⚠️ Pause the NodeWright before running `update-state`.**
 >
 > `update-state` performs a read-modify-write on the node-state annotation and
 > uses a merge patch with no resource-version check. The patch rewrites the
@@ -225,7 +225,7 @@ kubectl nodewright update-state <skyhook-name> <package> <version> <stage> <stat
 > same annotation will also be clobbered. If the operator reconciles the
 > node between the CLI's read and write, the operator can immediately
 > overwrite the manual edit — at best wasting the operation, at worst racing
-> the operator into an inconsistent state. Always pause the Skyhook
+> the operator into an inconsistent state. Always pause the NodeWright
 > (`kubectl nodewright pause <name> --confirm`) before running this command,
 > and resume only when finished.
 >
@@ -259,8 +259,8 @@ The global `--dry-run` flag is honored: the command prints the set of nodes
 it would patch and exits without writing.
 
 By default `update-state` targets only nodes that already have a `nodeState`
-entry for the named Skyhook. If `--node` names a node that does not exist
-or has no state for the Skyhook, the command warns and skips that node
+entry for the named NodeWright. If `--node` names a node that does not exist
+or has no state for the NodeWright, the command warns and skips that node
 rather than failing.
 
 #### `--add`
@@ -272,7 +272,7 @@ manually deleted.
 
 `--add` **requires** either `--node` or `--selector` so the scope of the
 creation is explicit. Without one of these flags, `--add` would apply to
-every node in the cluster that matches the Skyhook's selector, which is
+every node in the cluster that matches the NodeWright's selector, which is
 far too broad for a creation operation — the CLI rejects this combination
 with an error.
 
@@ -317,7 +317,7 @@ kubectl nodewright deployment-policy reset gpu-init --dry-run
 kubectl nodewright dp reset gpu-init --confirm
 ```
 
-The `deployment-policy reset` command resets the batch processing state for all compartments in the specified Skyhook, including:
+The `deployment-policy reset` command resets the batch processing state for all compartments in the specified NodeWright, including:
 
 - Current batch number (reset to 1)
 - Consecutive failure count
@@ -339,7 +339,7 @@ See [Deployment Policy documentation](deployment_policy.md) for details on auto-
 
 ### Node Commands
 
-Manage Skyhook nodes across the cluster.
+Manage NodeWright nodes across the cluster.
 
 ```bash
 # List all nodes targeted by a Skyhook
@@ -373,7 +373,7 @@ kubectl nodewright node unignore worker-1
 
 ### Package Commands
 
-Manage Skyhook packages.
+Manage NodeWright packages.
 
 ```bash
 # Query package status across nodes
@@ -484,7 +484,7 @@ kubectl nodewright reset my-skyhook --skip-batch-reset --confirm
 ### Surgical Recovery
 
 When a single package on a single node is wedged and a full reset is too
-disruptive, pause the Skyhook, edit the recorded state directly, then
+disruptive, pause the NodeWright, edit the recorded state directly, then
 resume:
 
 ```bash

--- a/docs/designs/webhook-bootstrap-lease.md
+++ b/docs/designs/webhook-bootstrap-lease.md
@@ -26,12 +26,12 @@ can enter the following dead state:
 4. Meanwhile, Argo/Helm applying the new manifests has reset the
    `MutatingWebhookConfiguration` `caBundle` to empty, so the apiserver no
    longer trusts the v0.7.x pods either. With `failurePolicy: Fail`, all
-   CREATE/UPDATE on Skyhook CRs fail with
+   CREATE/UPDATE on NodeWright CRs fail with
    `x509: certificate signed by unknown authority`.
 
 Net result: the new pod waits forever for a secret that requires leadership to
 create, the old pod holds leadership forever because the new pod never goes
-Ready, and Argo cannot reconcile any further Skyhook config changes.
+Ready, and Argo cannot reconcile any further NodeWright config changes.
 
 The only field operations that broke the cycle were manual:
 

--- a/docs/kyverno/README.md
+++ b/docs/kyverno/README.md
@@ -1,13 +1,13 @@
-# Kyverno Policy Examples for Skyhook
+# Kyverno Policy Examples for NodeWright
 
-This directory contains example [Kyverno](https://kyverno.io/) policies for use with Skyhook. These are **not installed by default** and are provided as templates for users to adapt to their own security needs.
+This directory contains example [Kyverno](https://kyverno.io/) policies for use with NodeWright. These are **not installed by default** and are provided as templates for users to adapt to their own security needs.
 
-- `disable_packages.yaml`: Example policy to restrict or disable certain Skyhook packages/images.
-- `skyhook-viewer-binding.yaml`: Example RBAC binding for Kyverno to view Skyhook resources.
+- `disable_packages.yaml`: Example policy to restrict or disable certain NodeWright packages/images.
+- `skyhook-viewer-binding.yaml`: Example RBAC binding for Kyverno to view NodeWright resources.
 
 **Note:**
 
 - This directory was previously at the repo root and has been moved to `docs/kyverno/` for clarity.
 - If you use these policies, ensure you enable the `skyhook-viewer-role` in your Helm values and bind Kyverno to that role.
 
-See the main [README](../README.md) for more information about Skyhook. 
+See the main [README](../README.md) for more information about NodeWright. 

--- a/docs/metrics/README.md
+++ b/docs/metrics/README.md
@@ -1,35 +1,35 @@
 # Metrics
 
-The current metrics supplied by the Operator are intended to be sufficient to determine the state of application of a Skyhook Custom Resource within a cluster. These metrics are defined at [internal/controller/metrics.go](../../operator/internal/controller/metrics.go).
+The current metrics supplied by the Operator are intended to be sufficient to determine the state of application of a NodeWright Custom Resource within a cluster. These metrics are defined at [internal/controller/metrics.go](../../operator/internal/controller/metrics.go).
 
-## Skyhook Status Metrics
+## NodeWright Status Metrics
 
- * `skyhook_status` : Binary metric indicating the status of the Skyhook Custom Resource (1 if in that status, 0 otherwise). Tags:
-    * `skyhook_name` : The name of the Skyhook Custom Resource
+ * `skyhook_status` : Binary metric indicating the status of the NodeWright Custom Resource (1 if in that status, 0 otherwise). Tags:
+    * `skyhook_name` : The name of the NodeWright Custom Resource
     * `status` : One of complete, disabled, paused
 
 ## Node Metrics
 
- * `skyhook_node_status_count` : Number of nodes in the cluster by status for the Skyhook Custom Resource. Tags:
-    * `skyhook_name` : The name of the Skyhook Custom Resource
+ * `skyhook_node_status_count` : Number of nodes in the cluster by status for the NodeWright Custom Resource. Tags:
+    * `skyhook_name` : The name of the NodeWright Custom Resource
     * `status` : One of complete, in_progress, erroring, blocked, waiting
- * `skyhook_node_target_count` : Total number of nodes targeted by this Skyhook Custom Resource. Tags:
-    * `skyhook_name` : The name of the Skyhook Custom Resource
+ * `skyhook_node_target_count` : Total number of nodes targeted by this NodeWright Custom Resource. Tags:
+    * `skyhook_name` : The name of the NodeWright Custom Resource
 
 ## Package Metrics
 
  * `skyhook_package_state_count` : Number of nodes in the cluster by state for this package. Tags:
-    * `skyhook_name` : The name of the SCR the package belongs to
+    * `skyhook_name` : The name of the CR the package belongs to
     * `package_name` : The name of the package
     * `package_version`: The version of the package
     * `state` : One of complete, in_progress, skipped, erroring, unknown
  * `skyhook_package_stage_count` : Number of nodes in the cluster by stage for this package. Tags:
-    * `skyhook_name` : The name of the SCR the package belongs to
+    * `skyhook_name` : The name of the CR the package belongs to
     * `package_name` : The name of the package
     * `package_version`: The version of the package
     * `stage` : One of apply, config, interrupt, post_interrupt, uninstall, upgrade
  * `skyhook_package_restarts_count`: Number of restarts for this package on this node. Tags:
-    * `skyhook_name` : The name of the SCR the package belongs to
+    * `skyhook_name` : The name of the CR the package belongs to
     * `package_name` : The name of the package
     * `package_version`: The version of the package
 
@@ -38,47 +38,47 @@ The current metrics supplied by the Operator are intended to be sufficient to de
 These metrics track the rollout progress and health of compartments defined in a DeploymentPolicy. See [Deployment Policy documentation](../deployment_policy.md) for details on compartments and strategies.
 
  * `skyhook_rollout_matched_nodes` : Number of nodes matched by this compartment's selector. Tags:
-    * `skyhook_name` : The name of the Skyhook Custom Resource
+    * `skyhook_name` : The name of the NodeWright Custom Resource
     * `policy_name` : The name of the DeploymentPolicy (or "legacy" if using interruptionBudget)
     * `compartment_name` : The name of the compartment (or "__default__" for unmatched nodes)
     * `strategy` : The rollout strategy type (fixed, linear, exponential, or unknown)
  * `skyhook_rollout_ceiling` : Maximum number of nodes that can be in progress at once in this compartment. Tags:
-    * `skyhook_name` : The name of the Skyhook Custom Resource
+    * `skyhook_name` : The name of the NodeWright Custom Resource
     * `policy_name` : The name of the DeploymentPolicy
     * `compartment_name` : The name of the compartment
     * `strategy` : The rollout strategy type
  * `skyhook_rollout_in_progress` : Number of nodes currently in progress in this compartment. Tags:
-    * `skyhook_name` : The name of the Skyhook Custom Resource
+    * `skyhook_name` : The name of the NodeWright Custom Resource
     * `policy_name` : The name of the DeploymentPolicy
     * `compartment_name` : The name of the compartment
     * `strategy` : The rollout strategy type
  * `skyhook_rollout_completed` : Number of nodes completed in this compartment. Tags:
-    * `skyhook_name` : The name of the Skyhook Custom Resource
+    * `skyhook_name` : The name of the NodeWright Custom Resource
     * `policy_name` : The name of the DeploymentPolicy
     * `compartment_name` : The name of the compartment
     * `strategy` : The rollout strategy type
  * `skyhook_rollout_progress_percent` : Percentage of nodes completed in this compartment (0-100). Tags:
-    * `skyhook_name` : The name of the Skyhook Custom Resource
+    * `skyhook_name` : The name of the NodeWright Custom Resource
     * `policy_name` : The name of the DeploymentPolicy
     * `compartment_name` : The name of the compartment
     * `strategy` : The rollout strategy type
  * `skyhook_rollout_current_batch` : Current batch number in the rollout strategy (0 if no batch processing). Tags:
-    * `skyhook_name` : The name of the Skyhook Custom Resource
+    * `skyhook_name` : The name of the NodeWright Custom Resource
     * `policy_name` : The name of the DeploymentPolicy
     * `compartment_name` : The name of the compartment
     * `strategy` : The rollout strategy type
  * `skyhook_rollout_consecutive_failures` : Number of consecutive batch failures in this compartment. Tags:
-    * `skyhook_name` : The name of the Skyhook Custom Resource
+    * `skyhook_name` : The name of the NodeWright Custom Resource
     * `policy_name` : The name of the DeploymentPolicy
     * `compartment_name` : The name of the compartment
     * `strategy` : The rollout strategy type
  * `skyhook_rollout_should_stop` : Binary metric indicating if rollout should be stopped due to failures (1 = stopped, 0 = continuing). Tags:
-    * `skyhook_name` : The name of the Skyhook Custom Resource
+    * `skyhook_name` : The name of the NodeWright Custom Resource
     * `policy_name` : The name of the DeploymentPolicy
     * `compartment_name` : The name of the compartment
     * `strategy` : The rollout strategy type
 
-Note: When a Skyhook is deleted all metrics for that Skyhook are no longer reported.
+Note: When a NodeWright is deleted all metrics for that NodeWright are no longer reported.
 
 ## Testing
 
@@ -97,16 +97,16 @@ The makefile provides the `metrics` command which will install prometheus and gr
 
 ## Dashboard
 
-A comprehensive Grafana dashboard is provided at [dashboards/skyhook-dashboard.json](dashboards/skyhook-dashboard.json) that consolidates all Skyhook monitoring into a single dashboard with a unified view that includes:
+A comprehensive Grafana dashboard is provided at [dashboards/skyhook-dashboard.json](dashboards/skyhook-dashboard.json) that consolidates all NodeWright monitoring into a single dashboard with a unified view that includes:
 
-### Skyhook Overview Section
+### NodeWright Overview Section
 
-* Total Skyhooks count
-* Skyhook status distribution (Complete, In Progress, Erroring, Blocked, Other States)
-* Skyhook status trends over time
-* Detailed Skyhook status table
+* Total NodeWrights count
+* NodeWright status distribution (Complete, In Progress, Erroring, Blocked, Other States)
+* NodeWright status trends over time
+* Detailed NodeWright status table
 
-![Skyhook Overview Example](images/skyhook-overview.png "Skyhook Overview Example")
+![NodeWright Overview Example](images/skyhook-overview.png "NodeWright Overview Example")
 
 ### Node Monitoring Section
 
@@ -171,7 +171,7 @@ make grafana-password
 
 ### Scrape directly
 
-Use the file [prometheus_values.yaml](prometheus_values.yaml) as an example of configuring a scraper job for Skyhook. Note: This can be used directly with the prometheus community chart:
+Use the file [prometheus_values.yaml](prometheus_values.yaml) as an example of configuring a scraper job for NodeWright. Note: This can be used directly with the prometheus community chart:
 ```bash
 helm install prometheus prometheus-community/prometheus -f ../docs/metrics/prometheus_values.yaml
 ```

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -1,6 +1,6 @@
-# Skyhook Release Process
+# NodeWright Release Process
 
-Step-by-step process for releasing Skyhook components using **release branches**.
+Step-by-step process for releasing NodeWright components using **release branches**.
 
 ## Release Branch Strategy
 
@@ -464,7 +464,7 @@ git push origin :refs/tags/operator/v1.2.3
 
 ## Third-Party Notices
 
-Skyhook ships `THIRD_PARTY_NOTICES.md` files that list every third-party module shipped in its released artifacts, along with verbatim license text. Three files are maintained:
+NodeWright ships `THIRD_PARTY_NOTICES.md` files that list every third-party module shipped in its released artifacts, along with verbatim license text. Three files are maintained:
 
 | File | Covers | Tool |
 | --- | --- | --- |

--- a/docs/resource_management.md
+++ b/docs/resource_management.md
@@ -1,6 +1,6 @@
 # Resource Management in NodeWright
 
-NodeWright provides flexible and robust resource management for the pods it creates, allowing you to control CPU and memory usage at both the namespace and per-package level. This document explains how resource defaults and overrides work, and what validation rules are enforced.
+NodeWright provides flexible resource management for the pods it creates: it uses a namespace LimitRange for defaults when one is present (the chart installs one by default, which you can disable) and allows per-package overrides. This document explains how resource defaults and overrides work, and what validation rules are enforced.
 
 ---
 

--- a/docs/runtime_required.md
+++ b/docs/runtime_required.md
@@ -49,10 +49,10 @@ A node is considered "new" if it has no NodeWright annotations. This works for b
 
 The taint is removed from a node when all CRs with `runtimeRequired: true` that target that node are complete **on that specific node**.
 
-**Important**: Taint removal is per-node, not per-skyhook. This means:
+**Important**: Taint removal is per-node, not per-NodeWright. This means:
 
-- Node A's taint is removed when all runtime-required nodewrights complete on Node A
-- Node A does NOT wait for Node B to complete those same nodewrights
+- Node A's taint is removed when all runtime-required NodeWrights complete on Node A
+- Node A does NOT wait for Node B to complete those same NodeWrights
 - If Node B is stuck or failing, Node A can still have its taint removed and become available
 
 This per-node behavior prevents deadlocks where a few bad nodes would block all other healthy nodes from becoming available.
@@ -65,4 +65,4 @@ This per-node behavior prevents deadlocks where a few bad nodes would block all 
 
 This is useful when you want to gate other work behind the successful completion of some set of NodeWright Packages. This can be for security reasons or for scheduling.
 
-**NOTE:** No additional toleration is required, nodewright auto tolerates this (env:`runtimeRequiredTaint`) taint.
+**NOTE:** No additional toleration is required; NodeWright automatically tolerates this (`runtimeRequiredTaint`) taint.

--- a/docs/uninstall.md
+++ b/docs/uninstall.md
@@ -85,7 +85,7 @@ Cancellation semantics depend on which stage the node is at when `apply` is flip
 
 When a NodeWright CR is deleted (`kubectl delete skyhook my-skyhook`):
 
-- **`enabled: true` packages**: The finalizer triggers uninstall pods, waits for completion on all nodes, then cleans up (uncordon nodes, remove CR labels/annotations, remove finalizer).
+- **`enabled: true` packages**: The finalizer triggers uninstall pods, waits for completion on all nodes, then removes this NodeWright's own cordon ownership and metadata. A node is uncordoned only once no `cordon_*` ownership annotations remain (other NodeWrights sharing the node may still hold it); the CR finalizer is removed last.
 - **`enabled: false` packages (or nil)**: No uninstall pods — state is cleaned up immediately. The package state remains on nodes so administrators can see what was previously applied.
 
 #### Deletion edge cases

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -1,8 +1,8 @@
-# Skyhook Versioning Strategy
+# NodeWright Versioning Strategy
 
-Skyhook uses independent versioning for three components, all following [Semantic Versioning](https://semver.org/):
+NodeWright uses independent versioning for three components, all following [Semantic Versioning](https://semver.org/):
 
-1. **Operator** - Kubernetes operator that manages Skyhook resources
+1. **Operator** - Kubernetes operator that manages NodeWright resources
 2. **Agent** - Container that executes package operations on nodes  
 3. **Chart** - Helm chart for deploying the operator
    1. NOTE: the versioning of the chat also includes versioning of the expected agent version. 
@@ -58,7 +58,7 @@ image: "ghcr.io/nvidia/skyhook/operator:0.7.0"
 
 ## Release Branching Strategy
 
-Skyhook uses **release branches** to manage patches and maintenance releases:
+NodeWright uses **release branches** to manage patches and maintenance releases:
 
 ```bash
 release/v0.8.x    # Contains operator v0.8.0 + agent v6.3.0 + chart v0.8.x


### PR DESCRIPTION
## What

Continues the Skyhook→NodeWright prose rename into the **remaining `docs/` files + `chart/README.md`** (8 files, 78/78 word swaps). Follows #369.

## How it stays safe

Same **prose-only** swap as #369: it never touches text inside code fences or inline-code spans, so every frozen literal is preserved by construction. Verified post-swap that none of these were altered:

- **Metric names** — `skyhook_status`, `skyhook_name`, `skyhook_node_status_count`, etc. (only their prose descriptions changed).
- **Namespace** — the `skyhook` namespace, including the CLI's `--namespace` **default `"skyhook"`** (matches `context.DefaultNamespace` in the CLI source).
- **Chart literals** — the `runtime-required` taint, host paths `/var/lib/skyhook` & `/var/log/skyhook`, the `ghcr.io/nvidia/skyhook/agent` image, and the `createSkyhook*Role` values keys.
- **API group / annotations** — `skyhook.nvidia.com/*`.
- **Filenames** — `skyhook-dashboard.json`, `skyhook-overview.png`, `skyhook-viewer-binding.yaml`, `ordering_of_skyhooks.md` links.

## SCR → CR

`SCR` ("Skyhook Custom Resource") no longer expands sensibly, so these files now use plain `CR` (no `CleanupSCRMetadata`-style identifiers exist in this set).

## Notes

- `docs/nodewright-migration.md` (intentionally bilingual) and all frozen surfaces (operator Go source + comments, agent package, chart templates, `operator/config` CRD/RBAC, metric names, examples) remain untouched — those move with the actual code/CRD migration.
- The top-level `README.md` / `ROADMAP` / `CONTRIBUTING` / `SUPPORT` rebrand is deferred pending a product-identity decision.