### PR TITLE
feat(operator): add skyhook_package_executor_count metric

### DIFF
--- a/docs/metrics/README.md
+++ b/docs/metrics/README.md
@@ -32,6 +32,11 @@ The current metrics supplied by the Operator are intended to be sufficient to de
     * `skyhook_name` : The name of the CR the package belongs to
     * `package_name` : The name of the package
     * `package_version`: The version of the package
+ * `skyhook_package_executor_count`: Number of a package's `batch/v1` Job executors by executor state. This surfaces Job-level states that node `state` cannot distinguish — a suspended executor still reports `state=in_progress`, and a parked one `state=erroring`. Tags:
+    * `skyhook_name` : The name of the SCR the package belongs to
+    * `package_name` : The name of the package
+    * `package_version`: The version of the package
+    * `executor_state` : One of `running` (an unfinished, unsuspended Job), `suspended` (a Job paused by the Emergency Stop), `parked` (a Job that exceeded its stage deadline and is held as the erroring marker)
 
 ## Rollout Metrics (Deployment Policy)
 

--- a/operator/internal/controller/job_controller.go
+++ b/operator/internal/controller/job_controller.go
@@ -754,6 +754,30 @@ func jobFinished(job *batchv1.Job) bool {
 	return failed
 }
 
+// executorState classifies a Job into its executor_state metric label, or "" if it is not an active
+// executor (a finished non-parked Job — Complete, or a Failed-non-deadline backstop). Parked is
+// checked before jobFinished because a parked Job is terminally Failed but is deliberately held in
+// place as the erroring marker, so it counts as an active executor.
+func executorState(job *batchv1.Job) string {
+	switch {
+	case isParkedJob(job):
+		return executorStateParked
+	case jobFinished(job):
+		return ""
+	case job.Spec.Suspend != nil && *job.Spec.Suspend:
+		return executorStateSuspended
+	default:
+		return executorStateRunning
+	}
+}
+
+// isJobOwnedPod reports whether a pod is a Job's child (carries the batch job-name label),
+// distinguishing it from a legacy pre-upgrade raw package pod during the migration window.
+func isJobOwnedPod(pod *corev1.Pod) bool {
+	_, ok := pod.Labels[batchJobNameLabel]
+	return ok
+}
+
 // failureTargetStale reports whether the Job has sat at FailureTarget past the grace window
 // without going terminal; the unreachable-node case.
 func failureTargetStale(job *batchv1.Job) bool {

--- a/operator/internal/controller/metrics.go
+++ b/operator/internal/controller/metrics.go
@@ -36,7 +36,18 @@ const (
 	labelPolicyName      = "policy_name"
 	labelCompartmentName = "compartment_name"
 	labelStrategy        = "strategy"
+
+	// Executor states for skyhook_package_executor_count — the Job-level states a package's
+	// executor can be in, which node State never distinguishes (a suspended Job still reads
+	// in_progress, a parked Job reads erroring). "running" is an unfinished, unsuspended Job;
+	// "suspended" is a paused Job; "parked" is a DeadlineExceeded failure held in place.
+	executorStateRunning   = "running"
+	executorStateSuspended = "suspended"
+	executorStateParked    = "parked"
 )
+
+// executorStates enumerates the executor_state label values, used to zero stale series.
+var executorStates = []string{executorStateRunning, executorStateSuspended, executorStateParked}
 
 var (
 	// skyhook metrics
@@ -88,6 +99,14 @@ var (
 			Help: "Number of restarts for this package on this node",
 		},
 		[]string{labelSkyhookName, labelPackageName, labelPackageVersion},
+	)
+
+	skyhook_package_executor_count = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "skyhook_package_executor_count",
+			Help: "Number of a package's batch/v1 Job executors by executor_state (running, suspended, parked)",
+		},
+		[]string{labelSkyhookName, labelPackageName, labelPackageVersion, "executor_state"},
 	)
 
 	// rollout metrics (per-compartment)
@@ -190,6 +209,10 @@ func zeroOutSkyhookPackageMetrics(skyhookName, packageName, packageVersion strin
 	for _, stage := range v1alpha1.Stages {
 		skyhook_package_stage_count.DeleteLabelValues(skyhookName, packageName, packageVersion, string(stage))
 	}
+
+	for _, es := range executorStates {
+		skyhook_package_executor_count.DeleteLabelValues(skyhookName, packageName, packageVersion, es)
+	}
 }
 
 func ResetSkyhookMetricsToZero(skyhook SkyhookNodes) {
@@ -238,6 +261,18 @@ func SetPackageStageMetrics(skyhookName, packageName, packageVersion string, sta
 
 func SetPackageRestartsMetrics(skyhookName, packageName, packageVersion string, restarts int32) {
 	skyhook_package_restarts_count.WithLabelValues(skyhookName, packageName, packageVersion).Set(float64(restarts))
+}
+
+func SetPackageExecutorMetrics(skyhookName, packageName, packageVersion, executorState string, count float64) {
+	skyhook_package_executor_count.WithLabelValues(skyhookName, packageName, packageVersion, executorState).Set(count)
+}
+
+// ClearPackageExecutorMetrics drops every executor series for a skyhook (all packages, versions,
+// states). recordExecutorMetrics calls it before re-emitting so a (package, version) that no longer
+// runs any Job — an in-place upgrade's old version, or a package removed from spec — is cleared
+// rather than frozen at its last value (the spec-keyed zero loop cannot reach an out-of-spec version).
+func ClearPackageExecutorMetrics(skyhookName string) {
+	skyhook_package_executor_count.DeletePartialMatch(prometheus.Labels{labelSkyhookName: skyhookName})
 }
 
 func SetNodeTargetCountMetrics(skyhookName string, count float64) {
@@ -345,6 +380,7 @@ func init() {
 		skyhook_package_state_count,
 		skyhook_package_stage_count,
 		skyhook_package_restarts_count,
+		skyhook_package_executor_count,
 		skyhook_rollout_matched_nodes,
 		skyhook_rollout_ceiling,
 		skyhook_rollout_in_progress,

--- a/operator/internal/controller/skyhook_controller.go
+++ b/operator/internal/controller/skyhook_controller.go
@@ -953,6 +953,13 @@ func (r *SkyhookReconciler) ReportState(ctx context.Context, clusterState *clust
 	// save updated state to skyhook status
 	skyhook.ReportState()
 
+	// The Job-level executor metrics (running/suspended/parked) can't be derived from node state,
+	// so publish them here from the Skyhook's Jobs. Best-effort: a listing hiccup must not preempt
+	// the reconcile, so log and continue.
+	if err := r.recordExecutorMetrics(ctx, skyhook); err != nil {
+		log.FromContext(ctx).Error(err, "recording executor metrics", "skyhook", skyhook.GetSkyhook().Name)
+	}
+
 	if skyhook.GetSkyhook().Updated {
 		_, errs := r.SaveNodesAndSkyhook(ctx, clusterState, skyhook)
 		if len(errs) > 0 {
@@ -962,6 +969,73 @@ func (r *SkyhookReconciler) ReportState(ctx context.Context, clusterState *clust
 	}
 
 	return false, nil
+}
+
+// recordExecutorMetrics publishes skyhook_package_executor_count from the Skyhook's Jobs. The
+// executor states (running/suspended/parked) are Job-level and invisible to node State — a suspended
+// Job still reads in_progress, a parked one erroring — so this lists Jobs directly rather than
+// deriving from node state like the other package metrics. Every package's series are zeroed first
+// so a state that emptied since the last pass reads 0 rather than a stale value.
+func (r *SkyhookReconciler) recordExecutorMetrics(ctx context.Context, skyhook SkyhookNodes) error {
+	skyhookName := skyhook.GetSkyhook().Name
+
+	// List first: on a transient list error, leave the previous values in place rather than zeroing
+	// them, which would flash a false "0 executors" for a Skyhook that has running work.
+	jobs, err := r.dal.GetJobs(ctx,
+		client.InNamespace(r.opts.Namespace),
+		client.MatchingLabels{fmt.Sprintf("%s/name", v1alpha1.METADATA_PREFIX): skyhookName},
+	)
+	if err != nil {
+		return fmt.Errorf("listing jobs for executor metrics on skyhook %s: %w", skyhookName, err)
+	}
+
+	// Drop every one of this skyhook's executor series so a (package, version) that no longer runs
+	// any Job disappears instead of freezing. Counts key off the Job's annotation version, which
+	// diverges from spec during an in-place upgrade, so a spec-keyed zero loop alone would leak the
+	// old version's series. Re-establish 0 for current spec packages so an idle package reads 0.
+	ClearPackageExecutorMetrics(skyhookName)
+	for _, pkg := range skyhook.GetSkyhook().Spec.Packages {
+		for _, es := range executorStates {
+			SetPackageExecutorMetrics(skyhookName, pkg.Name, pkg.Version, es, 0)
+		}
+	}
+
+	if jobs == nil {
+		return nil
+	}
+	for pkgName, versions := range executorCounts(jobs.Items) {
+		for version, states := range versions {
+			for state, count := range states {
+				SetPackageExecutorMetrics(skyhookName, pkgName, version, state, count)
+			}
+		}
+	}
+	return nil
+}
+
+// executorCounts tallies Jobs into counts[packageName][version][executorState], keyed off each
+// Job's own package annotation. Finished non-parked Jobs (not active executors) and Jobs without a
+// readable package annotation (legacy raw pods have no Job) are skipped.
+func executorCounts(jobs []batchv1.Job) map[string]map[string]map[string]float64 {
+	counts := map[string]map[string]map[string]float64{}
+	for i := range jobs {
+		state := executorState(&jobs[i])
+		if state == "" {
+			continue
+		}
+		pkg, err := GetPackage(&jobs[i])
+		if err != nil || pkg == nil {
+			continue
+		}
+		if counts[pkg.Name] == nil {
+			counts[pkg.Name] = map[string]map[string]float64{}
+		}
+		if counts[pkg.Name][pkg.Version] == nil {
+			counts[pkg.Name][pkg.Version] = map[string]float64{}
+		}
+		counts[pkg.Name][pkg.Version][state]++
+	}
+	return counts
 }
 
 func (r *SkyhookReconciler) UpdatePauseStatus(ctx context.Context, clusterState *clusterState, skyhook SkyhookNodes) (bool, error) {

--- a/operator/internal/controller/swap_test.go
+++ b/operator/internal/controller/swap_test.go
@@ -20,6 +20,7 @@ package controller
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/NVIDIA/nodewright/operator/api/nodewright/v1alpha1"
@@ -389,6 +390,68 @@ var _ = Describe("Jobs execution swap", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(invalid).To(BeTrue())                     // validation marked it invalid...
 			Expect(got.Spec.Suspend).To(HaveValue(BeTrue())) // ...and left suspend untouched
+		})
+	})
+
+	Describe("executor metric classification", func() {
+		It("maps a Job to its executor_state", func() {
+			running := stageJob(v1alpha1.StageApply)
+			Expect(executorState(running)).To(Equal(executorStateRunning))
+
+			suspended := stageJob(v1alpha1.StageApply)
+			suspended.Spec.Suspend = ptr(true)
+			Expect(executorState(suspended)).To(Equal(executorStateSuspended))
+
+			parked := stageJob(v1alpha1.StageApply, batchv1.JobCondition{Type: batchv1.JobFailed, Status: corev1.ConditionTrue, Reason: batchv1.JobReasonDeadlineExceeded})
+			Expect(executorState(parked)).To(Equal(executorStateParked))
+
+			// finished-but-not-parked Jobs are not active executors
+			complete := stageJob(v1alpha1.StageApply, batchv1.JobCondition{Type: batchv1.JobComplete, Status: corev1.ConditionTrue})
+			Expect(executorState(complete)).To(BeEmpty())
+			failed := stageJob(v1alpha1.StageApply, batchv1.JobCondition{Type: batchv1.JobFailed, Status: corev1.ConditionTrue, Reason: "BackoffLimitExceeded"})
+			Expect(executorState(failed)).To(BeEmpty())
+		})
+	})
+
+	Describe("executor metric counting", func() {
+		fooPkg := func(version string) *v1alpha1.Package {
+			return &v1alpha1.Package{PackageRef: v1alpha1.PackageRef{Name: "foo", Version: version}, Image: "ghcr.io/nvidia/skyhook-packages/foo"}
+		}
+		// executorJob builds a Job carrying foo/<version>'s package annotation + name label.
+		executorJob := func(version string, mutate func(*batchv1.Job)) batchv1.Job {
+			job := &batchv1.Job{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "foo-" + strings.ReplaceAll(version, ".", "-") + "-apply", Namespace: namespace,
+					Labels: map[string]string{nameLabel: skyhookName},
+				},
+				Spec: batchv1.JobSpec{Template: corev1.PodTemplateSpec{Spec: corev1.PodSpec{NodeName: nodeName}}},
+			}
+			Expect(SetPackages(job, &v1alpha1.NodeWright{ObjectMeta: metav1.ObjectMeta{Name: skyhookName}}, image, v1alpha1.StageApply, fooPkg(version))).To(Succeed())
+			if mutate != nil {
+				mutate(job)
+			}
+			return *job
+		}
+
+		It("tallies executors per package version (keyed off the Job's annotation), skipping finished Jobs", func() {
+			suspend := func(j *batchv1.Job) { j.Spec.Suspend = ptr(true) }
+			complete := func(j *batchv1.Job) {
+				j.Status.Conditions = []batchv1.JobCondition{{Type: batchv1.JobComplete, Status: corev1.ConditionTrue}}
+			}
+
+			// Two versions coexist during an in-place upgrade — they must count under distinct
+			// versions, and a Complete Job is not an active executor.
+			counts := executorCounts([]batchv1.Job{
+				executorJob("1.0.0", nil),
+				executorJob("1.0.0", suspend),
+				executorJob("2.0.0", nil),
+				executorJob("2.0.0", complete),
+			})
+
+			Expect(counts["foo"]["1.0.0"][executorStateRunning]).To(Equal(1.0))
+			Expect(counts["foo"]["1.0.0"][executorStateSuspended]).To(Equal(1.0))
+			Expect(counts["foo"]["2.0.0"][executorStateRunning]).To(Equal(1.0))
+			Expect(counts["foo"]["2.0.0"]).To(HaveLen(1)) // the Complete Job contributed nothing
 		})
 	})
 })


### PR DESCRIPTION
Recreating #356 


Adds `skyhook_package_executor_count{skyhook_name, package_name, package_version, executor_state}` — a gauge of each package's `batch/v1` Job executors by state. The Jobs model introduced states that node `state` cannot express: a **suspended** executor (Emergency Stop / pause) still reports `state=in_progress`, and a **parked** executor (deadline-exceeded, held as the erroring marker) reports `state=erroring`. This metric surfaces them so operators can alert on frozen or wedged work.

## Shape

- `executor_state ∈ {running, suspended, parked}`. `running` = unfinished, unsuspended Job; `suspended` = paused Job; `parked` = `DeadlineExceeded` failure held in place. Finished non-parked Jobs (Complete, or a Failed-non-deadline backstop) are not active executors and are not counted. Legacy raw pods (migration window) have no Job and are excluded.
- `executorState(job)` checks `isParkedJob` **before** `jobFinished` — a parked Job is terminally Failed but must count as `parked`, not be dropped as finished.
- Emitted from `ReportState` per reconcile (for every Skyhook, incl. paused/disabled) by listing the Skyhook's Jobs from the namespace-scoped informer cache. **Best-effort**: a list error logs and continues rather than preempting reconcile.

## Staleness (the load-bearing bit)

Counts key off each **Job's annotation** version, which diverges from **spec** during an in-place upgrade. So each pass **`DeletePartialMatch`-clears the skyhook's executor series** and re-emits: a `(package, version)` that stops running Jobs — an upgrade's old version, or a package removed from spec — drops out instead of freezing at its last value (which would read as a permanently-wedged executor and slowly leak cardinality). Current spec packages are re-set to 0 so an idle package reads 0, not absent. Listing happens **before** the clear so a transient list error leaves the prior values intact rather than flashing a false `0`. Series are `DeleteLabelValues`-removed when the package/skyhook is removed.

## Verification

- New specs (`swap_test.go`): `executorState` classification (running/suspended/parked/complete→∅/failed-non-deadline→∅), and `executorCounts` version-keying (two versions coexisting during an in-place upgrade count under distinct versions; a Complete Job contributes nothing).
- Controller suite **258**; `make lint` **0 issues**; `gofmt` clean; `go build` clean.
- Adversarial review (opus, xhigh): found one MAJOR — a stale-series leak on in-place upgrade (spec-keyed zero loop vs annotation-keyed count loop) — now fixed by the clear-then-set above; MINOR-1 (list-first) folded in; the version-keying test guards the counting divergence. New pattern called out: `DeletePartialMatch` for per-skyhook metric reset (first use in this package; the existing rollout metrics use per-series `DeleteLabelValues`).

## Docs

`docs/metrics/README.md` documents the new metric and its `executor_state` values.

## Follow-up (not in this PR)

A related `restarts` regression: under `restartPolicy: Never`, the in-flight-erroring path (`jobPodReconcile`) records pod `RestartCount`=0, so `skyhook_package_restarts_count` under-reports for an actively-erroring package. Note that `JobReconcile`'s completion/erroring paths already record `job.Status.Failed`; only the in-flight pod path is affected. Scoped separately.
