### PR TITLE
docs: add governance, maintainers, and security policy

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,28 +1,28 @@
 # Global catch-all
-* @lockwobr @mskalka @ayuskauskas @rice-riley
+* @lockwobr @ayuskauskas @rice-riley
 
 # Operator
-operator/          @lockwobr @mskalka @ayuskauskas @rice-riley
+operator/          @lockwobr @ayuskauskas @rice-riley
 
 # Agent
-agent/             @lockwobr @mskalka @ayuskauskas @rice-riley
+agent/             @lockwobr @ayuskauskas @rice-riley
 
 # Helm chart
-chart/             @lockwobr @mskalka @ayuskauskas @rice-riley
+chart/             @lockwobr @ayuskauskas @rice-riley
 
 # Containers
-containers/        @lockwobr @mskalka @ayuskauskas @rice-riley
+containers/        @lockwobr @ayuskauskas @rice-riley
 
 # Documentation
-docs/              @lockwobr @mskalka @ayuskauskas @rice-riley
+docs/              @lockwobr @ayuskauskas @rice-riley
 
 # Examples
-examples/          @lockwobr @mskalka @ayuskauskas @rice-riley
+examples/          @lockwobr @ayuskauskas @rice-riley
 
 # Tests
-k8s-tests/         @lockwobr @mskalka @ayuskauskas @rice-riley
+k8s-tests/         @lockwobr @ayuskauskas @rice-riley
 
 # Build/ops
-.github/           @lockwobr @mskalka @ayuskauskas @rice-riley
-scripts/           @lockwobr @mskalka @ayuskauskas @rice-riley
-Makefile           @lockwobr @mskalka @ayuskauskas @rice-riley
+.github/           @lockwobr @ayuskauskas @rice-riley
+scripts/           @lockwobr @ayuskauskas @rice-riley
+Makefile           @lockwobr @ayuskauskas @rice-riley

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -10,75 +10,84 @@ Community | Developers | Project Leads
 
 ## Our Pledge
 
-In the interest of fostering an open and welcoming environment, we as
-contributors and maintainers pledge to making participation in our project and
-our community a harassment-free experience for everyone, regardless of age, body
-size, disability, ethnicity, sex characteristics, gender identity and expression,
-level of experience, education, socio-economic status, nationality, personal
-appearance, race, religion, or sexual identity and orientation.
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
 
 ## Our Standards
 
-Examples of behavior that contributes to creating a positive environment
-include:
+Examples of behavior that contributes to a positive environment for our community include:
 
-* Using welcoming and inclusive language
-* Being respectful of differing viewpoints and experiences
-* Gracefully accepting constructive criticism
-* Focusing on what is best for the community
-* Showing empathy towards other community members
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
 
-Examples of unacceptable behavior by participants include:
+Examples of unacceptable behavior include:
 
-* The use of sexualized language or imagery and unwelcome sexual attention or
-  advances
-* Trolling, insulting/derogatory comments, and personal or political attacks
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
 * Public or private harassment
-* Publishing others' private information, such as a physical or electronic
-  address, without explicit permission
-* Other conduct which could reasonably be considered inappropriate in a
-  professional setting
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
 
-## Our Responsibilities
+## Enforcement Responsibilities
 
-Project maintainers are responsible for clarifying the standards of acceptable
-behavior and are expected to take appropriate and fair corrective action in
-response to any instances of unacceptable behavior.
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
 
-Project maintainers have the right and responsibility to remove, edit, or
-reject comments, commits, code, wiki edits, issues, and other contributions
-that are not aligned to this Code of Conduct, or to ban temporarily or
-permanently any contributor for other behaviors that they deem inappropriate,
-threatening, offensive, or harmful.
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
 
 ## Scope
 
-This Code of Conduct applies both within project spaces and in public spaces
-when an individual is representing the project or its community. Examples of
-representing a project or community include using an official project e-mail
-address, posting via an official social media account, or acting as an appointed
-representative at an online or offline event. Representation of a project may be
-further defined and clarified by project maintainers.
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting GitHub_Conduct@nvidia.com. All complaints will be reviewed and
-investigated and will result in a response that is deemed necessary and appropriate
-to the circumstances. The project team is obligated to maintain confidentiality with
-regard to the reporter of an incident. Further details of specific enforcement policies
-may be posted separately. 
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at GitHub_Conduct@nvidia.com. All complaints will be reviewed and investigated promptly and fairly.
 
-Project maintainers who do not follow or enforce the Code of Conduct in good
-faith may face temporary or permanent repercussions as determined by other
-members of the project's leadership.
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+The response timeline and what falls outside the scope of a conduct report are documented in [CONTRIBUTING.md](CONTRIBUTING.md#community-standards).
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
-available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
 
 [homepage]: https://www.contributor-covenant.org
-
-For answers to common questions about this code of conduct, see
-https://www.contributor-covenant.org/faq/
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,14 @@
 
 Want to contribute to Skyhook (NodeWright)? We welcome bug reports, feature requests, and pull requests.
 
+## Code of Conduct
+
+This project is governed by the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md). By participating you are expected to uphold it. Report unacceptable behavior to GitHub_Conduct@nvidia.com. See [Community standards](#community-standards) for how reports are handled.
+
+## Governance
+
+Maintainers, decision-making, and the process for becoming a maintainer are documented in [GOVERNANCE.md](GOVERNANCE.md) and [MAINTAINERS.md](MAINTAINERS.md). Path-level review ownership is in [`.github/CODEOWNERS`](.github/CODEOWNERS).
+
 ## Filing Issues
 
 - **Bug reports**: Use the [bug report template](https://github.com/NVIDIA/skyhook/issues/new?template=bug_report_form.yml).
@@ -121,3 +129,28 @@ make license-fmt
 ```
 
 This adds the license header based on the LICENSE file and removes/replaces any existing header. Component Makefiles also run this automatically via `make fmt`.
+
+## Community standards
+
+We enforce the [Code of Conduct](CODE_OF_CONDUCT.md) in every project space: issues, pull requests, discussions, and any venue where someone is representing NodeWright.
+
+### Reporting
+
+Send reports to GitHub_Conduct@nvidia.com. Include what happened, where, when, and links if the incident is public. You do not need to be the target of the behavior to report it.
+
+### Response timeline
+
+- **Acknowledgement within 3 business days.** You get a confirmation that the report was received and who is handling it.
+- **Resolution within 14 business days** for most reports. If an investigation needs longer, we tell you that before day 14 and give an updated estimate.
+- **Immediate action** for ongoing harassment, threats, or doxxing, ahead of the full investigation.
+
+Reporter identity is shared only with the people investigating. Outcomes follow the [Enforcement Guidelines](CODE_OF_CONDUCT.md#enforcement-guidelines) ladder: correction, warning, temporary ban, permanent ban.
+
+### Out of scope
+
+The following are handled elsewhere, not through a conduct report:
+
+- **Security vulnerabilities**: see [SECURITY.md](SECURITY.md). Do not file a public issue.
+- **Technical disagreements**, including rejected pull requests and design decisions you disagree with. Escalate through the process in [GOVERNANCE.md](GOVERNANCE.md#decision-making).
+- **Conduct in venues unrelated to NodeWright**, unless it creates a credible safety risk for someone in this community.
+- **NVIDIA employment or HR matters**, which go through NVIDIA's internal channels.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,83 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# NodeWright Project Governance
+
+This document describes how the NodeWright project (formerly Skyhook) is governed: the roles people hold, how decisions get made, and how maintainers join and leave. It is intentionally lightweight and will grow with the project. For the current roster and maintainer responsibilities, see [MAINTAINERS.md](MAINTAINERS.md).
+
+## Project Scope
+
+NodeWright is a Kubernetes-aware package manager for safely modifying and maintaining host infrastructure at scale. It coordinates the node lifecycle (cordon, drain, apply package, interrupt or reboot, uncordon) as controlled rollouts gated by interruption budgets and deployment policies.
+
+In scope: the operator and its CRDs, the package agent, the `kubectl nodewright` CLI, the Helm chart, and the documentation and test infrastructure that support them.
+
+Out of scope: the contents of individual packages (those live with their authors), cluster provisioning, and workload scheduling. NodeWright applies host changes; it does not decide what those changes should be.
+
+## Roles
+
+NodeWright uses three roles. Code ownership maps directly to [`.github/CODEOWNERS`](.github/CODEOWNERS).
+
+### Contributors
+
+Anyone who opens an issue, pull request, or discussion. Contributors follow the [Code of Conduct](CODE_OF_CONDUCT.md) and sign off their commits under the DCO (see [CONTRIBUTING.md](CONTRIBUTING.md)). No special access is required to contribute.
+
+### Code Owners
+
+Trusted contributors who review and approve pull requests for the paths they own. Code ownership is declared per path in [`.github/CODEOWNERS`](.github/CODEOWNERS), which GitHub uses to request reviews automatically. Code owners keep their areas healthy and mentor contributors.
+
+### Maintainers
+
+Maintainers have merge rights, make and ratify project decisions, manage releases, and own this governance process, including adding and removing maintainers. Maintainers are also code owners. The current roster is in [MAINTAINERS.md](MAINTAINERS.md).
+
+## Areas of Ownership
+
+Path-level ownership is authoritative in [`.github/CODEOWNERS`](.github/CODEOWNERS). At a high level the project is organized into:
+
+- **Operator** (`operator/`): the controller-manager, CRDs, reconcile loop, and the `kubectl nodewright` CLI under `operator/cmd/cli/`.
+- **Agent** (`agent/`): the Python package that runs inside every package container and executes lifecycle steps.
+- **Chart and deployment surface** (`chart/`, `operator/config/`): the Helm chart and the kustomize manifests it mirrors.
+- **Containers** (`containers/`): base images and container build tooling.
+- **Documentation** (`docs/`, root project docs): domain concepts and behavioral contracts.
+- **Tests and CI** (`k8s-tests/`, `.github/`, `scripts/`): chainsaw e2e suites, workflows, and release tooling.
+
+Maintainers hold cross-cutting responsibility across all areas.
+
+## Decision-Making
+
+NodeWright decides by **lazy consensus**: a proposal (pull request, issue, or discussion) is accepted if no maintainer raises a blocking objection within a reasonable review window, at least five business days for non-trivial changes. Most day-to-day changes are merged through normal code-owner review under [`.github/CODEOWNERS`](.github/CODEOWNERS) and the process in [CONTRIBUTING.md](CONTRIBUTING.md).
+
+When consensus is not reached:
+
+- **Majority vote.** Any maintainer may call a vote. A proposal passes on a simple majority of non-emeritus maintainers; quorum is a simple majority of that same group.
+- **Blocking objection (veto).** A maintainer may block a change by stating a concrete technical rationale and an actionable path to resolution. A blocked change proceeds only if a two-thirds supermajority of non-emeritus maintainers votes to override.
+- **Supermajority decisions.** Adding or removing a maintainer, and changes to this document, require a two-thirds supermajority of non-emeritus maintainers.
+
+Changes that alter a public contract (CRD field, CLI flag, annotation, metric, or lifecycle semantics) always require an explicit approval from at least one maintainer who did not author the change, regardless of the review window.
+
+## Tie-Breaking
+
+If a vote is tied, the **lead maintainer** has the casting vote. The lead maintainer is designated by the maintainer team and recorded in [MAINTAINERS.md](MAINTAINERS.md); the role exists to break deadlocks and carries no additional day-to-day authority. If the lead maintainer is the subject of, or is recused from, a decision, the remaining maintainers designate an acting lead for that decision.
+
+## Adding and Removing Maintainers
+
+### Adding
+
+Maintainers are added on merit. An existing maintainer nominates a candidate based on sustained contributions, review quality, and domain expertise. The nominee is added when a two-thirds supermajority of non-emeritus maintainers approves.
+
+### Removing and stepping down
+
+A maintainer may step down at any time by opening a pull request that moves them to emeritus. A maintainer may also be removed by a two-thirds supermajority of non-emeritus maintainers, for sustained inactivity (see [Emeritus](#emeritus)) or for conduct that violates the [Code of Conduct](CODE_OF_CONDUCT.md). Removal for cause follows the Code of Conduct enforcement process.
+
+## Emeritus
+
+A maintainer is considered **inactive** after six months with no substantive contribution, review, or governance participation. Inactive maintainers are moved to the Emeritus list in [MAINTAINERS.md](MAINTAINERS.md) either voluntarily, or involuntarily by the same two-thirds supermajority of non-emeritus maintainers required for removal. Moving to emeritus removes merge rights and excludes the maintainer from quorum and vote counts. Emeritus maintainers are welcomed back through the normal onboarding process when they return to active participation.
+
+## Deprecation and End-of-Life
+
+Components are versioned and released independently under the rules in [`docs/versioning.md`](docs/versioning.md). Removing or breaking a public surface (CRD field, CLI command or flag, annotation, env var, or metric) requires a deprecation period announced in the relevant `CHANGELOG.md` and a migration path in `docs/` before the removal ships. The `skyhook.nvidia.com` to `nodewright.nvidia.com` transition documented in [`docs/nodewright-migration.md`](docs/nodewright-migration.md) is the reference example.
+
+## Changing This Document
+
+Amendments follow the supermajority rule above: a pull request plus approval from a two-thirds supermajority of non-emeritus maintainers.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,43 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Maintainers
+
+This document lists the maintainers of the NodeWright project (formerly Skyhook). Project decision-making, tie-breaking, and the maintainer add/remove and emeritus processes are documented in [GOVERNANCE.md](GOVERNANCE.md). Path-level review ownership is defined in [`.github/CODEOWNERS`](.github/CODEOWNERS).
+
+## Current Maintainers
+
+Lead maintainer first, then sorted by GitHub handle.
+
+| GitHub | Name |
+|---|---|
+| [@lockwobr](https://github.com/lockwobr) | Brian Lockwood (**lead maintainer**) |
+| [@ayuskauskas](https://github.com/ayuskauskas) | Alex Yuskauskas |
+| [@rice-riley](https://github.com/rice-riley) | Riley Rice |
+
+The lead maintainer holds the casting vote on tied maintainer votes and has no additional day-to-day authority. See [Tie-Breaking](GOVERNANCE.md#tie-breaking).
+
+## Maintainer Responsibilities
+
+Maintainers are responsible for:
+
+- Reviewing and merging pull requests
+- Triaging issues and discussions
+- Ensuring code quality and test coverage
+- Making release decisions across the independently versioned components (operator, CLI, agent, chart)
+- Keeping `docs/` accurate as behavior changes
+- Upholding the [Code of Conduct](CODE_OF_CONDUCT.md)
+
+## Changes to This List
+
+Maintainers are added and removed through the process in [GOVERNANCE.md](GOVERNANCE.md#adding-and-removing-maintainers). A change lands in this file and in [`.github/CODEOWNERS`](.github/CODEOWNERS) in the same pull request.
+
+## Emeritus Maintainers
+
+Maintainers who are no longer actively maintaining the project. A maintainer moves here on request, or involuntarily after six months of inactivity by a two-thirds supermajority of non-emeritus maintainers. Inactivity alone does not move anyone automatically; the vote is required. Emeritus maintainers are welcomed back through the normal onboarding process. See [Emeritus](GOVERNANCE.md#emeritus).
+
+| GitHub | Name |
+|---|---|
+| [@mskalka](https://github.com/mskalka) | Michael Skalka |

--- a/README.md
+++ b/README.md
@@ -305,17 +305,24 @@ cd operator
 make build-cli
 
 # Install as kubectl plugin
-cp bin/skyhook /usr/local/bin/kubectl-skyhook # other another directory in $PATH with write access
+cp bin/nodewright /usr/local/bin/kubectl-nodewright # or another directory in $PATH with write access
 
 # Verify installation
-kubectl skyhook version
+kubectl nodewright version
 ```
 
 See the [full CLI documentation](docs/cli.md) for detailed usage and examples.
 
 ## Contributing
 
-Start here: [CONTRIBUTING.md](CONTRIBUTING.md)
+- Start here: [CONTRIBUTING.md](CONTRIBUTING.md)
+- Code of Conduct: [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)
+
+## Governance & Maintainers
+
+- Governance: [GOVERNANCE.md](GOVERNANCE.md) - roles, how decisions get made, how maintainers join and leave
+- Maintainers: [MAINTAINERS.md](MAINTAINERS.md) - current roster and how to become one
+- Review ownership: [`.github/CODEOWNERS`](.github/CODEOWNERS)
 
 ## Security
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -19,6 +19,89 @@ To report a potential security vulnerability in any NVIDIA product:
 
 While NVIDIA currently does not have a bug bounty program, we do offer acknowledgement when an externally reported security issue is addressed under our coordinated vulnerability disclosure policy. Please visit our [Product Security Incident Response Team (PSIRT)](https://www.nvidia.com/en-us/security/psirt-policies/) policies page for more information.
 
+## Coordinated Disclosure
+
+PSIRT owns triage, severity assessment, and the disclosure date for reports filed through the channels above. What that means in this repository, while a report is under embargo:
+
+- Maintainers will not discuss the report in public issues, pull requests, or discussions.
+- A fix will not be merged with a commit message, pull request description, or test name that reveals the vulnerability ahead of the coordinated date.
+- No release will be tagged or announced in a way that advertises the issue before PSIRT publishes.
+- The patched release and the advisory ship together on the coordinated date, and the `CHANGELOG.md` entry links to the advisory.
+- Reporters who ask to remain anonymous are credited as "an anonymous reporter" rather than by name.
+
 ## NVIDIA Product Security
 
 For all security-related concerns, please visit NVIDIA's Product Security portal at https://www.nvidia.com/en-us/security
+
+## Supported Versions
+
+NodeWright releases its components independently, each following [Semantic Versioning](https://semver.org/). Security fixes are released against the latest minor of each component. Critical fixes may be backported to the most recent prior release branch (`release/v{MAJOR.MINOR}.x`), at the maintainers' discretion; see [docs/versioning.md](docs/versioning.md).
+
+| Component | Tag prefix | Supported |
+|---|---|---|
+| Operator | `operator/v` | Latest minor |
+| Helm chart | `chart/v` | Latest minor |
+| Agent | `agent/v` | Latest minor |
+| CLI (`kubectl nodewright`) | `cli/v` | Latest minor |
+
+The current version of each line is whatever the newest tag with that prefix says; this file deliberately does not restate it.
+
+Older minors are not patched. If you are running one, upgrade to the latest release of that component. The full list is on the [releases page](https://github.com/NVIDIA/nodewright/releases).
+
+Kubernetes version support is a separate policy: we CI-test and support the **latest four Kubernetes minor versions**. See [docs/kubernetes-support.md](docs/kubernetes-support.md) for the current window and what happens when it moves.
+
+## Verifying Release Artifacts
+
+Every released container image and the Helm chart is signed with [Sigstore cosign](https://docs.sigstore.dev/) in keyless mode, has a CycloneDX SBOM attached as an attestation, and carries [SLSA build provenance](https://slsa.dev/). Each signing job verifies its own output before finishing.
+
+**Each artifact is signed by the workflow that builds it, gated on its own tag family, so the certificate identity differs per artifact.** A single identity pattern will not verify everything:
+
+| Artifact | Signing workflow | Tag family |
+|---|---|---|
+| Operator image | `.github/workflows/operator-ci.yaml` | `refs/tags/operator/` |
+| Agent image | `.github/workflows/agent-ci.yaml` | `refs/tags/agent/` |
+| Helm chart | `.github/workflows/release.yml` | `refs/tags/chart/` |
+
+Verify by digest, not by tag. A tag can be repointed between the moment you verify it and the moment you pull it; a digest cannot. This is also what the signing workflows themselves do.
+
+```bash
+REPO=ghcr.io/nvidia/nodewright/operator
+ISSUER=https://token.actions.githubusercontent.com
+# Operator image: pins the signing workflow AND the operator tag family.
+# Swap both per the table above to verify the chart or the agent instead.
+IDENTITY='^https://github\.com/NVIDIA/nodewright/\.github/workflows/operator-ci\.yaml@refs/tags/operator/.*$'
+
+# Resolve the tag to an immutable digest once, then use it everywhere below
+DIGEST=$(crane digest "$REPO:<tag>")
+IMAGE="$REPO@$DIGEST"
+
+# Signature (keyless, GitHub Actions OIDC identity)
+cosign verify --certificate-oidc-issuer="$ISSUER" \
+  --certificate-identity-regexp="$IDENTITY" "$IMAGE"
+
+# SBOM attestation (CycloneDX)
+cosign verify-attestation --type cyclonedx \
+  --certificate-oidc-issuer="$ISSUER" \
+  --certificate-identity-regexp="$IDENTITY" "$IMAGE"
+
+# SLSA build provenance
+cosign verify-attestation --type https://slsa.dev/provenance/v1 \
+  --certificate-oidc-issuer="$ISSUER" \
+  --certificate-identity-regexp="$IDENTITY" "$IMAGE"
+```
+
+These are the same three checks the signing workflow runs against its own output before it finishes. Pin the digest you verified in your Helm values or image reference, so the artifact you checked is the artifact that runs.
+
+Without `crane`, use:
+
+```bash
+DIGEST=$(docker buildx imagetools inspect --format '{{.Manifest.Digest}}' "$REPO:<tag>")
+```
+
+Take the top-level manifest digest, which is what the signature and attestations are bound to. Do not substitute one of the per-platform digests listed under `Manifests:` in the plain `docker buildx imagetools inspect` output; those are children of the index and will not verify.
+
+The identity regexp is deliberately narrow: it pins the signer to one workflow and one tag family in this repository, not merely to the NVIDIA organization. Loosening it to `refs/tags/` would let a signature produced by any other release path satisfy the check. Swap the workflow and tag family per the table above when verifying the chart or the agent.
+
+Artifacts released before the Skyhook to NodeWright repository rename carry a `NVIDIA/skyhook` certificate identity; substitute that path when verifying older releases.
+
+A verification failure on a published artifact is itself a security report. Route it through the channels above.


### PR DESCRIPTION
## What

Adds the community and governance files the [NVIDIA PLC-OSS-Template](https://github.com/NVIDIA-GitHub-Management/PLC-OSS-Template) README prescribes but does not ship, and fills gaps found in an open source health review. Companion to NVIDIA/nodewright-packages#107.

| File | Change |
|---|---|
| `GOVERNANCE.md` | New. Roles, areas of ownership, decision-making, tie-breaking, maintainer add/remove, emeritus, deprecation policy. |
| `MAINTAINERS.md` | New. Current roster and emeritus list. |
| `CODE_OF_CONDUCT.md` | Contributor Covenant 1.4 to 2.1, same `GitHub_Conduct@nvidia.com` contact. |
| `CONTRIBUTING.md` | Adds Code of Conduct, Governance, and Community standards sections. |
| `SECURITY.md` | Adds supported versions, coordinated disclosure, and artifact verification. NVIDIA PSIRT block untouched. |
| `README.md` | Links the Code of Conduct and the new governance docs. |
| `.github/CODEOWNERS` | Drops `@mskalka`, now recorded as emeritus. |

## Why these specifics

**Contributor Covenant 2.1, not 1.4 or 3.0.** Our 1.4 text is the PLC-OSS-Template file verbatim and has no enforcement ladder. 3.0 ships with `[NOTE: ...]` placeholders you must fill in yourself and is licensed CC BY-SA 4.0, a ShareAlike term, in an otherwise Apache-2.0 repo. 2.1 is the finished document with the four-rung Community Impact ladder, and matches what [NVIDIA/aicr](https://github.com/NVIDIA/aicr/issues/1420) adopted.

**`SECURITY.md` additions are additive only.** The NVIDIA PSIRT block is byte-identical to `main`. The new Coordinated Disclosure section deliberately does not restate the PSIRT contact points, policy link, or acknowledgement language already there; it covers only what maintainers of this repo do while a report is under embargo.

**Verification is documented by digest, not tag.** A tag can be repointed between the moment you verify it and the moment you pull it. The release workflow already verifies `subject@digest`, so a tag-based example would have contradicted what CI enforces. The three cosign commands mirror `.github/actions/cosign-verify-release`, and the certificate identity regexp pins the signer to this repository's release workflow rather than the whole NVIDIA org.

**Supported versions reuse what already exists.** The Kubernetes window points at `docs/kubernetes-support.md` rather than restating it, and the component table follows the per-component tag prefixes from `docs/versioning.md`.

**Nothing promises external maintainer eligibility.** Whether contributors outside NVIDIA can become maintainers is an open question, so `GOVERNANCE.md` documents the nomination and supermajority mechanism without claiming who is eligible. That can be added once the answer is known.

## Needs confirmation before merge

1. `SECURITY.md` says older minors are not patched, with critical fixes possibly backported. `docs/versioning.md` says backports *may* happen, and release branches exist only through `release/v0.13.x` while current is `0.17.x`. Confirm this matches actual practice.
2. The supported-versions table names the current minor lines (`0.17.x`, `6.4.x`, `0.2.x`) and will need bumping over time.
3. `@lockwobr` is recorded as lead maintainer for tie-breaking.

## Verification

- `markdownlint-cli2` clean against `ci/.markdownlint-cli2.yaml`.
- All internal links and anchors resolve; every path named in `GOVERNANCE.md` and `.github/CODEOWNERS` exists in the tree.
- `SECURITY.md` changes are additions only; no original line altered.