### PR TITLE
fix(operator): stop stranding a dependency-free package in the DAG walk

### DIFF
--- a/operator/internal/graph/dependency_graph.go
+++ b/operator/internal/graph/dependency_graph.go
@@ -21,7 +21,6 @@ package graph
 import (
 	"fmt"
 	"io"
-	"slices"
 	"sort"
 )
 
@@ -48,13 +47,11 @@ func New[T any]() DependencyGraph[T] {
 	return &dag[T]{
 		vertices:     map[string]*vertex[T]{},
 		placeholders: map[string]*vertex[T]{},
-		leafs:        map[string]*vertex[T]{},
 	}
 }
 
 type dag[T any] struct {
 	vertices     map[string]*vertex[T]
-	leafs        map[string]*vertex[T]
 	placeholders map[string]*vertex[T]
 }
 
@@ -81,14 +78,13 @@ func (d *dag[T]) Add(name string, object T, dependencies ...string) error {
 	if !ok {
 		vert = &vertex[T]{name: name, object: object, parents: dependencies}
 	} else {
-		// set object on placeholder
+		// A placeholder was created by a child that named this vertex before it was added, so
+		// it carries edges but no parents; set both here or the parents are lost for good and
+		// this vertex looks dependency-free forever.
 		vert.object = object
+		vert.parents = dependencies
 	}
 	d.vertices[name] = vert
-
-	if len(dependencies) == 0 {
-		d.leafs[name] = vert
-	}
 
 	for _, dependency := range dependencies {
 		if dep, ok := d.vertices[dependency]; ok {
@@ -107,75 +103,43 @@ func (d *dag[T]) Add(name string, object T, dependencies ...string) error {
 	return nil
 }
 
-// leaves handle edge cases where there are more then one leaf, and from is a subset of the leaves not in the from
-func (d *dag[T]) leaves(from []string) []string {
-	leaves := make([]string, 0, len(d.leafs))
-	for _, f := range d.leafs {
-		leaves = append(leaves, f.name)
-	}
-	if len(from) > len(leaves) {
-		return nil
-	}
-	dif := diff(leaves, from)
-	return dif
-}
-
-// diff returns the elements in a that are not in b
-func diff(a, b []string) []string {
-	ret := make([]string, 0, len(a))
-	for _, v := range a {
-		if !slices.Contains(b, v) {
-			ret = append(ret, v)
-		}
-	}
-	return ret
-}
-
+// Next returns every vertex that is not yet in from and whose parents are all in from.
+//
+// Scanning all vertices rather than walking outward from from is deliberate: a walk only
+// ever reaches children of completed vertices, so a dependency-free vertex — which is
+// nobody's child — could never be re-offered once it was missed. That is what stranded a
+// still-incomplete package for good when the completed count grew past the number of
+// dependency-free packages.
 func (d *dag[T]) Next(from ...string) ([]string, error) {
 	if err := d.Valid(); err != nil {
 		return nil, err
 	}
 
-	if len(from) == 0 { // base starting case
-		return getNames(flat(d.leafs)), nil
-	}
-	leaves := d.leaves(from)
-	if len(leaves) > 0 {
-		return leaves, nil
+	done := make(map[string]struct{}, len(from))
+	for _, name := range from {
+		done[name] = struct{}{}
 	}
 
-	// Use a map to deduplicate edges
-	seen := make(map[string]*vertex[T])
-	for _, f := range from {
-		vert := d.vertices[f]
-		for _, edge := range vert.edges {
-			// Skip if already processed
-			if slices.Contains(from, edge.name) {
-				continue
-			}
+	ready := make([]*vertex[T], 0, len(d.vertices))
+	for _, vert := range d.vertices {
+		if _, ok := done[vert.name]; ok {
+			continue
+		}
 
-			// Check if all parents are in the completed set
-			allParentsSatisfied := true
-			for _, parent := range edge.parents {
-				if !slices.Contains(from, parent) {
-					allParentsSatisfied = false
-					break
-				}
+		satisfied := true
+		for _, parent := range vert.parents {
+			if _, ok := done[parent]; !ok {
+				satisfied = false
+				break
 			}
-			if allParentsSatisfied {
-				seen[edge.name] = edge
-			}
+		}
+		if satisfied {
+			ready = append(ready, vert)
 		}
 	}
 
-	// Convert map to slice
-	root := make([]*vertex[T], 0, len(seen))
-	for _, v := range seen {
-		root = append(root, v)
-	}
-
-	sortEdges(root)
-	return getNames(root), nil
+	sortEdges(ready)
+	return getNames(ready), nil
 }
 
 func (d *dag[T]) Get(from ...string) []T {
@@ -195,16 +159,6 @@ func (d *dag[T]) Valid() error {
 		return fmt.Errorf("error graph is not valid, missing: %v", miss)
 	}
 	return nil
-}
-
-func flat[T any](m map[string]*vertex[T]) []*vertex[T] {
-	root := make([]*vertex[T], 0, len(m))
-	for _, val := range m {
-		root = append(root, val)
-	}
-
-	sortEdges(root)
-	return root
 }
 
 func sortEdges[T any](e []*vertex[T]) {

--- a/operator/internal/graph/dependency_graph_test.go
+++ b/operator/internal/graph/dependency_graph_test.go
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  *
@@ -19,7 +19,10 @@
 package graph
 
 import (
+	"fmt"
 	"math/rand"
+	"slices"
+	"sort"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -312,6 +315,108 @@ var _ = Describe("DAG tests", func() {
 		Expect(step).To(BeEquivalentTo([]string{"D"}))
 	})
 
+	It("should still offer a dependency-free vertex once more vertices are complete than there are dependency-free vertices", func() {
+		/* Graph structure:
+		   A   B   Z
+		      / \
+		     C   D
+
+		   A, B and Z have no dependencies. Walking outward from the completed
+		   set only ever reaches children of completed vertices, and Z is nobody's
+		   child, so Z has to be found by scanning rather than by walking.
+		*/
+
+		d := New[*string]()
+		Expect(d.Add("A", nil)).Should(Succeed())
+		Expect(d.Add("B", nil)).Should(Succeed())
+		Expect(d.Add("Z", nil)).Should(Succeed())
+		Expect(d.Add("C", nil, "B")).Should(Succeed())
+		Expect(d.Add("D", nil, "B")).Should(Succeed())
+
+		// four complete, three dependency-free vertices, and Z has never run
+		step, err := d.Next("A", "B", "C", "D")
+		Expect(err).To(BeNil())
+		Expect(step).To(BeEquivalentTo([]string{"Z"}))
+
+		// level-triggered: asking again with the same completed set is stable
+		step, err = d.Next("A", "B", "C", "D")
+		Expect(err).To(BeNil())
+		Expect(step).To(BeEquivalentTo([]string{"Z"}))
+
+		step, err = d.Next("A", "B", "C", "D", "Z")
+		Expect(err).To(BeNil())
+		Expect(step).To(BeEmpty())
+	})
+
+	It("should offer dependency-free and newly unblocked vertices in the same step", func() {
+		/* Graph structure:
+		   A   B   Z
+		      / \
+		     C   D
+		*/
+
+		d := New[*string]()
+		Expect(d.Add("A", nil)).Should(Succeed())
+		Expect(d.Add("B", nil)).Should(Succeed())
+		Expect(d.Add("Z", nil)).Should(Succeed())
+		Expect(d.Add("C", nil, "B")).Should(Succeed())
+		Expect(d.Add("D", nil, "B")).Should(Succeed())
+
+		// B unblocks C and D; A and Z were runnable all along and must not be dropped
+		step, err := d.Next("B")
+		Expect(err).To(BeNil())
+		Expect(step).To(BeEquivalentTo([]string{"A", "C", "D", "Z"}))
+	})
+
+	It("should keep the dependencies of a vertex that was forward-referenced before it was added", func() {
+		/* Graph structure:
+		      A
+		     / \
+		    P   Q
+		     \ /
+		      Z
+		      |
+		      X
+
+		   X names Z before Z is added, so Z exists as a placeholder when its own
+		   Add promotes it. BuildGraph ranges a Go map, so this order happens at
+		   random in production.
+
+		   A sits above P and Q so that the interesting step (only P complete) has
+		   a completed set larger than the single dependency-free vertex; with a
+		   smaller completed set the answer comes from the dependency-free vertices
+		   and Z's parents are never consulted.
+		*/
+
+		d := New[*string]()
+		Expect(d.Add("X", nil, "Z")).Should(Succeed()) // creates the placeholder for Z
+		Expect(d.Add("Z", nil, "P", "Q")).Should(Succeed())
+		Expect(d.Add("P", nil, "A")).Should(Succeed())
+		Expect(d.Add("Q", nil, "A")).Should(Succeed())
+		Expect(d.Add("A", nil)).Should(Succeed())
+
+		step, err := d.Next()
+		Expect(err).To(BeNil())
+		Expect(step).To(BeEquivalentTo([]string{"A"}))
+
+		step, err = d.Next("A")
+		Expect(err).To(BeNil())
+		Expect(step).To(BeEquivalentTo([]string{"P", "Q"}))
+
+		// Z must wait for Q, not race ahead on an empty parent set
+		step, err = d.Next("A", "P")
+		Expect(err).To(BeNil())
+		Expect(step).To(BeEquivalentTo([]string{"Q"}))
+
+		step, err = d.Next("A", "P", "Q")
+		Expect(err).To(BeNil())
+		Expect(step).To(BeEquivalentTo([]string{"Z"}))
+
+		step, err = d.Next("A", "P", "Q", "Z")
+		Expect(err).To(BeNil())
+		Expect(step).To(BeEquivalentTo([]string{"X"}))
+	})
+
 	It("should walk the graph one vertex at a time", func() {
 		/* Graph structure:
 		   A   B
@@ -377,5 +482,186 @@ var _ = Describe("DAG tests", func() {
 		Expect(*d.Get("D")[0]).To(Equal("D"))
 		Expect(*d.Get("E")[0]).To(Equal("E"))
 		Expect(*d.Get("F")[0]).To(Equal("F"))
+	})
+
+	// Property checks over generated graphs. The hand-written specs above pin
+	// specific shapes; these pin the contract itself, so a future rewrite of Next
+	// cannot satisfy the examples while still losing or mis-ordering a vertex.
+	// Graphs are generated from GinkgoRandomSeed(), which Ginkgo prints, so any
+	// failure is reproducible with --ginkgo.seed=<printed>.
+	Describe("properties over generated graphs", func() {
+
+		// randomDAG builds an acyclic graph over names v0..v{n-1}, only ever pointing
+		// an edge from a lower index to a higher one, which makes cycles impossible by
+		// construction. addOrder decides the order Add is called in, so a vertex can be
+		// forward-referenced before it exists (the placeholder path).
+		// orderRng is deliberately separate from rng: the order-independence spec needs
+		// the same logical graph rebuilt with a different Add order, which is impossible
+		// if one stream drives both the edges and the shuffle.
+		randomDAG := func(rng *rand.Rand, orderRng *rand.Rand, n int) (DependencyGraph[*string], map[string][]string, []string) {
+			names := make([]string, n)
+			deps := make(map[string][]string, n)
+			for i := range names {
+				names[i] = fmt.Sprintf("v%d", i)
+			}
+			for i := 1; i < n; i++ {
+				for j := range i {
+					if rng.Intn(3) == 0 {
+						deps[names[i]] = append(deps[names[i]], names[j])
+					}
+				}
+			}
+
+			addOrder := append([]string(nil), names...)
+			orderRng.Shuffle(len(addOrder), func(a, b int) { addOrder[a], addOrder[b] = addOrder[b], addOrder[a] })
+
+			d := New[*string]()
+			for _, name := range addOrder {
+				n := name
+				Expect(d.Add(n, &n, deps[n]...)).To(Succeed())
+			}
+			return d, deps, names
+		}
+
+		// The contract in both directions. Soundness alone (never offer something
+		// unrunnable) is not enough: the strand was a completeness failure, where a
+		// runnable vertex was silently dropped.
+		It("offers exactly the vertices whose dependencies are complete", func() {
+			rng := rand.New(rand.NewSource(GinkgoRandomSeed()))
+
+			for range 300 {
+				d, deps, names := randomDAG(rng, rng, 2+rng.Intn(8))
+
+				// an arbitrary completed set, including sets that are not downward
+				// closed: resets and hand-edited annotations produce exactly that
+				from := make([]string, 0, len(names))
+				for _, name := range names {
+					if rng.Intn(2) == 0 {
+						from = append(from, name)
+					}
+				}
+
+				want := make([]string, 0, len(names))
+				for _, name := range names {
+					if slices.Contains(from, name) {
+						continue
+					}
+					runnable := true
+					for _, parent := range deps[name] {
+						if !slices.Contains(from, parent) {
+							runnable = false
+							break
+						}
+					}
+					if runnable {
+						want = append(want, name)
+					}
+				}
+
+				got, err := d.Next(from...)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(got).To(ConsistOf(want),
+					"frontier wrong for completed set %v (deps %v)", from, deps)
+			}
+		})
+
+		// A spec update adds packages to a NodeWright that is already part-way
+		// rolled out, so the walk starts from a completed set it did not produce
+		// itself. Starting from empty cannot reach that state, and it is the state
+		// the e2e stall was in. Once a vertex stops being offered it is never run
+		// again, so the walk must never go empty while work remains.
+		It("converges from a completed set it did not build itself", func() {
+			rng := rand.New(rand.NewSource(GinkgoRandomSeed()))
+
+			for range 300 {
+				d, deps, names := randomDAG(rng, rng, 3+rng.Intn(7))
+
+				// pre-existing progress: any downward-closed subset, as if these
+				// packages were already complete when new ones were added to the spec
+				complete := make([]string, 0, len(names))
+				for _, name := range names {
+					if rng.Intn(2) != 0 {
+						continue
+					}
+					satisfied := true
+					for _, parent := range deps[name] {
+						if !slices.Contains(complete, parent) {
+							satisfied = false
+							break
+						}
+					}
+					if satisfied {
+						complete = append(complete, name)
+					}
+				}
+
+				for len(complete) < len(names) {
+					step, err := d.Next(complete...)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(step).ToNot(BeEmpty(),
+						"stalled with %d/%d complete: have %v, deps %v", len(complete), len(names), complete, deps)
+
+					// finish an arbitrary non-empty subset, leaving the rest in flight,
+					// which is what asynchronous stage Jobs do
+					for i, name := range step {
+						if rng.Intn(2) == 0 || i == len(step)-1 {
+							complete = append(complete, name)
+						}
+					}
+				}
+			}
+		})
+
+		It("gives the same answer whatever order the graph was built in", func() {
+			rng := rand.New(rand.NewSource(GinkgoRandomSeed()))
+
+			for range 100 {
+				seed := rng.Int63()
+				n := 2 + rng.Intn(8)
+				d, _, names := randomDAG(rand.New(rand.NewSource(seed)), rand.New(rand.NewSource(rng.Int63())), n)
+
+				from := make([]string, 0, len(names))
+				for _, name := range names {
+					if rng.Intn(2) == 0 {
+						from = append(from, name)
+					}
+				}
+
+				want, err := d.Next(from...)
+				Expect(err).ToNot(HaveOccurred())
+
+				for range 5 {
+					// same deps seed, different Add order: forward references land on the
+					// placeholder path, which must not change the answer
+					other, _, _ := randomDAG(rand.New(rand.NewSource(seed)), rand.New(rand.NewSource(rng.Int63())), n)
+					got, err := other.Next(from...)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(got).To(Equal(want), "answer depended on Add order")
+				}
+			}
+		})
+
+		It("returns results in a stable sorted order", func() {
+			rng := rand.New(rand.NewSource(GinkgoRandomSeed()))
+
+			for range 100 {
+				d, _, names := randomDAG(rng, rng, 2+rng.Intn(8))
+
+				from := make([]string, 0, len(names))
+				for _, name := range names {
+					if rng.Intn(2) == 0 {
+						from = append(from, name)
+					}
+				}
+
+				step, err := d.Next(from...)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(sort.StringsAreSorted(step)).To(BeTrue(), "unsorted result %v", step)
+
+				again, err := d.Next(from...)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(again).To(Equal(step), "repeat call changed the answer")
+			}
+		})
 	})
 })

--- a/operator/internal/wrapper/node_test.go
+++ b/operator/internal/wrapper/node_test.go
@@ -139,6 +139,57 @@ var _ = Describe("SkyhookNode", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(pkgs).To(BeEmpty())
 		})
+
+		// Mirrors simple-update-skyhook after its update step: three packages with no
+		// dependsOn (baxter, dexter, jackie-chan) plus two that depend on dexter. A
+		// dependency-free package is nobody's child, so it has to stay runnable until it
+		// is itself complete, including once more packages are complete than there are
+		// dependency-free ones. Regression for the stall that parked a package at
+		// apply/complete and left the NodeWright in_progress forever.
+		It("still returns a dependency-free package once more packages are complete than there are roots", func() {
+			node := corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "test-node"}}
+			skyhook := v1alpha1.NodeWright{
+				ObjectMeta: metav1.ObjectMeta{Name: "simple-update-skyhook"},
+				Spec: v1alpha1.NodeWrightSpec{
+					Packages: map[string]v1alpha1.Package{
+						"baxter":      {PackageRef: v1alpha1.PackageRef{Name: "baxter", Version: "2.3.1-test"}, Image: "img"},
+						"dexter":      {PackageRef: v1alpha1.PackageRef{Name: "dexter", Version: "1.2.3"}, Image: "img"},
+						"jackie-chan": {PackageRef: v1alpha1.PackageRef{Name: "jackie-chan", Version: "2024.7.7-test"}, Image: "img"},
+						"foobar":      {PackageRef: v1alpha1.PackageRef{Name: "foobar", Version: "1.2"}, Image: "img", DependsOn: map[string]string{"dexter": "1.2.3"}},
+						"spencer":     {PackageRef: v1alpha1.PackageRef{Name: "spencer", Version: "3.2.3"}, Image: "img", DependsOn: map[string]string{"dexter": "1.2.3"}},
+					},
+				},
+			}
+
+			skyhookNode, err := NewSkyhookNode(&node, &skyhook)
+			Expect(err).NotTo(HaveOccurred())
+
+			// everything except jackie-chan reaches config/complete
+			for _, ref := range []v1alpha1.PackageRef{
+				{Name: "baxter", Version: "2.3.1-test"},
+				{Name: "dexter", Version: "1.2.3"},
+				{Name: "foobar", Version: "1.2"},
+				{Name: "spencer", Version: "3.2.3"},
+			} {
+				Expect(skyhookNode.Upsert(ref, "img", v1alpha1.StateComplete, v1alpha1.StageConfig, 0, "")).To(Succeed())
+			}
+
+			// jackie-chan finished apply and is waiting to be advanced to config
+			Expect(skyhookNode.Upsert(v1alpha1.PackageRef{Name: "jackie-chan", Version: "2024.7.7-test"},
+				"img", v1alpha1.StateComplete, v1alpha1.StageApply, 0, "")).To(Succeed())
+
+			Expect(skyhookNode.IsComplete()).To(BeFalse())
+
+			pkgs, err := skyhookNode.RunNext()
+			Expect(err).NotTo(HaveOccurred())
+
+			names := make([]string, 0, len(pkgs))
+			for _, p := range pkgs {
+				names = append(names, p.Name)
+			}
+			Expect(names).To(ContainElement("jackie-chan"),
+				"jackie-chan is incomplete and has no unmet dependencies, so it must still be runnable")
+		})
 	})
 
 	Context("HasSkyhookAnnotations", func() {


### PR DESCRIPTION
## What

`dag.Next(complete...)` could permanently stop offering a package that has no `dependsOn` and has not finished yet. That package is then never passed to `ApplyPackage`, so it parks at its last recorded stage forever while the NodeWright stays `in_progress` with no error, no event and no condition.

This is the intermittent apply→config stall in `e2e/core`.

## Root cause

`leaves()` bailed out with `if len(from) > len(leaves) { return nil }`, and `Next` then fell back to walking outward from the completed set. That walk only ever reaches **children of completed vertices**, and a dependency-free vertex is nobody's child — so once it was skipped it could never be offered again.

`simple-update-skyhook` has three dependency-free packages out of five (`baxter`, `dexter`, `jackie-chan`; `foobar` and `spencer` depend on `dexter`). Once four complete, `len(from) > 3` and the fifth is stranded if it is one of the dependency-free three:

| Run | Complete | Stranded at `apply`/`complete` |
| --- | --- | --- |
| 30472815069 (k8s 1.36.1) | baxter, dexter, foobar, spencer | `jackie-chan` |
| 30477269377 (k8s 1.33.12) | dexter, foobar, jackie-chan, spencer | `baxter` |

Whichever dependency-free package finishes last is the one that hangs. That depends on which stage Job finishes last, which is why it read as flake and moved between Kubernetes versions rather than tracking one.

## Fix

Replace both branches of `Next` with a single scan: every vertex not in `from` whose parents are all in `from`. That is the definition the existing specs already encode step for step, and it cannot lose a vertex because it never depends on reachability from the completed set. `leaves`, `diff` and `flat` become dead and are removed.

Second, smaller fix in the same file: `Add` now fills in `parents` when it promotes a placeholder. A vertex named by a child before it was added kept an empty parent set, so the "all parents complete" check passed vacuously and it could run **ahead of** its dependencies. `BuildGraph` ranges a Go map, so the add order is re-randomised every reconcile and the promotion happens at random. This had to be fixed here because the new `Next` consults `parents` on every vertex rather than only on walked children.

## Tests

Four specs, each confirmed to fail on the unfixed code and pass after:

- `internal/graph` — dependency-free vertex is still offered once the completed set outgrows the dependency-free set (plus a repeat call, to pin level-triggered stability)
- `internal/graph` — dependency-free and newly unblocked vertices come back in the same step; the old code returned one set or the other, never both
- `internal/graph` — a forward-referenced vertex keeps its dependencies and does not run early
- `internal/wrapper` — the production path through `RunNext()`, using the exact `simple-update-skyhook` package set

Against the unfixed graph: 9 passed / 3 failed in `internal/graph`, and the wrapper spec fails. After: full unit suite green, `make lint` clean.

## Notes for review

- **Behaviour change worth a look:** `Next` can now return dependency-free *and* newly unblocked vertices in the same step, so slightly more packages may run in parallel on a node than before. All existing specs still pass unchanged, and package-level parallelism is not specified in `docs/`.
- **Both defects predate the Jobs migration** — `dependency_graph.go` is byte-identical on `main`. The Jobs swap only changed which package tends to finish last, which changed how often the strand is hit. `main` is exposed to the same bug.
- **No docs update:** this restores intended `dependsOn` behaviour rather than changing a documented contract. No page describes the DAG walk or package-level parallelism.
- The placeholder-`parents` half overlaps `worktree-2.patch` from `docs/plans/2026-07-23-operator-audit-v3.md` (K2) — same one-line fix. Its test and mine cover the same case; drop one if that patch also lands. **The K2 patch alone does not fix the strand** — I verified that by applying it to unmodified `HEAD` and re-running the wrapper spec, which still failed.
- Audit K6 (missing `dependsOn` cycle detection) is **not** addressed here and is unaffected: a 2-cycle still gives `Valid() == nil` and `Next() == []`.