### PR TITLE
fix(cli): correct stale examples in `version --help`

### DIFF
--- a/operator/cmd/cli/app/version.go
+++ b/operator/cmd/cli/app/version.go
@@ -45,14 +45,13 @@ func NewVersionCmd(ctx *cliContext.CLIContext) *cobra.Command {
 		The plugin version is always shown. By default, the command also queries the cluster
 		to discover the NodeWright operator version. Use --client-only to skip the cluster query.`,
 		Example: `  # Show both plugin and operator versions
-		skyhook version
 		kubectl nodewright version
 
 		# Show only the plugin version (no cluster query)
-		skyhook version --client-only
+		kubectl nodewright version --client-only
 
 		# Query operator in a specific namespace
-		skyhook version -n skyhook-system`,
+		kubectl nodewright version -n skyhook`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "NodeWright plugin:\t%s\n", version.Summary())
 


### PR DESCRIPTION
## What

The `version` command's example block advertised a binary that no longer exists and a namespace that never did.

```diff
   Example: `  # Show both plugin and operator versions
-		skyhook version
 		kubectl nodewright version
 
 		# Show only the plugin version (no cluster query)
-		skyhook version --client-only
+		kubectl nodewright version --client-only
 
 		# Query operator in a specific namespace
-		skyhook version -n skyhook-system`,
+		kubectl nodewright version -n skyhook`,
```

## Why

**`skyhook version` is not a valid invocation.** The plugin binary is `kubectl-nodewright` and the CLI is `kubectl nodewright`. One of the three examples had already been updated, so the block listed both forms and printed the same command twice, which reads like the two do different things.

**`skyhook-system` is not a namespace this project uses.** `context.DefaultNamespace` is `skyhook` (asserted in `operator/cmd/cli/app/cli_test.go:251`), and that is where the chart installs. Anyone copying `-n skyhook-system` got an empty result with no hint as to why.

Found while reviewing NVIDIA/nodewright#381; flagged there and split out rather than folded into a governance docs PR, since this is user-facing CLI output.

## Scope

Help text only. No behavior change, no flag change, no docs update needed: `docs/cli.md` does not reproduce these examples.

Deliberately **not** touched: `operator/cmd/cli/app/lifecycle.go:136` also says `kubectl edit skyhook`, but that is correct. It is the error path for operators older than v0.8.0, which used the legacy `Skyhook` CR and `spec.pause` rather than annotations. Renaming it there would send users of old operators to a resource their cluster does not have.

## Verification

```
$ make build-cli && ./bin/nodewright version --help
Examples:
  # Show both plugin and operator versions
		kubectl nodewright version

		# Show only the plugin version (no cluster query)
		kubectl nodewright version --client-only

		# Query operator in a specific namespace
		kubectl nodewright version -n skyhook

$ go test -mod=vendor ./cmd/cli/app/...
ok  	github.com/NVIDIA/nodewright/operator/cmd/cli/app	1.835s

$ grep -rn "skyhook version\|skyhook-system" cmd/cli/
(no matches)
```