### PR TITLE
chore(skills): add nodewright-cross-review multi-agent review skill

### DIFF
--- a/.claude/skills/nodewright-cross-review/SKILL.md
+++ b/.claude/skills/nodewright-cross-review/SKILL.md
@@ -1,0 +1,869 @@
+---
+name: nodewright-cross-review
+description: |
+  Multi-agent review of a NodeWright/Skyhook change using Claude Code, Codex,
+  and CodeRabbit. Runs parallel reviews with integration impact analysis, then
+  one cross-review round to a 2-of-3 consensus, with every confirmed finding
+  adversarially verified by a fresh agent. Reviews a PR by number, the PR for
+  the current branch, or a branch that has no PR yet. Never runs the reviewed
+  commit's code, and posts only when asked, as a pending draft review that a
+  human submits. Use when asked for a thorough cross-review or multi-reviewer
+  analysis. Requires the Codex plugin;
+  CodeRabbit is best-effort. Claude Code only: uses the Workflow and Agent
+  tools, which are not available in other agents.
+user-invocable: true
+# Reviewer lanes must not reach a skill that posts. code-review permits `gh pr comment`
+# and the CodeRabbit skill auto-triggers on review tasks, so denying Skill closes the
+# automatic path that removing the explicit nested call did not.
+disallowed-tools: Skill
+argument-hint: "[PR-number-or-URL] (omit to review the current branch)"
+version: 0.1.0
+---
+
+# NodeWright Cross-Review: Multi-Agent Review with Consensus
+
+Three reviewers (Claude Code, Codex, CodeRabbit) plus a targeted integration impact
+analysis, cross-reviewed to 2-of-3 consensus, with every confirmed finding
+adversarially verified by a fresh agent. Orchestration runs as a **Workflow**
+(`scripts/workflow.mjs`).
+
+**Claude Code only.** If the `Workflow` tool is unavailable, stop and say why. Do not
+fall back to another review command. `/code-review` in particular posts its result to
+the PR (see Phase 2), which this skill never does without an explicit request.
+
+**When in doubt, stop.** Every check below either passes or ends the review with an
+explanation. The skill never executes the reviewed commit's code, and never posts to
+the PR unless you explicitly ask (Phase 5).
+
+**Provenance.** Derived from the `aicr-cross-review` skill in `NVIDIA/aicr`, which is
+where the consensus mechanics and the operational notes below were worked out. Claims
+in this file marked "measured" were measured *there*, against the same CLIs on the same
+machine, and have not been re-measured against this repo. The repository-specific parts
+(review focus, integration surfaces, PR classification, the repo context handed to every
+lane) are new here. The generic multi-mode `cross-agents:cross` plugin is a separate,
+earlier lineage; this skill is not built on it.
+
+## Input
+
+Raw arguments: `$ARGUMENTS`
+
+`$ARGUMENTS` is **optional**. It selects one of three modes, resolved in Phase 0:
+
+| `$ARGUMENTS` | Mode | What is reviewed |
+| --- | --- | --- |
+| A PR number or URL | `pr` | That PR's head commit on `NVIDIA/nodewright` |
+| Empty, current branch has a PR | `pr` | That PR's head commit |
+| Empty, current branch has no PR | `local` | The committed work on the branch, against its merge-base with the PR base branch |
+
+Validate the argument's *shape* in Phase 0 first, and reject a URL for another
+repository. Then pass the validated value to `gh` **unchanged**: `gh` accepts a bare
+number or a pull URL directly, so nothing needs rewriting. What is prohibited is
+transforming the value, not checking it.
+
+**Uncommitted work is never reviewed, in either mode.** Every lane reads a diff pinned to
+a commit, and the CodeRabbit lane is explicitly forbidden from `-t uncommitted`; a dirty
+tree would hand each lane a different view of the code. If the branch has uncommitted
+changes you want reviewed, commit them first and re-run.
+
+## Phase 0: Pre-flight and mode resolution
+
+Only the required lanes are hard requirements. Claude, Codex and integration analysis
+must work; if one fails at runtime the review reports `incomplete` and stops.
+CodeRabbit is best-effort: a missing or unauthenticated CLI is not an error, its vote
+slot just records `NONE`.
+
+```bash
+for tool in gh git; do
+  which "$tool" >/dev/null || { echo "$tool not found — install it and retry."; exit 1; }
+done
+# `find`, not a bare glob. The `||` branch DOES fire on an unmatched glob under zsh, so
+# the remedy below still prints — but the `2>/dev/null` cannot suppress zsh's own
+# "no matches found", because that error comes from expansion and `ls` never runs to own
+# the redirection. The result is a confusing shell error immediately above the real
+# message, in exactly the case this check exists for. `find` prints nothing and exits 0,
+# which is why the CodeRabbit lane already uses it for its own directory sweep.
+[ -n "$(find ~/.claude/plugins/cache/openai-codex/codex \
+          -path '*/scripts/codex-companion.mjs' -print -quit 2>/dev/null)" ] \
+  || { echo "Codex companion not found. Install the Codex plugin (Settings → Extensions → Codex)."; exit 1; }
+echo "Pre-flight OK."
+```
+
+If either check fails, stop and report which tool is missing. Do not fall back to
+another review command.
+
+**Resolve the mode, before anything else needs it.**
+
+Every `gh` call and the ref fetch are scoped to `NVIDIA/nodewright` **literally**, written
+out in each command. Two reasons: a contributor PR arrives from a fork, which has neither
+the PR nor `refs/pull/*`; and a shell variable would not survive anyway, since each Bash
+call is a fresh shell.
+
+**Validate `$ARGUMENTS` yourself before it reaches a shell.** It is a template
+placeholder the harness substitutes textually, not a shell variable, so shell quoting is
+not by itself a defense: by the time the shell parses the command the value is already
+part of the source text, and a value containing `;`, a backtick or `$(...)` is executed.
+Accept exactly two shapes and stop on anything else:
+
+- a bare PR number: digits only
+- a pull URL **for this repository**: `https://github.com/NVIDIA/nodewright/pull/<digits>`
+
+Reject a URL naming any other owner or repository rather than passing it through. Every
+later command in this skill is scoped to `NVIDIA/nodewright` literally, so a URL for a
+different project would either fail confusingly or resolve against the wrong repository.
+
+Pass the validated value to `gh` **unchanged**. Do not normalize a URL into a number or a
+number into a URL: `gh` accepts either form, and a rewrite is a transformation that can
+only introduce a mistake.
+
+Then run one of these two forms, substituting the validated value literally. Do not
+build a single command with an empty argument in it: `gh pr view ""` passes an empty
+positional and breaks the current-branch resolution the no-argument mode depends on.
+
+```bash
+# With a validated argument:
+gh pr view <validated-value> --repo NVIDIA/nodewright \
+  --json number,title,body,baseRefName,headRefName,headRefOid,files
+
+# With no argument (resolves the PR for the checked-out branch):
+gh pr view --repo NVIDIA/nodewright \
+  --json number,title,body,baseRefName,headRefName,headRefOid,files
+```
+
+- **It succeeds** (with or without an argument): mode is `pr`. Take `<n>` = `.number` and
+  use that numeric value for every later temp path, scoped ref name and `gh` call, never
+  the raw argument. Keep the rest of the response; Phase 1 does not re-fetch it.
+- **It fails and `$ARGUMENTS` was non-empty**: stop. A bad PR reference is a typo, not a
+  reason to silently review something else.
+- **It fails and `$ARGUMENTS` was empty**: mode is `local`. Confirm you are on a branch
+  with commits of its own before continuing:
+
+  ```bash
+  git -C "<repo-path>" rev-parse --abbrev-ref HEAD    # not "HEAD" (detached) and not "main"
+  git -C "<repo-path>" rev-parse HEAD
+  ```
+
+  If the branch is `main`, or detached, or has no commits beyond the base, stop and say
+  so. There is nothing to review and no sensible base to diff against.
+
+**Self-review guard.** In `pr` mode, from the `files` list just fetched: if any changed
+path is under `.claude/skills/nodewright-cross-review/`, **stop**. The scripts you would
+execute are the ones under review. Ask for a trusted checkout. In `local` mode, run the
+same check against `git diff --name-only <base>...HEAD`. This catches the accidental case
+only; `SKILL.md` lives inside the reviewed repo, so it is not a security boundary.
+
+## Phase 1: Setup
+
+**Batch A, one parallel message:**
+
+1. Pin `HEAD_SHA`. In `pr` mode that is `headRefOid` from the Phase 0 response; in
+   `local` mode it is the `git rev-parse HEAD` above. Every reviewer reviews this exact
+   commit. `<n>` is already resolved in Phase 0; do not re-fetch.
+2. Worktree hygiene: `git worktree prune`, then `git worktree list | wc -l`. If the
+   count still exceeds ~15, **stop** and ask the user to clean up before retrying.
+   Do not remove worktrees yourself: a clean detached-HEAD worktree may be another
+   session's active review, and this repo keeps long-lived worktrees under
+   `.claude/worktrees/`. (Each worktree adds sandbox deny-list paths; at ~70 the profile
+   exceeded the OS spawn-arg limit and every sandboxed Bash call failed with `E2BIG`.
+   Recovery needs a fresh session.)
+
+**Batch B, after A** (needs `HEAD_SHA` and the base branch name). `gh pr diff` takes no
+SHA argument, so pin the diff with `git fetch`. Refs and the diff file are
+**session-scoped**: two sessions reviewing the same change must not share, overwrite, or
+delete each other's pinned input.
+
+In `pr` mode:
+
+```bash
+set -euo pipefail   # a failed fetch or diff must abort, not leave an empty diff file
+BASE="<baseRefName>"                    # from Phase 0 — never hardcode "main"
+DIFFPATH=$(mktemp "${TMPDIR:-/tmp}/nw-cross-review-pr<n>.XXXXXX")   # must end in X on macOS
+SID=${DIFFPATH##*.}                     # reuse mktemp's unique suffix to scope the refs
+PRREF="refs/cr/pr<n>-$SID"; BASEREF="refs/cr/base<n>-$SID"
+# Echo the names BEFORE the first command that can fail, not merely before the diff.
+# mktemp has ALREADY created the file, and a partial fetch can create $PRREF and then
+# fail on $BASEREF (e.g. the base branch no longer exists on the canonical repo). Under
+# `set -e` an echo placed after either one never runs, leaving a temp file and a ref
+# whose random suffix nobody recorded and Phase 5 cannot clean up.
+echo "DIFFPATH=$DIFFPATH"; echo "PRREF=$PRREF"; echo "BASEREF=$BASEREF"
+# Fetch from the canonical repo by URL, not from `origin`: a contributor PR lives on a
+# fork, and refs/pull/* exist only on the canonical repository.
+git -C "<repo-path>" fetch "https://github.com/NVIDIA/nodewright.git" \
+  "+refs/pull/<n>/head:$PRREF" "+refs/heads/$BASE:$BASEREF"
+# Head moved → stop. Clean the refs we just created before exiting; set -e would
+# otherwise abort before the names are ever printed, leaving them unreclaimable.
+if [ "$(git -C "<repo-path>" rev-parse "$PRREF")" != "<HEAD_SHA>" ]; then
+  git -C "<repo-path>" update-ref -d "$PRREF"; git -C "<repo-path>" update-ref -d "$BASEREF"
+  rm -f "$DIFFPATH"; echo "HEAD moved since setup — restart the review"; exit 1
+fi
+git -C "<repo-path>" diff "$BASEREF...$PRREF" > "$DIFFPATH"
+test -s "$DIFFPATH"                     # a real PR diff is never empty
+# repoNotes source, pinned to the BASE ref — a fork PR must not be able to rewrite
+# the instructions fed to the reviewer.
+git -C "<repo-path>" show "$BASEREF":.claude/CLAUDE.md
+# BASE_SHA is the base branch tip. Its only consumer is CodeRabbit's --base-commit,
+# and the CLI resolves the merge-base itself, so this stays consistent with the
+# three-dot diff above without a second baseline to keep in sync.
+echo "BASE_SHA=$(git -C "<repo-path>" rev-parse "$BASEREF")"
+```
+
+In `local` mode the shape is identical; only the head side changes. There is no
+`refs/pull/*` to fetch, so the head is the local commit and only the base is fetched.
+The base is still fetched **from the canonical URL**, not from `origin`, and the notes are
+still read from the fetched base ref rather than the working copy. That is deliberate: it
+keeps one code path correct instead of two, and it means a local branch that has quietly
+edited `.claude/CLAUDE.md` cannot rewrite the instructions its own review runs under.
+
+```bash
+set -euo pipefail
+BASE="main"                             # or the branch this work is intended to merge into
+DIFFPATH=$(mktemp "${TMPDIR:-/tmp}/nw-cross-review-local.XXXXXX")
+SID=${DIFFPATH##*.}
+BASEREF="refs/cr/base-local-$SID"
+# Same rule as the pr block: echo before the fetch, not after it.
+echo "DIFFPATH=$DIFFPATH"; echo "BASEREF=$BASEREF"
+git -C "<repo-path>" fetch "https://github.com/NVIDIA/nodewright.git" "+refs/heads/$BASE:$BASEREF"
+git -C "<repo-path>" diff "$BASEREF...<HEAD_SHA>" > "$DIFFPATH"
+test -s "$DIFFPATH"                     # empty means the branch has no committed work
+git -C "<repo-path>" show "$BASEREF":.claude/CLAUDE.md
+echo "BASE_SHA=$(git -C "<repo-path>" rev-parse "$BASEREF")"
+# Report but do not review: uncommitted changes are outside the pinned commit.
+git -C "<repo-path>" status --porcelain
+```
+
+If `git status --porcelain` is non-empty, say so in the final report: the reviewers saw
+the committed work only, and the dirty files are named so the reader knows what was not
+covered.
+
+Capture `DIFFPATH`, `BASE_SHA`, `BASEREF` and (in `pr` mode) `PRREF`. Shell variables do
+not persist between Bash calls and Phase 5 needs the ref names.
+
+Then build `repoNotes` for the Claude reviewer only (never fed to Codex, per the
+lean-context rule): distill the base-pinned `.claude/CLAUDE.md` plus any local overlay
+into 3 to 6 lines of the rules most likely to catch defects in the changed paths. The
+workflow already hands every lane a standing repository-context block (components,
+the partial Skyhook to NodeWright rename, the Status/State/Stage distinction, the
+vendored and generated trees to skip), so `repoNotes` should carry what is specific to
+*this* change, not repeat that.
+
+Note that the repo's root `AGENTS.md` is a symlink to `.claude/CLAUDE.md`, so there is one
+file here, not two.
+
+The check below reduces accidental exposure, but it is **not a trust boundary**:
+reviewer subagents load the checkout's `CLAUDE.md` hierarchy automatically, before any
+guard here runs. Treat `repoNotes` as a relevance digest, not a sanitiser.
+
+**For an untrusted or fork PR, run this skill from a session started in a trusted
+checkout**, the same operational remedy as the self-review guard in Phase 0. Git
+overwrites *ignored* files during checkout without complaint, so checking out a fork
+that force-added an ignored overlay silently replaces yours.
+
+```bash
+for f in AGENTS.local.md CLAUDE.local.md .claude/CLAUDE.local.md; do
+  [ -e "<repo-path>/$f" ] || continue
+  # Skip symlinks first. The tracked-status check applies to the link, not its target,
+  # so an untracked symlink pointing at a PR-tracked file would otherwise be reported
+  # TRUSTED while resolving to PR-controlled instructions.
+  [ -L "<repo-path>/$f" ] && { echo "SKIP $f — symlink"; continue; }
+  if git -C "<repo-path>" ls-files --error-unmatch -- "$f" >/dev/null 2>&1; then
+    echo "SKIP $f — tracked by this change, not a trusted local overlay"
+  else
+    echo "TRUSTED $f"      # regular untracked file: safe to read
+  fi
+done
+```
+
+Read only the paths reported `TRUSTED`.
+
+## Phase 1.5: Classify and extract the change list
+
+**Classify** the change: `code-change` | `design-doc` | `config-change` |
+`documentation-only`. `design-doc` covers `docs/designs/` and `docs/plans/`;
+`config-change` covers `chart/`, `operator/config/`, `.github/workflows/` and similar
+when no Go or Python behavior changes with them.
+
+**Extract a bounded change list** so integration analysis verifies specific items
+instead of fishing across a repo with two vendored trees in it:
+
+- Exported Go functions, types, constants, and interfaces added, removed, or modified
+- CRD fields and kubebuilder markers under `operator/api/`
+- Annotation, label, taint, and finalizer keys (`nodewright.nvidia.com/*`,
+  `skyhook.nvidia.com/*`), and any `nodeState_*` shape change
+- Status, State, or Stage values added, removed, or renamed
+- Helm values and template keys (`chart/values.yaml`, `chart/templates/`) and their
+  `operator/config/` counterparts
+- CLI commands and flags under `operator/cmd/cli/`
+- Agent package-config keys and `agent/skyhook-agent/.../schemas/` changes
+- Workflow inputs and triggers under `.github/workflows/`; Makefile and `*.mk` targets
+- File or manifest paths renamed or restructured
+- Behaviorally significant defaults changed (timeouts, requeue intervals, image tags,
+  versions, namespaces, interruption-budget defaults)
+
+> **This skill never runs the PR's code.** No build, test, generator, coverage, or
+> `make` target; every reviewer prompt forbids it. Only trusted tools run (`git`, `gh`,
+> the CodeRabbit CLI, the Codex companion). If a reviewer suspects generated-artifact
+> drift, that is reported as a finding against the diff, not settled by running
+> `make manifests generate`. CI is what actually runs things; see Phase 3.
+
+## Phase 2: Run the review workflow
+
+```
+Workflow({
+  scriptPath: "<skill-dir>/scripts/workflow.mjs",
+  args: {
+    mode: "pr" | "local",
+    pr: <number>,                       // omit in local mode
+    branch: "<branch name>",            // local mode; harmless in pr mode
+    repo: "NVIDIA/nodewright",
+    repoPath: "<local checkout path>",
+    headSha: "<HEAD_SHA>",
+    baseSha: "<BASE_SHA>",
+    diffPath: "<DIFFPATH>",
+    prType: "<classification>",
+    changeList: ["<item 1>", "<item 2>"],
+    repoNotes: "<3-6 line digest, optional>"
+  }
+})
+```
+
+Pass `changeList` as a real JSON array, not a stringified one. Every lane is
+`general-purpose` and inherits the session model, so there is no model argument to pass.
+
+`mode` defaults to `pr`, and `pr` is required in that mode; the script rejects the
+combination rather than guessing. Everything downstream of the header is mode-independent
+by design: both modes pin a commit and hand every lane the same saved diff, so there is
+one consensus path to keep correct rather than two.
+
+**What the workflow does** (`scripts/workflow.mjs` is the single source of truth for
+the consensus mechanics):
+
+- **Review** — Claude Code (reviews the pinned diff directly; it deliberately does
+  *not* delegate to the `code-review` command, whose step 8 instructs its agent to
+  `gh pr comment` the result back to the PR), Codex (background dispatch, a 9-min
+  bounded wait plus one continuation wait when the job is still running, about 18 min
+  for a live job), CodeRabbit (CLI against a detached worktree at `HEAD_SHA`, explicit
+  600000 ms timeout; the Bash tool caps any single call at 10 minutes, which is why
+  Codex exceeds it by waiting twice rather than waiting longer), and integration
+  analysis (bounded to `changeList`). Every lane is a `general-purpose` agent. All
+  parallel, schema-validated, and none may execute the reviewed commit's code.
+- **Repo context** — every lane receives a standing block naming the three components,
+  the partial Skyhook to NodeWright rename (a mixed vocabulary is expected and is not a
+  finding), the Status/State/Stage distinction (using one for another *is* a finding),
+  the vendored and generated trees not to review, the `zz.migration.*.go` exception, and
+  the pathspec that excludes `operator/vendor` and `agent/vendor` from repo-wide greps.
+  Most of that block removes work rather than adding it, which is why it is affordable
+  even in the context-starved Codex lane.
+- **Merge** — dedupe by `path:line:normalized-summary:consumerPath:consumerLine`;
+  duplicates merge to the highest severity and union their sources; a finding citing a
+  file the reporter never listed in `filesChecked` is flagged for extra scrutiny.
+
+  **Two lanes wording one defect differently stay separate candidates, by design.** Keying
+  on location alone was tried and reverted: it did merge those duplicates, but the
+  evaluation schema permits exactly one verdict per candidate id, so a merged pair of
+  *distinct* same-line defects has no correct verdict. Confirming the real one also
+  confirms the false one, and refuting the false one dismisses the real one. Retaining
+  both summaries prevented data loss but not mis-adjudication, which is the worse failure.
+
+  Instead, candidates sharing a location (`path:line` **and** the same
+  `consumerPath`/`consumerLine`) are **flagged** as possible duplicates. The consumer half
+  matters: one changed declaration breaking two callers is deliberately two candidates, and
+  hinting that they might be duplicates would push reviewers to collapse a distinction the
+  key exists to preserve. The flag reaches the cross-review candidate list and the refuter
+  prompt, so reviewers decide whether the two are one defect and evaluate them
+  consistently. Equivalence stays an explicit judgement rather than an assumption from a
+  shared line number.
+
+  Merging also stops once candidates are presented: a late finding that merged into an
+  already-evaluated id would inherit votes cast before it existed. Late findings always
+  become their own candidate and, being unpresented, stay contested for the human.
+
+- **Cross-review (one round, Claude + Codex only)** — each re-reviews independently
+  first (anti-anchoring), then returns AGREE/DISAGREE/OPEN_QUESTION per candidate.
+  CodeRabbit does *not* take part: its CLI is a slow blocking cloud call and it
+  reviews Git changes generically, so it cannot adjudicate our candidate ids and a
+  second run over the same commit adds no signal. Its round-1 findings still stand as its
+  AGREE votes, so it can still corroborate a split it independently reported. Anything
+  still split afterwards is reported as contested for you to settle.
+- **Consensus rule** — confirmed = 2 of the 3 reviewer slots AGREE **with evidence**;
+  integration analysis is never a reviewer slot. A round-1 finding whose evidence is
+  blank or whitespace-only is dropped at intake, so it never registers its reporter as
+  a source. In the cross-review round an unevidenced AGREE/DISAGREE instead aborts the
+  run (`incomplete`), because dropping it would leave the reviewer's round-1 source vote
+  to decide the tally.
+- **Verify** — every confirmed finding goes to a fresh adversarial refuter
+  (REFUTED → dismissed; UNVERIFIABLE, no result, or a verdict without a citation →
+  the `unresolved` array). `consensusReached` is true only when both `contested` and
+  `unresolved` are empty: a finding that reached consensus but failed verification is
+  an open question, not a settled one.
+
+  **Read `adjudication` on every contested entry.** The bucket holds two different states
+  and they need different things from you. `evaluated` means the finding was presented,
+  the reviewers voted, and they did not reach 2-of-3: a genuine split, so break the tie.
+  `raised-late` means it was raised *during* the cross-review round, after candidates were
+  presented, so nobody cross-evaluated it and its only position is its reporter's; it just
+  needs reading. Measured on a real run: 8 of 8 contested findings were `raised-late`, each
+  with a single AGREE and NONE elsewhere, so the count read as eight disagreements when
+  there were none. `consensusReached` counts both, deliberately: a late finding is
+  unadjudicated, and letting it report consensus would be the same overstatement this
+  skill exists to avoid.
+- **Report incomplete and stop** — Claude, Codex and integration analysis are required
+  in round 1, and Claude and Codex must each return exactly one evaluation per
+  candidate in the cross-review round. A missing lane, a missing evaluation, a
+  duplicate, or an unknown candidate id returns `status: "incomplete"` with the reason
+  and raw unverified findings. There is no degraded-consensus mode. CodeRabbit is the
+  only best-effort lane: when it does not run, its vote slot records `NONE`, which
+  raises the bar (Claude and Codex must then agree) rather than lowering it.
+
+  One deliberate exception, at the level of a **finding** rather than a lane. An
+  integration finding claims a specific consumer breaks, so one lacking
+  `consumerPath`/`consumerLine` cannot be verified and never enters consensus; it is
+  dropped on its own, with a `log()` naming what went, rather than failing the run. The
+  earlier all-or-nothing rule was disproportionate: on a real run the lane returned
+  several findings, one of them a genuine evidenced defect, plus a stale-comment finding
+  that legitimately has no consumer, and the review reported `incomplete` with all four
+  lanes `ok` and no report produced. The run still stops when **every** integration
+  finding is unusable, which is the case that motivated the check: silently dropping the
+  lane's only finding once yielded `consensusReached: true` while a required lane had
+  contributed nothing.
+
+  "Unusable" is measured on what survives `intake()`, not on the coordinate check alone.
+  `intake()` independently drops a finding whose `evidence` is blank, so gating on
+  coordinates let a coordinate-complete, whitespace-evidence finding pass the filter and
+  then vanish inside `intake()`: zero candidates, `status: ok`, `consensusReached: true`.
+  That is the same false-clean, in a narrower form. One rule now covers both drop reasons:
+  a non-empty integration result that yields no accepted finding stops the run, and the
+  message says how many went for each reason.
+
+  **Coordinates are validated by a single shared rule**, `hasCoords`, applied to a
+  finding's own `path`/`line` in `intake()` (every lane, not just integration) and to
+  `consumerPath`/`consumerLine` for the integration pair. The response schema **requires**
+  `path` and `line` and leaves `consumerPath`/`consumerLine` optional, deliberately, since
+  only integration findings carry a consumer, but it constrains none of the four, so
+  `""`, `"   "`, `0` and `-1` all satisfy it and all passed a truthiness/null check.
+  Tightening the schema instead would fail a whole lane on one bad field, which is the
+  all-or-nothing behavior this section exists to remove. It is one helper rather than two
+  call-site conditions for a specific reason: every earlier version of this guard fixed the
+  pair it was shown and left the other, and a shared rule is what stops the next field pair
+  from repeating that.
+
+  **The zero-survivor rule applies to every required round-1 batch**, not just integration.
+  Claude's and Codex's round-1 findings go through `intakeBatch`, which reports what
+  survived. A required lane whose round-1 findings are *all* malformed contributed
+  nothing, and letting them vanish silently is the same false-clean one lane over. Mixed
+  batches still proceed. CodeRabbit is exempt: a total loss there records `NONE` and
+  raises the bar, exactly as a lane that never ran. Rejection reasons are counted
+  separately (`unlocatable` vs `unevidenced`) rather than inferred from a subtraction, so
+  the message names the defect the reader should go looking for.
+
+  **It deliberately does NOT apply to cross-review `newFindings`.** Those go through the
+  same `intakeBatch` gate, so a malformed late finding still never enters the tally, but a
+  total loss there is not fatal. The rule tests "this lane contributed nothing", which
+  round 1 can assert because findings are the lane's whole output. In the cross-review
+  round the lane's output is its *evaluations*, and the completeness gate has already
+  returned `incomplete` unless the lane evaluated every presented candidate; `newFindings`
+  are supplementary and volunteered. Aborting there would throw away a full set of
+  adjudications and the verification round over one imprecise extra finding: the same
+  disproportionate total loss seen once before, one round over. Malformed late findings are
+  dropped individually and each drop is logged with its reason.
+
+**Operational notes:**
+
+- The workflow runs in the background; wait for its completion notification.
+- If it dies mid-run, **resume, don't restart**:
+  `Workflow({scriptPath: ..., resumeFromRunId: "<wf_...>"})`. Completed lanes replay
+  from cache. Empty or odd result → read `<transcriptDir>/journal.jsonl` first.
+- The Codex lane fails in three distinct ways, and the dispatch protocol treats them
+  differently:
+  - **Lookup miss** — the status call exits 1 with empty stdout and `No job found` on
+    stderr. Companion state is keyed by workspace root and each Bash call is a fresh
+    shell, so an unpinned lookup resolves to a different workspace and reports a live job
+    as unknown; the miss is **not** evidence the job died. **Always recheck exactly once**
+    with `--cwd` pinned, whether or not the missing call already carried it: two causes
+    produce the identical message and only one is settled by adding the flag. The other is
+    transient. In companion v1.0.2 `saveState` writes `state.json` with a plain
+    `fs.writeFileSync` (truncate-then-write, no temp-and-rename) while `loadState` wraps
+    `JSON.parse` in a bare `catch` returning the **default** state, whose `jobs` list is
+    empty. A read landing inside that write window yields a well-formed `No job found`
+    rather than an error, and the background worker is rewriting that file precisely while
+    the status call runs. So an identical repeat need not return an identical answer. Once
+    a pinned recheck has also missed, return `unavailable` saying the job could not be
+    located. Never re-dispatch (the original may still be running) and never record it as
+    exhausted budget.
+  - **Fast transient failure** — retried **once**, and only when all three hold:
+    `.job.status` is `failed` (never `cancelled`), the job died in **under 60 seconds**
+    by its own timestamps, and the error names a known-retryable cause such as an upstream
+    capacity rejection (`Selected model is at capacity`) or a transient dispatch fault.
+    The threshold is a number rather than a judgment because the observed cases are far
+    apart (a capacity rejection at ~10s against a genuine timeout at 10m19s), and an
+    undefined "quickly" is how a one-retry budget erodes. A retry then costs seconds and
+    these clear on their own. **`cancelled` is never retried**: the companion emits it only
+    for explicit cancellation, so a retry would restart work someone deliberately stopped.
+    Nor is a late failure: `.waitTimedOut` false only means the job became terminal before
+    the inner deadline, which a failure at 8:59 also satisfies while having burned the
+    whole window. An unrecognised error is not assumed retryable either.
+  - **Wait elapsed, job still alive** (`.waitTimedOut` true with `.job.status` still
+    `queued`/`running`) — not the end of the lane. The job is dispatched in the background
+    and outlives the Bash call waiting on it, so it needs more **time**, not another
+    attempt, and the protocol gives it exactly that: **one continuation wait** on the
+    *same* job id in a fresh call. That is not a retry; nothing is re-dispatched and no
+    work is duplicated. A second `.waitTimedOut` is then genuinely exhausted budget, and
+    the lane returns `unavailable` with the job id so the result can be fetched later.
+    Measured on a real run: the lane timed out at the full 540000 ms while the job was
+    demonstrably mid-work, the job was **still** `running` long after the review was
+    abandoned, and its result stayed retrievable, so reporting exhausted budget there
+    discarded a required lane, and the whole review with it, over a job that had merely
+    not finished.
+  - **Exhausted budget** — a second `.waitTimedOut`, or no parseable JSON at all because
+    the outer timeout killed the call (a dead broker). No retry, no further wait.
+
+  The ceiling is not tunable: the wait runs inside a Bash call, and that tool silently
+  kills any foreground command at 600000 ms. Exceeding 10 minutes requires polling across
+  several calls, which is exactly what the continuation wait above does; a live job gets
+  two waits, roughly eighteen minutes, without a longer single call. The inner wait is
+  therefore 540000 ms, deliberately **below** the outer cap: were the two equal, Bash could
+  kill the command before it printed its JSON, leaving no `.waitTimedOut` to classify on.
+  That is why an unclassifiable kill counts as exhausted-budget rather than a fast failure;
+  guessing wrong there costs another full window for nothing.
+- Codex is required, so a lane that is still unavailable after its retry makes the run
+  report `incomplete`; re-run rather than interpreting a partial result.
+- CodeRabbit slow runs: check the newest file in `~/.coderabbit/logs/` (429/queue lines
+  mean cloud-side queueing) and confirm `which -a coderabbit` resolves to the
+  brew-managed binary; a stale `~/.local/bin` copy shadows it.
+- **A sandboxed CodeRabbit run hangs instead of failing.** `~/.coderabbit` is outside the
+  sandbox write allowlist, so the CLI cannot create its log or review store; it stalls at
+  `connecting_to_review_service` until the timebox kills it. The lane therefore runs the
+  `coderabbit` command with sandbox bypass, and only that command.
+
+  **Why bypass rather than an allowlist entry.** Adding `~/.coderabbit` to the sandbox
+  write allowlist is the narrower grant and was considered first. It was rejected because
+  this skill is checked into the repo and has to work on a contributor's machine as
+  written: an allowlist entry lives in each person's local settings, so anyone who has not
+  made the same edit gets the silent ten-minute hang above rather than a usable lane. The
+  bypass is portable and self-documenting at the call site. Its cost is a permission
+  prompt on step 2 of every round, which is accepted. Adding the allowlist entry locally
+  is still worthwhile if you run this often (it does not conflict with the bypass), but
+  the skill must not depend on it.
+
+  **Diagnose it by absence:** a stall at `connecting` *with no new file in
+  `~/.coderabbit/logs/`* is sandbox denial. A process killed mid-run still flushes a
+  partial log, so zero bytes means it never created one. A real cloud problem leaves a log
+  with 429/queue lines. Do not read this stall as an outage or as contention with another
+  session: an unsandboxed run succeeding while a sandboxed one hangs looks exactly like
+  contention and is not.
+- **Persisted-store fallback.** If a run still fails, the lane checks
+  `~/.coderabbit/reviews/*/*/reviews/*/git.json`, whichever session produced the record.
+  Acceptance is `head` plus **the pinned change itself**, never `baseCommitId`. Measured:
+  the CLI writes `baseCommitId` from the base it resolves locally in that working
+  directory, not from the `--base-commit` the lane passes. In one real store the same head
+  carried two different values (a main tip, and a commit not on main at all), while three
+  other valid records carried the stale local `main` rather than the base Phase 1 fetched
+  from the canonical repo. Gating on equality discarded good reviews whenever the local ref
+  lagged, which is the common case for a fork PR. `baseCommitId` is now reported in
+  `statusNote` and never branched on.
+
+  What identifies the review instead is the **blob OIDs the record already stores**.
+  Acceptance is layered, cheapest first, and only the last step is identity:
+
+  1. Same paths, from `git diff --numstat -z` over the **three-dot** range Phase 1 saved.
+     Two-dot would compare the base tip to the head and pull in everything that landed on
+     the base after branching; on a real pair, 13 files against the valid record's 59.
+     `-z` matters independently: a plain `split()` shreds a path containing a space into
+     separate members and would reject every record for such a PR.
+  2. Same per-file line counts, against the record's `linesAdded` / `linesRemoved`.
+  3. The committed-only `lanes` shape.
+  4. The **file modes and blob OIDs** the record's own patch states, equal to what
+     `git diff --raw --no-abbrev` reports for the pinned range.
+
+  Steps 1 and 2 are a prefilter, never a result: two different patches collide on a
+  numstat trivially. A `beta`→`BETA` edit and a `gamma`→`GAMMA` edit in the same file both
+  report one added and one removed, and a review of this head against another base can
+  leave exactly such a record.
+
+  Step 4 compares OIDs rather than the stored patch text, which was the obvious move and
+  is wrong. Bare `git diff` output moves with the reader's gitconfig (measured: the text
+  differs under `diff.noprefix` and `diff.context`, and fails outright under
+  `diff.external`), so a contributor with ordinary settings gets a permanent mismatch and
+  this fallback silently never fires. That is the same works-on-my-machine class the
+  sandbox decision rejected an allowlist for. Pinning flags (`--no-ext-diff`, `--no-color`,
+  `-U3`, `--src-prefix`) fixes *our* side only; if the CLI produced the record under that
+  same config, hardening makes the mismatch worse. Blob OIDs are content hashes: stable on
+  both sides, and exact content identity rather than a rendering of it. Both git calls
+  still pass `--no-ext-diff --no-color`, since the `--raw` call needs them.
+
+  **Modes are checked before OIDs, because OIDs alone are not identity.** With a `chmod +x`
+  in one commit and an edit in the next, a stored review of the *edit alone* carries the
+  same path, counts, `lanes` and **both** blob OIDs as the pinned range covering both
+  changes (verified). Only the modes differ: pinned `100644 → 100755` against the record's
+  `100755 → 100755`. Git states modes in one of four shapes (`old mode`/`new mode`,
+  `new file mode`, `deleted file mode`, or the trailing mode on the `index` line), and the
+  trailing mode is absent exactly when the `old`/`new` pair is present, so the cases do not
+  overlap. A record that states no mode at all cannot prove identity and is skipped. This
+  repo ships executable scripts under `scripts/` and `k8s-tests/`, so a `chmod` landing in
+  a range is not hypothetical here.
+
+  An entry with **no** `index` line is not automatically rejected. Git omits that line
+  exactly when the blob is unchanged: for a `chmod +x` the mode lines carry the
+  information instead, and the mode check above has already matched them. Such an entry is
+  accepted when the pinned diff agrees the blob is unchanged (`src == dst`), and rejected
+  as `no-index-line` otherwise. Rejecting on sight would have disabled this fallback for
+  any change that merely marks a script executable. A rename or copy in the pinned range is
+  rejected outright as `rename-unverifiable`, by an explicit status check rather than
+  incidentally: the record is keyed on the post-rename path and carries no source path, so
+  an edit-only review of that path is indistinguishable from one that covered the rename
+  (measured: a pinned `R077 old.txt -> new.txt` and a stored `M new.txt` share modes, blobs
+  and line counts). The scope prefilter usually rejects such a record first, since the CLI
+  scopes its stored patch and counts to the post-rename path.
+
+  Every entry must additionally prove it was **committed-only**. `lanes` is a boolean map
+  (`{"committed": true, "uncommitted": false}`), so the check tests the values and requires
+  that exact shape. Merely rejecting a truthy `uncommitted` was not enough: a record from
+  an older CLI that omits `lanes`, or carries a non-dict, would pass as clean and
+  contribute comments on code outside the pinned head. Absent proof of clean, skip.
+
+  The pinned diff itself is computed **fail-closed**: an unreachable base exits non-zero
+  with empty output, and treating that as an empty result would reject every record and
+  then report a clean "nothing matched", so the scan aborts with an `ERROR` line instead.
+  Several records can also pass every check at once (a re-run after a transient failure
+  produces a twin), so candidates are ordered by mtime and exactly one `MATCH` is emitted:
+  newest wins, since a re-run supersedes what it replaced.
+
+## Phase 3: CI status for the pinned commit
+
+**`pr` mode only.** In `local` mode there is no PR and no CI run for the commit; say so
+in one line and move on. Do not push the branch to trigger CI, and do not run tests
+locally: the no-execution rule covers `make unit-tests` and `make test` exactly as it
+covers everything else.
+
+Do **not** compute coverage locally and do **not** parse a CI coverage comment. CI
+enforces its own thresholds and reports against its own baseline; a locally computed
+number is not comparable and is not worth the run.
+
+`gh pr checks` reports the PR's **current** head, not `HEAD_SHA`, and the head can move
+during a long review. Confirm it first:
+
+```bash
+# Separate `if`, not `A && B || C`: gh pr checks exits nonzero for pending (8) and
+# failing checks, so chaining would report "head moved" whenever CI is simply red or
+# still running.
+if [ "$(gh pr view <n> --repo NVIDIA/nodewright --json headRefOid -q .headRefOid)" = "<HEAD_SHA>" ]; then
+  gh pr checks <n> --repo NVIDIA/nodewright   # 0 = green, 8 = still running, other = failing
+else
+  echo "head moved during review — no CI status for the reviewed commit"
+fi
+```
+
+If the head moved, omit the CI line rather than reporting another commit's result.
+Otherwise report one line: passing, failing (name them), or still running. This repo runs
+a `Merge Gate` workflow plus per-component CI (`operator-ci`, `agent-ci`, `lint-ci`,
+`codeql`, and others), so "failing" should name the check, not just the count.
+
+Do **not** add `--required`: before an aggregate gate job exists it prints "no required
+checks reported" and exits 1, so an ordinary in-progress run looks like an error. Plain
+`gh pr checks` exits 8 while running and 0 when green, and handles `skipped`/`neutral`
+correctly, unlike a raw check-runs query which counts them as failures and returns only
+the first page.
+
+## Phase 4: Consensus report
+
+Build from the workflow's return value plus the CI status line from Phase 3:
+
+```markdown
+## Cross-Review Summary for <PR #number | branch <name>>
+
+**Reviewers:** Claude Code, Codex, CodeRabbit + Integration Analysis
+**Head commit:** <sha> | **Consensus reached:** Yes/No
+**Review depth:** <two passes per lane | ONE pass per lane: no round-1 candidates, so the
+cross-review round and its independent re-review did not run — from `crossRoundRan`>
+**Change-list items analysed:** <from `changeListSize`; if 0, say plainly that the
+integration lane verified nothing>
+**CI for this commit:** <passing | failing: check names | still running | n/a (no PR)>
+<note if CodeRabbit was unavailable — it is the only best-effort lane>
+<in local mode, note any uncommitted files from Phase 1: they were NOT reviewed>
+
+### Confirmed Issues (met consensus rule; survived adversarial verification)
+
+| # | File | Line | Severity | Description | Confirmed By |
+|---|------|------|----------|-------------|--------------|
+
+### Integration Findings (cross-cutting impact)
+
+| # | Changed File | Consumer File | Severity | Description | Confirmed By |
+|---|--------------|---------------|----------|-------------|--------------|
+
+### Unresolved (no settled disposition)
+
+| # | File | Line | Severity | Description | Why unresolved |
+|---|------|------|----------|-------------|----------------|
+
+<from the workflow's `unresolved` array: findings that reached consensus but did not
+survive adversarial verification, plus findings no reviewer cast a valid vote on; omit
+the section if empty>
+
+### Contested Issues (no 2-of-3 disposition)
+
+Split reviewers, a lone dissent, or a finding raised during the cross-review round and
+therefore never presented for evaluation.
+
+**Carry the `adjudication` field into the table.** The two states need different things
+from the reader and the counts are not comparable: `evaluated` was presented, voted on,
+and did not reach 2-of-3, so it needs a tie broken; `raised-late` was never presented to
+anyone, so its only position is its reporter's and it just needs reading. Collapsing them
+is what makes a row of late findings read as a row of disagreements.
+
+| # | File | Line | Severity | Description | Adjudication | For | Against | Reasoning |
+|---|------|------|----------|-------------|--------------|-----|---------|-----------|
+
+<`Adjudication` is `evaluated` or `raised-late`, verbatim from the workflow's field of
+that name; the workflow's `why` explains each in one line>
+
+### Dismissed Findings
+
+<finding, who flagged it, why dismissed (incl. "failed adversarial verification: ...")>
+
+### Open Questions
+
+<unverifiable findings + reviewers' open questions>
+
+### Residual Risk
+
+<from the workflow's residualRisk array: reviewer-flagged risks that are not
+findings; omit the section if empty>
+
+### Positive Observations
+
+<noteworthy good patterns>
+```
+
+## Phase 5: Output
+
+**Default: do NOT post.** Present the full report in chat and stop. Do not ask
+whether to post. In `local` mode there is nothing to post to, so this phase does not
+apply at all.
+
+**When asked to post, post a DRAFT review, not a comment.** A review created through the
+API with no `event` field stays `PENDING`: GitHub shows it only to the account that
+created it, in the PR's Files-changed tab, where it can be edited comment by comment and
+then submitted or discarded. Nothing is public until a human presses Submit. That is the
+right default for a machine-generated review, and it is why this phase does not use
+`gh pr comment`, which publishes immediately and cannot be recalled.
+
+Findings already carry `path` and `line`, so anchor them as inline comments rather than
+flattening them into one blob. Split them first:
+
+- **Inline-able**: the finding's `path:line` falls on a line the PR diff actually touches.
+- **Everything else**: goes in the review body. GitHub rejects the whole request with 422
+  if any single comment names a line outside the diff, and this skill deliberately reads
+  full files at the pinned commit, so findings outside the diff are normal, not an error.
+  One bad coordinate loses the entire review, so when in doubt put it in the body.
+
+Build the payload with the Write tool and post it with `--input`. Never interpolate a
+finding into a shell argument: findings quote PR content, and a backtick or `$(...)` in
+one would be executed by the shell before `gh` ever runs. JSON in a file avoids that
+entirely.
+
+```json
+{
+  "commit_id": "<HEAD_SHA>",
+  "body": "<the filtered summary — see the content rules below>",
+  "comments": [
+    {"path": "operator/internal/controller/foo.go", "line": 412, "side": "RIGHT",
+     "body": "<one finding, stated plainly>"}
+  ]
+}
+```
+
+```bash
+# No "event" key in the payload: that is what makes it a PENDING (draft) review.
+gh api repos/NVIDIA/nodewright/pulls/<n>/reviews --method POST --input "<payload-file>"
+```
+
+`<payload-file>` is the exact path you passed to Write. A Write-tool call cannot export a
+shell variable, so substitute the literal path here.
+
+Then tell the user it is waiting as a draft on the Files-changed tab, and stop. Do not
+submit it for them. Submitting is a one-click action in the UI, and the whole point of the
+draft is that a human reads it first.
+
+Three failure modes worth naming, because each returns a bare 422:
+
+- **One pending review per user per PR.** A second POST while one is still pending fails.
+  Say so plainly rather than retrying; the earlier draft has to be submitted or discarded
+  in the UI first.
+- **`commit_id` must be the reviewed commit.** Pass `HEAD_SHA`, not the PR's current head.
+  If Phase 3 found the head had moved, say the review anchors to a commit that is no
+  longer the tip, or skip posting.
+- **A line outside the diff** rejects the entire request, not just that comment.
+
+Content rules, unchanged from a posted comment:
+
+- Post **issues only**: Confirmed Issues (without the "Confirmed By" column),
+  confirmed Integration Findings, Contested Issues, Unresolved, Open Questions.
+- **No reviewer-agent attribution and no severity-label prefixes** in posted
+  content. State each finding and its evidence plainly.
+- Never post Dismissed Findings or Positive Observations.
+- State the review depth in the body when `crossRoundRan` is false, and say the
+  integration lane verified nothing when `changeListSize` is 0. A reader of the PR cannot
+  see the workflow's return value, so an unqualified review reads as a full one.
+
+If the user explicitly asks to submit rather than draft, add `"event": "COMMENT"` to the
+payload. Never use `"REQUEST_CHANGES"` or `"APPROVE"`: this skill's output is evidence for
+a human, not an approval decision.
+
+## Rules
+
+- Never post to the PR without an explicit user request, and when asked, post a PENDING
+  draft review (no `event` field) so a human submits it. Never submit or approve.
+- The consensus rule, the required-lane contract, the repo-context block, and the
+  single-cross-review-round structure live in `scripts/workflow.mjs`; keep it and this
+  doc in sync.
+- **This skill never executes the reviewed commit's code.** No builds, tests, coverage,
+  generators, `make` targets, package managers, or repository scripts. In particular:
+  suspected `make manifests generate` drift is reported as a finding against the diff, not
+  settled by running the generator. If a claim can only be settled by running something,
+  it is an open question.
+- Confirmed integration findings identifying broken consumers escalate to at least
+  **medium** severity (done in-script).
+- Severity scale: critical (must fix) > major (should fix) > medium > minor.
+- Keep the report concise: actionable findings, not noise.
+- Never set `dangerouslyDisableSandbox` for reviewer or companion commands; they run
+  fine sandboxed. **Exactly two exceptions**, both kept in sync with the protocols in
+  `scripts/workflow.mjs`, and both scoped to a single command that performs no Git
+  operation, no working-copy mutation, and no GitHub write. (They do *read* files;
+  CodeRabbit necessarily reads the detached worktree it was pointed at. The rule bars
+  bypassing calls that **act on** the working copy, not calls that read a path):
+  - **Codex companion** — it writes its job log under `~/.claude/plugins/data`, which is
+    sandbox-denied. If dispatch fails on that write, bypass for that call only.
+  - **CodeRabbit review** — `~/.coderabbit` is outside the write allowlist, so a
+    sandboxed CLI cannot create its log or review store and hangs at
+    `connecting_to_review_service` until the timebox kills it. Bypass **step 2 only** of
+    the three-step CodeRabbit protocol, which is a lone `coderabbit review` command;
+    worktree setup and cleanup live in steps 1 and 3 and stay sandboxed.
+
+  Anything else stays sandboxed. In particular, never bypass a call that also performs
+  `git` operations; that is why the CodeRabbit protocol is split into three calls rather
+  than the single invocation it used to be.
+
+  Note that in this repo `.claude/skills/` is itself on the sandbox write deny-list, so
+  *editing this skill* needs a bypass even though *running* it does not. That is a
+  property of the local sandbox profile, not of the skill.
+- **The tool shell is zsh, and every prompt that hands out a shell command says so.**
+  `scripts/workflow.mjs` defines a single `SHELL_CONTRACT` constant, interpolated in
+  **exactly one place**: `NO_EXECUTION`, which every prompt builder composes exactly
+  once. So every assembled prompt carries it exactly once. Do not add a second
+  interpolation: `NO_EXECUTION` already embeds `PINNED_READS`, so putting it in
+  `PINNED_READS` or `CODEX_LEAN` as well silently doubles it in every lane. That is how
+  the first attempt got it wrong, and no block-level check can see it; the duplication
+  only appears once the prompts are assembled. It covers the three differences that bite
+  silently: `shopt` and other bash builtins are simply absent, an unmatched glob is a hard
+  error that aborts the command list rather than passing through literally, and `status`
+  is readonly.
+- **Clean up before finishing:** `rm -f <the DIFFPATH echoed in Phase 1>` and delete the
+  scoped refs captured in Phase 1 (`git -C "<repo-path>" update-ref -d "$BASEREF"`, and
+  `"$PRREF"` in `pr` mode; use the exact names echoed there, not a guess). Confirm no
+  `${TMPDIR:-/tmp}/cr-rabbit.*` worktree path remains in `git worktree list`. Write the
+  fallback out, since setup creates the worktree under `${TMPDIR:-/tmp}` and with `TMPDIR`
+  unset a bare `$TMPDIR/cr-rabbit.*` names `/cr-rabbit.*` while the leak sits in `/tmp`.
+  The CodeRabbit lane cleans its own in step 3, but verify, since a lane killed between
+  steps 2 and 3 leaves one behind. Step 1 of the next run reaps `cr-rabbit.*` directories
+  older than 120 minutes, which bounds the leak but does not clear it now. Do not compare
+  total worktree counts: this repo keeps its own worktrees under `.claude/worktrees/` and
+  concurrent sessions change the total legitimately.

--- a/.claude/skills/nodewright-cross-review/scripts/workflow.mjs
+++ b/.claude/skills/nodewright-cross-review/scripts/workflow.mjs
@@ -1,0 +1,1347 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Claude Code Workflow script — runs in a custom async execution context where
+// top-level `return` statements are valid (they return the workflow result).
+// Standard JS linters may flag those as parse errors; that is expected.
+export const meta = {
+  name: 'nodewright-cross-review',
+  description: 'Multi-reviewer PR review of NVIDIA/nodewright (Claude Code, Codex, CodeRabbit) with integration impact analysis, consensus rounds, and adversarial verification of confirmed findings',
+  whenToUse: 'Invoked by the nodewright-cross-review skill after Phase 1 setup; args carry the mode (pr or local), the pinned SHAs, saved diff path, change type, and bounded change list.',
+  phases: [
+    { title: 'Review', detail: '3 reviewers + integration impact analysis, parallel' },
+    { title: 'Cross-review', detail: 'independent re-review, then AGREE/DISAGREE on every candidate' },
+    { title: 'Verify', detail: 'one adversarial refuter per confirmed finding' },
+  ],
+}
+
+// ---------- args ----------
+// Tolerate args arriving as a JSON string (observed 2026-07-21: the harness
+// delivered `args` stringified even when the tool call passed a real object).
+// The parse is wrapped because its bare failure is undiagnosable, unlike the
+// missing-arg loop below: it throws "JSON Parse error: Unterminated string" naming
+// neither this skill nor `args`, no agent ever spawns, and the run dies before Phase 1.
+// Observed while passing args as a JSON-encoded string, which the Workflow tool
+// explicitly does not want — nothing in the message pointed at that.
+let parsedArgs
+try {
+  parsedArgs = typeof args === 'string' ? JSON.parse(args) : (args || {})
+} catch (err) {
+  throw new Error(
+    `nodewright-cross-review: could not parse the "args" input as JSON (${err.message}). ` +
+    'Pass args as a real object in the Workflow tool call, not a JSON-encoded string — ' +
+    'a stringified object with embedded quotes is the usual cause.')
+}
+const { pr, repo, repoPath, headSha, baseSha, diffPath, prType, changeList, repoNotes, mode, branch } = parsedArgs
+// Two modes, ONE code path. 'pr' reviews a real PR head; 'local' reviews the committed
+// work on a branch that has no PR yet. Everything downstream is identical because both
+// pin a commit and hand every lane the same saved diff — the only differences are what
+// the header calls the change and that `pr` is absent in local mode. Resist adding a
+// second path here: the guards this script inherits are worth more than the branch
+// they would save, and a mode-specific shortcut is a mode-specific bug.
+const reviewMode = mode === 'local' ? 'local' : 'pr'
+// Uncommitted working-tree changes are deliberately NOT reviewable in either mode. Every
+// lane reads a diff pinned to a commit, and the CodeRabbit lane is explicitly forbidden
+// from "-t uncommitted"; a dirty tree would give each lane a different view of the code.
+const required = { repo, repoPath, headSha, baseSha, diffPath, prType }
+if (reviewMode === 'pr') required.pr = pr
+for (const [k, v] of Object.entries(required)) {
+  if (!v) throw new Error(`missing required arg: ${k}${k === 'pr' ? ' (required in pr mode; pass mode:"local" to review a branch with no PR)' : ''}`)
+}
+// What to call the thing under review, in logs and in the result.
+const subject = reviewMode === 'pr' ? `PR #${pr}` : `branch ${branch || headSha.slice(0, 8)}`
+const changes = Array.isArray(changeList) ? changeList : []
+// ---------- schemas ----------
+const FINDING_ITEM = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['severity', 'path', 'line', 'summary', 'evidence', 'impact'],
+  properties: {
+    severity: { type: 'string', enum: ['critical', 'major', 'medium', 'minor'] },
+    path: { type: 'string', description: 'repo-relative file path' },
+    line: { type: 'integer' },
+    summary: { type: 'string' },
+    evidence: { type: 'string', description: 'what in code proves the issue (path:line + fact)' },
+    impact: { type: 'string', description: 'who breaks / what regresses' },
+    consumerPath: { type: 'string', description: 'integration findings only: the consumer-side file. One consumer per finding — report a second broken consumer as a separate finding.' },
+    consumerLine: { type: 'integer' },
+  },
+}
+
+const FINDINGS_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['status', 'findings', 'openQuestions', 'filesChecked'],
+  properties: {
+    status: { type: 'string', enum: ['ok', 'unavailable'] },
+    statusNote: { type: 'string', description: 'when unavailable: what failed (broker dead, cloud timeout, CLI missing)' },
+    findings: { type: 'array', items: FINDING_ITEM },
+    openQuestions: { type: 'array', items: { type: 'string' } },
+    residualRisk: { type: 'array', items: { type: 'string' } },
+    positives: { type: 'array', items: { type: 'string' } },
+    filesChecked: { type: 'array', items: { type: 'string' }, description: 'files actually read (full or targeted excerpts), not just the diff' },
+  },
+}
+
+const EVAL_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['status', 'evaluations', 'newFindings'],
+  properties: {
+    status: { type: 'string', enum: ['ok', 'unavailable'] },
+    statusNote: { type: 'string' },
+    evaluations: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['id', 'verdict', 'reason'],
+        properties: {
+          id: { type: 'string' },
+          verdict: { type: 'string', enum: ['AGREE', 'DISAGREE', 'OPEN_QUESTION'] },
+          evidence: { type: 'string', description: 'path:line — REQUIRED for AGREE and DISAGREE' },
+          reason: { type: 'string' },
+        },
+      },
+    },
+    newFindings: { type: 'array', items: FINDING_ITEM },
+    filesChecked: { type: 'array', items: { type: 'string' }, description: 'files actually read during the independent re-review' },
+  },
+}
+
+const REFUTE_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['verdict', 'reason'],
+  properties: {
+    verdict: { type: 'string', enum: ['CONFIRMED', 'REFUTED', 'UNVERIFIABLE'] },
+    evidence: { type: 'string', description: 'path:line you independently checked — REQUIRED for CONFIRMED and REFUTED' },
+    reason: { type: 'string' },
+  },
+}
+
+// ---------- shared prompt fragments ----------
+// codex uses general-purpose (not codex:codex-rescue) so it has full multi-step Bash
+// access for the dispatch protocol; codex-rescue prefers background execution and may
+// return a job handle instead of structured findings.
+// All lanes use general-purpose: the CodeRabbit prompt drives the CLI itself, so the
+// `coderabbit:code-reviewer` plugin agent is an undocumented dependency we do not need.
+const AGENT_TYPE = { claude: 'general-purpose', codex: 'general-purpose', coderabbit: 'general-purpose' }
+
+const header = `${reviewMode === 'pr'
+  ? `PR #${pr} on ${repo}, head commit ${headSha} (review THIS commit).`
+  : `Local branch ${branch || '(detached HEAD)'} on ${repo}, head commit ${headSha} (review THIS commit). There is no PR yet: the change under review is the committed work in ${baseSha}...${headSha}. Uncommitted working-tree changes are NOT under review; do not read the working copy to find them.`}
+Saved diff: ${diffPath} — read the diff from this file; do NOT re-fetch it (the branch may move mid-review; every reviewer must see the same code).
+Repo working copy: ${repoPath}.`
+
+// The working copy may be on a different branch (concurrent sessions), so every
+// read and search goes through the pinned commit tree.
+// Placeholders are substituted with PR-controlled values (filenames, config keys), so
+// they go inside SINGLE quotes. Double quotes stop globbing but still expand $(...)
+// and backticks, so a filename like docs/$(id).md would execute — the exact thing this
+// skill promises not to run. Single quotes are the only literal form in sh/bash/zsh.
+// Interpolated in exactly ONE place: NO_EXECUTION, which every prompt builder composes
+// exactly once, so every assembled prompt carries this once. Do not also add it to
+// PINNED_READS or CODEX_LEAN — NO_EXECUTION already embeds PINNED_READS, so a second
+// interpolation silently doubles it in every lane (that is how the first attempt got
+// it wrong, and a block-level check cannot see it).
+const SHELL_CONTRACT = `Shell contract: the tool shell is zsh, not bash. Never name a shell variable "status" (readonly in zsh; the assignment silently fails). Do not reach for bash builtins such as "shopt" — they are simply not found. An unmatched glob is a hard error that aborts the whole command list, not a literal passthrough as in bash, so prefer doing the work in python3 whenever a pattern might match nothing.`
+
+const PINNED_READS = `  read:   git -C "${repoPath}" show '${headSha}:<path>'
+  search: git -C "${repoPath}" grep -n -e '<pattern>' ${headSha} -- '<glob>'
+  SINGLE quotes are required and must not be changed to double quotes: they are what
+  makes the substituted value literal. If a path or pattern itself contains a single
+  quote it cannot be read this way. Do NOT escape it and do NOT downgrade it to an
+  open question — an uninspectable file means this lane could not do its job, so
+  return status:"unavailable" naming the path (a verifier returns UNVERIFIABLE).
+  Open questions do not block consensus; an unavailable required lane does.`
+
+// This skill reviews code; it never runs it. The intentional execution path (the Go
+// coverage lane) was deleted, but these lanes are general-purpose agents with shell
+// access, so the prohibition has to be stated rather than assumed.
+const NO_EXECUTION = `
+Execution rules:
+- Do NOT execute anything from the reviewed commit: no tests, builds, package managers,
+  repository scripts, Makefile targets, generators, or checked-in binaries. Not even to
+  "verify" a finding — an unrunnable claim is an open question, not a reason to run it.
+- Do NOT post to GitHub and do NOT mutate the working copy: no "gh pr comment", no
+  "gh pr review", no commits, pushes, or branch switches.
+- ALLOWED: the trusted commands this prompt explicitly prescribes anywhere (including any
+  detached worktree or CLI invocation it spells out), read-only "gh" queries, and the
+  saved diff plus pinned reads/searches:
+${PINNED_READS}
+${SHELL_CONTRACT}`
+
+const OUTPUT_RULES = `
+Reporting rules:
+- Report only findings you verified in code. Do not report preferences or speculative concerns as findings.
+- If something might be wrong but you cannot verify it, put it in openQuestions, not findings.
+- Do not cite upstream charts, external APIs, or third-party docs unless you actually fetched and read them in this session; otherwise it is an open question.
+- "No findings" is a valid and valuable outcome. Do not reach for speculative findings to avoid returning empty-handed.
+- Every finding needs exact path + line + evidence + impact.
+- List every file you actually read in filesChecked.`
+
+const CODEX_LEAN = `
+Context rules (IMPORTANT — the Codex broker reproducibly crashes mid-generation on large accumulated context; verified on PR #1196):
+- Work primarily from the saved diff (cat "${diffPath}"). Read only targeted excerpts at the pinned commit:
+    git -C "${repoPath}" show '${headSha}:<path>' | sed -n '<start>,<end>p'
+- For consumer/caller searches use git grep against the pinned tree, not bare rg (which searches the mutable working copy). Use exactly the quoted recipe above; do not unquote it.
+- Do NOT read CLAUDE.md.
+- Before reporting a missing path/key/field/API, confirm absence at the pinned commit with a targeted check, not a full-file read.`
+
+const CODEX_DISPATCH = `
+Codex dispatch protocol (mandatory):
+1. comp=$(ls -t ~/.claude/plugins/cache/openai-codex/codex/*/scripts/codex-companion.mjs | head -1)
+2. Dispatch the review as a BACKGROUND job (pass --background to codex-companion task) so it returns a job id immediately. NEVER run foreground: a foreground call hangs forever if the broker dies mid-turn.
+   Pass --cwd "${repoPath}" on this call and on EVERY later status/result call. Companion state is keyed by the workspace root derived from the working directory, and each Bash call is a fresh shell that may start somewhere else — an unpinned lookup silently resolves to a different workspace and reports the job as unknown.
+3. Wait for it with the companion's own bounded wait — do NOT hand-roll a poll loop:
+     node "$comp" status <job-id> --cwd "${repoPath}" --wait --timeout-ms 540000 --poll-interval-ms 30000 --json
+   Run that Bash call with a timeout of 600000 ms. The inner wait is deliberately 60s SHORTER than the outer cap: the two must not be equal, or Bash can kill the command before it prints its JSON, leaving you with no .waitTimedOut to classify on — and an unclassifiable kill is the one case step 5 must never guess at, since retrying a genuine timeout doubles the wall clock for nothing.
+   Read the returned JSON yourself. The job state is at .job.status (NOT a top-level "status" field), and .waitTimedOut is true if the inner deadline expired while the job was still queued/running.
+   Absent JSON has TWO causes and they are not interchangeable — distinguish them before classifying:
+     - Exit status 1 with EMPTY stdout and "No job found" on stderr (measured on companion v1.0.2; the message goes to stderr even with --json, so capture both streams before deciding): this is a LOOKUP MISS. It is NOT evidence the job died — it may still be running. Never classify a lookup miss as exhausted budget; doing so abandons a live required lane. Note the exit status is a reliable discriminator here, so read it directly rather than inferring from output — and do not read it through a pipe, where $? is the last stage's status, not the companion's.
+       ALWAYS recheck EXACTLY ONCE with --cwd "${repoPath}" pinned, whether or not the call that missed already carried it. Two independent causes produce the identical message, and only one of them is settled by adding the flag:
+         - An unpinned lookup resolves to a different workspace and reports a live job as unknown. Pinning fixes it.
+         - A pinned lookup can miss TRANSIENTLY. In companion v1.0.2, saveState writes state.json with a plain fs.writeFileSync (truncate-then-write, no temp-file-and-rename), and loadState wraps JSON.parse in a bare catch that returns the DEFAULT state — whose jobs list is empty. A read landing inside that write window therefore yields a well-formed "No job found" rather than an error, and the background worker is updating that file precisely while the status call runs. So an identical repeat is NOT guaranteed to return an identical answer; a brief pause before the recheck makes it likelier to clear.
+       Once a pinned recheck has also missed, return status:"unavailable" saying the job could not be located, and stop. Do NOT re-dispatch the task: the original may still be running, and a second dispatch doubles the work while the first result becomes unreachable. Do NOT call it exhausted budget either; the distinction belongs in statusNote.
+     - No output at all because your Bash call hit its 600000 ms timeout: that IS exhausted budget. Do not retry; say so in statusNote.
+4. .job.status == "completed" → fetch the payload with: node "$comp" result <job-id> --cwd "${repoPath}" --json  (NOT status, which returns only a job summary).
+5. Otherwise classify, and retry ONLY a failure that is demonstrably both fast and transient. All three conditions must hold:
+   a. .job.status is "failed" — NOT "cancelled". The companion emits "cancelled" only for explicit cancellation, so retrying it restarts work something or someone deliberately stopped.
+   b. .waitTimedOut is false AND the job died in UNDER 60 SECONDS — compute elapsed from the job's own timestamps, not from the absence of a timeout. Use the number, not a judgment call: the two observed cases sit far apart (an upstream capacity rejection landed at ~10s, a genuine timeout at 10m19s), and leaving "quickly" undefined is how a one-retry budget turns into retry-whenever-it-feels-right. A job that fails at 8:59 also satisfies .waitTimedOut == false while having consumed nearly the whole window; that is not a transient blip and retrying it costs another full window.
+   c. The error text names a known-retryable cause: an upstream capacity rejection ("Selected model is at capacity"), a broker startup error, or a transient dispatch fault. An unrecognised error is not assumed retryable.
+   All three true → dispatch ONE new background job per step 2 and wait once more per step 3. If the second attempt also fails, return status:"unavailable" with BOTH observed .job.status values and the broker error text in statusNote.
+   Anything else — "cancelled", a late failure, or an unrecognised error — is a deliberate stop or an unexplained failure. Do NOT retry. Return status:"unavailable" with .job.status, .waitTimedOut, elapsed time, and whether the job log showed active progress.
+   Retry budget is exactly one, and only when a, b and c all hold. Never loop.
+6. .waitTimedOut true is DIFFERENT from all of the above, and is NOT the end of the lane. It means only that the inner wait elapsed — it says nothing about the job, which is dispatched in the background and outlives the Bash call that was waiting on it. Re-read .job.status:
+   - Still "queued" or "running" → the job is ALIVE and needs more TIME, not another attempt. Wait once more on the SAME job id, in a NEW Bash call, exactly as in step 3 (same 540000 ms inner wait, same 600000 ms outer timeout). This is a CONTINUATION, not a retry: no second job is dispatched, no work is duplicated, and the first job's result stays the one you collect. Then classify the second wait's outcome by these same rules — except that this continuation is granted ONCE, so a second .waitTimedOut IS exhausted budget: return status:"unavailable" saying the job was still running after both waits, and give the job id so the result can be fetched later with: node "$comp" result <job-id> --cwd "${repoPath}" --json
+   - Any terminal state ("completed", "failed", "cancelled") → it finished while you were between calls. Handle it under step 4 or step 5; do not treat the earlier timeout as the verdict.
+   Why this exists: measured on a real run, the lane hit .waitTimedOut at the full 540000 ms while the job was demonstrably mid-work (its log showed pinned git greps completing, exit 0), the job was STILL "running" long after the review was abandoned, and its result remained retrievable. Reporting "exhausted budget" there discarded a required lane, and with it the whole review, over a job that simply had not finished yet. Re-dispatching would have been wrong — waiting again was not.
+   Never substitute your own review for an unavailable Codex lane in either case — an unavailable lane is an expected outcome the workflow handles.
+   The 600000 ms outer ceiling is not tunable: the wait runs inside a Bash call, and the Bash tool silently kills any foreground command at that point. The inner wait is 540000 ms precisely so it finishes and prints its JSON before that happens — do not raise it to match. Step 6 is how a job legitimately exceeds ten minutes: not a longer wait, but a second one across a fresh call, which is the "polling across several calls" the ceiling leaves open. Total budget for a live job is therefore two waits, about eighteen minutes.
+Every Codex task you dispatch must carry the execution rules verbatim in its own prompt — Codex runs in its own shell and does not inherit this one's constraints. That includes the shell contract stated elsewhere in this prompt: it arrives via NO_EXECUTION, which every prompt builder composes exactly once, so it is deliberately not repeated here.
+Sandbox: the review itself runs sandboxed. The one known exception is the companion's own job log under ~/.claude/plugins/data, which is sandbox-denied — if dispatch fails on that write, bypass for that call only. Never bypass for anything else, and never for a call that performs a Git operation, mutates the working copy, or writes to GitHub. Reading a path is not the boundary; acting on it is.`
+
+// Repo-specific context. Short by design: the Codex lane is context-starved (see
+// CODEX_LEAN) and most of this block REMOVES work rather than adding it, by naming the
+// trees not worth reading and the vocabulary mismatch that is not a defect.
+const REPO_CONTEXT = `
+Repository context (NVIDIA/nodewright):
+- Three components, three toolchains: operator/ (Go controller-manager, controller-runtime + Kubebuilder v4, deps vendored), agent/skyhook-agent/ (Python package that runs inside every package container and executes lifecycle steps), chart/ (Helm chart mirroring operator/config/).
+- The project is being renamed Skyhook -> NodeWright and the rename is PARTIAL BY DESIGN. Already moved: the GitHub repository itself (NVIDIA/nodewright), the Go module, the Helm chart, both images, the primary CRD group (nodewright.nvidia.com/v1alpha1), the CLI (kubectl nodewright). Deliberately NOT moved: the Kubernetes namespace (skyhook) and the legacy read-only skyhook.nvidia.com CRD group. A mixed vocabulary is therefore EXPECTED and is not a finding. Never report "this should say skyhook" or "this should say nodewright" as a defect. It is only a finding when the name actually breaks something: for example, code reading an annotation key the operator no longer writes.
+- Status / State / Stage are three DISTINCT concepts, deliberately named to look alike: Status = health of a NodeWright CR or a node; State = one package's outcome on one node; Stage = which lifecycle phase that package is in. A field, variable, log key or doc line named for one that carries another IS a real finding. Authoritative definitions: docs/operator-status-definitions.md at the pinned commit.
+- Do NOT review, and do not report findings in: operator/vendor/, agent/vendor/, any zz_generated.*.go, operator/config/crd/bases/*.yaml, operator/bin/, agent/dist/, reporting/. They are vendored or generated. ONE EXCEPTION: the hand-written zz.migration.<version>.go files under operator/internal/controller/ and operator/internal/wrapper/ are NOT generated despite the prefix; review them normally.
+- Exclude the vendored trees from every repo-wide search or the results are unusable:
+    git -C "${repoPath}" grep -n -e '<pattern>' ${headSha} -- '<glob>' ':(exclude)operator/vendor' ':(exclude)agent/vendor'
+  The pathspec goes in SINGLE quotes for the same reason the read recipe does.`
+
+const REVIEW_FOCUS = {
+  'code-change': `Review for bugs, regressions, broken consumers, security issues, and instruction/config compliance.
+
+Behavioral correctness (review the changed code's internal logic, not just its callers):
+- For each materially changed function or new control-flow branch, trace concrete inputs through happy path, error path, and edge cases; check actual behavior matches comments, tests, and the PR description.
+- For fallback/reset/retry/exclusion logic, verify the scope precisely: it must affect only the intended state and not discard unrelated data.
+- For metadata/diagnostic output (warnings, errors, logs, status fields), verify names/paths/IDs derive from the real triggering context, not placeholders or stale variables.
+- For loops or multi-branch state assembly, check accumulated maps/slices/sets stay consistent across all branches, including early returns and partial-failure paths.
+
+Operator invariants. This is a Kubernetes controller, and these are the defect classes it actually ships. Check each against the changed code:
+- LEVEL-TRIGGERED, not edge-triggered. Reconcile must be correct given only the current state of the world. Code that assumes a particular event caused this invocation, that the previous reconcile ran, or that it will be called again "soon" without an explicit requeue, is a finding.
+- IDEMPOTENT. Two identical reconciles must not double-apply a side effect. A pod create, drain, cordon, taint, annotation write or status write with no preceding existence/equality check is a finding.
+- NO RECONCILER-OWNED STATE. Progress cached on the reconciler struct between reconciles is lost on pod restart or leader-election rollover; anything that must survive belongs on the apiserver (Node annotations, the status subresource, finalizers). Reading the operator's own published status back as authoritative state is the same defect wearing a different hat: state is re-derived from the cluster.
+- Status writes go through .Status().Update() / .Status().Patch(), never a plain Update().
+- Cleanup: anything created outside the owner-reference tree (host-side mutations, Node taints and annotations) must be reversed via the nodewright finalizer. Kubernetes-native children want controllerutil.SetControllerReference so they GC on their own.
+- No time.Sleep and no apiserver polling loop inside reconcile: use ctrl.Result{RequeueAfter} or a Watch. No context.Background() in the reconcile path. No http.DefaultClient (zero timeout).
+- Mutable resources use controllerutil.CreateOrUpdate/CreateOrPatch; IgnoreAlreadyExists on a mutable kind silently keeps stale state and is a finding.
+- Errors wrapped with %w and real context: a bare err returned from a multi-step function is a finding, as is an unchecked Close() on a writable handle (errcheck is enabled).
+
+Cross-surface contracts. A change to one side without the other is a REAL finding, not a nit:
+- operator/config/ (kustomize) and chart/ (Helm) describe the same deployment surface through two tools. A new or changed RBAC rule, env var, volume mount, resource limit, webhook wiring, arg or CRD present in one and absent from the other is a defect. Check chart/values.yaml too when the change adds a knob.
+- Edits under operator/api/ require regenerated artifacts: zz_generated.deepcopy.go, operator/config/crd/bases/*.yaml, webhook config. A changed kubebuilder marker or API type with no corresponding generated change means "make manifests generate" was not run, so report the drift as a finding. Do NOT run the generators yourself.
+- Edits to a mocked interface require regenerated mockery output under operator/internal/controller/mock/. Stale mocks that still compile are still a finding.
+- The CLI (operator/cmd/cli/) is a client of the operator over annotations (nodewright.nvidia.com/pause, /disable, /nodeState_*), status shape, and well-known label and finalizer names. An operator change to any of those with no CLI change is a finding. So is a CLI change that breaks against older operators without feature-detecting, since the CLI ships on its own schedule; docs/cli.md carries the authoritative compatibility matrix and a version-gated command missing from it is a finding.
+- Behavior-changing PRs must update docs/ IN THE SAME DIFF. A changed CRD field, CLI command or flag, env var, annotation, metric, lifecycle semantic, or install/upgrade flow with no docs/ edit is a finding; so is a docs/ page the change has silently made false.
+- Agent side: agent/skyhook-agent/ reads /skyhook-package/config.json validated against its schemas/. A config-shape change on either the operator or the agent side without the matching change is a finding.
+- Versioning is strictly enforced per component (operator/, cli/, agent/, chart/) because the operator uses semver to tell upgrade from downgrade from fresh-apply. A behavior change with no CHANGELOG.md entry for the component it lands in is a finding.
+
+Consumer search:
+- Search for consumers of changed exported APIs, config keys, flags, env vars, annotation and label keys, image names, workflow inputs, and file paths.
+- Check .github/workflows/, Makefile and *.mk, chart/templates/ and chart/values.yaml, operator/config/, k8s-tests/chainsaw/ (the e2e fixtures assert on exact annotation keys, statuses and stage names, so a renamed constant breaks them silently), testdata/, and docs/.
+- Skip purely local/private helper callers unless the behavior change escapes the file.`,
+  'design-doc': `This PR is a design doc or plan (docs/designs/, docs/plans/): prose, usually one file, fine to read in full. Read only the specific prior design docs, docs/ pages, or implementation sections a given claim depends on.
+
+Review for concrete design gaps:
+- Missing required contracts for correctness (reconcile idempotency, what survives a restart, what the finalizer must reverse)
+- Unacknowledged behavior changes versus the current operator, CLI, agent, or chart
+- Missing operational semantics: failure, rollback, migration of existing CRs and Node annotations, minimum operator/CLI/agent versions
+- Claims that do not connect to actual codebase concepts — check the Status/State/Stage vocabulary is used correctly, and that named annotations, CRD fields, stages and CLI commands actually exist at the pinned commit
+Only report a finding if you can point to the exact doc line plus supporting code or doc evidence. No generic style preferences.`,
+  'config-change': `Review for correctness, downstream consumers, and environment impact.
+- For each changed config value, search the repo for every consumer that reads or depends on it.
+- Check both halves of the deployment surface: operator/config/ (kustomize) and chart/ (Helm) plus chart/values.yaml. A value changed in one and not the other is a finding.
+- Check .github/workflows/, Makefile and *.mk, k8s-tests/chainsaw/ fixtures, operator code that reads the key, and docs/ pages that document it.
+- For a chart change, check whether it is one helmify would have produced from operator/config/ — the chart is hand-edited after generation, so a regenerated file can silently revert templating variables, comments or ordering.
+- Skip purely local references unless the change crosses a boundary.`,
+  'documentation-only': `Review the changed docs for:
+- Factual accuracy: do the docs match what the operator, CLI, agent, or chart actually does at the pinned commit?
+- Stale references: do linked files, functions, flags, annotation keys, CRD fields, stages and CLI commands still exist?
+- Correct vocabulary: Status, State and Stage are distinct (see the repository context above): a doc line using one for another is a finding.
+- Missing context: omitted caveats, prerequisites, minimum component versions.
+Read only targeted excerpts of the code or config the docs describe. No style or formatting preferences.`,
+}
+
+// prType is an unconstrained string and THREE sites derive behavior from it: the two
+// focus selections below fall back to 'code-change', while the cross-review prompt gates
+// its extra clauses on `prType === 'code-change'` and `=== 'design-doc'`. A misspelled
+// value therefore silently takes the code-change focus WITHOUT the matching code-change
+// clause, and nothing in the result records the fallback. Reject it instead.
+// Derived from REVIEW_FOCUS rather than a parallel literal: a hand-maintained list is one
+// more thing to forget when a type is added. This runs before any agent() call, which is
+// the fail-fast that matters here — the cost of a bad prType is spent tokens, not a late
+// line number.
+const PR_TYPES = Object.keys(REVIEW_FOCUS)
+if (!PR_TYPES.includes(prType)) {
+  throw new Error(`unknown prType ${JSON.stringify(prType)} — expected one of: ${PR_TYPES.join(', ')}`)
+}
+
+// ---------- Round 1 prompts ----------
+function claudeReviewPrompt() {
+  // Deliberately NOT delegating to Skill("code-review:code-review"): that command's
+  // step 8 instructs its agent to `gh pr comment` the result back to the PR, and it
+  // carries Bash(gh pr comment:*) in allowed-tools. A prompt asking it to skip that
+  // is advisory, not a write barrier — this skill must never post by default.
+  return `You are the Claude Code reviewer in a multi-reviewer cross-review.
+${header}
+${repoNotes ? `Repo conventions relevant to this review:\n${repoNotes}\n` : ''}
+Do NOT post anything to GitHub. Do not run "gh pr comment", "gh pr review", or any
+other write command; your findings are returned to this prompt only.
+
+Review the saved diff thoroughly, then verify every finding at the pinned commit:
+${PINNED_READS}
+${REPO_CONTEXT}
+${REVIEW_FOCUS[prType] || REVIEW_FOCUS['code-change']}
+Only return findings that survive verification. Before reporting a missing path/config key/field/API, read the full existing file at the pinned commit to confirm it is actually absent.
+${NO_EXECUTION}
+${OUTPUT_RULES}`
+}
+
+function codexReviewPrompt() {
+  return `You drive the Codex reviewer in a multi-reviewer cross-review.
+${header}
+${CODEX_DISPATCH}
+
+${NO_EXECUTION}
+
+Compose a LEAN Codex task prompt containing the saved-diff path, these review instructions, the repository context, the execution rules above, and the reporting rules:
+${REPO_CONTEXT}
+${REVIEW_FOCUS[prType] || REVIEW_FOCUS['code-change']}
+${CODEX_LEAN}
+${OUTPUT_RULES}
+Translate Codex's raw output into the structured result yourself.`
+}
+
+// The CodeRabbit CLI runs exactly once, in round 1; the cross-review round replays
+// its saved findings instead of paying for another slow cloud call.
+const CODERABBIT_RUN = `Run this as THREE separate Bash calls. Only the middle one is sandbox-bypassed, so git never runs unsandboxed against the working copy.
+
+STEP 1 — setup (SANDBOXED, normal Bash call):
+   set -euo pipefail
+   { find "\${TMPDIR:-/tmp}" -maxdepth 1 -type d -name 'cr-rabbit.*' -mmin +120 -print0 |
+     while IFS= read -r -d '' STALE; do
+       git -C "${repoPath}" worktree remove --force "$STALE/head" 2>/dev/null || true
+       rm -rf "$STALE" 2>/dev/null || true
+     done
+     git -C "${repoPath}" worktree prune; } || true
+   CRROOT=$(mktemp -d "\${TMPDIR:-/tmp}/cr-rabbit.XXXXXX")
+   git -C "${repoPath}" worktree add --detach "$CRROOT/head" ${headSha}
+   echo "CRROOT=$CRROOT"
+Record the echoed CRROOT: shell variables do not survive between Bash calls, so steps 2 and 3 must use the literal path.
+The find/prune pair is the bounded reaper for STEP 3's known leak. Two limits make the FIND half safe: it matches ONLY the cr-rabbit.* prefix this lane creates, and only entries older than 120 minutes — twelve times the 600000 ms (10 minute) cap a single review can occupy, so it can never reach another session's live worktree. Do not widen either limit. "find" is used rather than a glob because an unmatched glob aborts the command list under zsh; find prints nothing and exits 0. The whole reaper — find, the removal loop AND the prune — is wrapped so it cannot fail the call. Under set -e any of them aborts STEP 1 before the mktemp and the worktree add, and both halves have been seen to fail: an unremovable stale directory where TMPDIR is unset and /tmp is shared between users, and "git worktree prune" itself exiting "Operation not permitted" on .git/worktrees when the sandbox profile, computed at session start, does not cover a worktree created later in that session. Neither is a reason not to review. Only the reaper is neutralised; the worktree add below stays fatal, since STEP 2 must not review the wrong tree.
+The PRUNE half is repo-wide, not prefix-scoped — be precise about that rather than reading the two limits onto it. It is included to collect the admin entries whose directories the loop just removed, and it is near-harmless because prune only reaps entries whose directory is ALREADY gone. The residual case is an unrelated worktree whose directory is transiently absent (unmounted volume, an rm in flight): its entry would be pruned too. That is accepted; re-adding such a worktree is cheap, and the alternative is leaving this lane's own stale entries to accumulate.
+One more rough edge, cosmetic: a cr-rabbit.* directory left by a DIFFERENT clone is removed by the rm -rf while its admin entry lives in that other repo, which "git -C ${repoPath} worktree remove" cannot reach. That entry is then collected by the other repo's own next prune, so it self-heals — but the removal is less clean than the within-repo case.
+
+STEP 2 — the review (THIS CALL ONLY runs with dangerouslyDisableSandbox):
+   coderabbit review --agent --committed --base-commit ${baseSha} --dir "<CRROOT>/head"
+Nothing else belongs in this call: no Git operation, no working-copy mutation, no GitHub write. Reading is not the boundary — this very command reads the detached worktree it is pointed at. What the bypass must never cover is a call that ACTS on the working copy or GitHub. Note its exit status rather than assuming success — a non-zero exit must still reach RECOVERY, which is the whole point of the fallback. Do NOT use "-t uncommitted".
+Timebox: give THIS call an explicit timeout of 600000 ms. The Bash tool defaults to 2 minutes and is capped at 10, so an unset or larger timeout silently kills the run. Steps 1 and 3 are fast and need no explicit timeout.
+Accept the run ONLY if its reported baseCommit equals ${baseSha}; otherwise discard it and return status:"unavailable" with what it reported. Ignore currentBranch, baseBranch, and workingDirectory — a detached worktree correctly reports currentBranch:"HEAD", the CLI's inferred baseBranch stays unrelated even when --base-commit is honored, and the commit pair is what identifies the reviewed context.
+
+STEP 3 — cleanup (SANDBOXED, normal Bash call). Run it ALWAYS: after success, after failure, and after a timebox kill.
+   git -C "${repoPath}" worktree remove --force "<CRROOT>/head" 2>/dev/null || true
+   rm -rf "<CRROOT>"
+STEP 3 carries no "set -euo pipefail": every command in it is already \`|| true\`-guarded or idempotent, and failing the call on a cleanup that partially succeeded would abort the rest of the cleanup. STEP 1 does set it because a failed worktree add there must stop the lane before STEP 2 reviews the wrong tree. STEP 2 is a single command, so the flags would change nothing.
+There is no EXIT trap any more — a single invocation could carry one, three cannot. So STEP 3 is the only PROMPT cleanup there is: if you die between steps 2 and 3, the worktree leaks and STEP 3 will not run. Do not skip STEP 3 on the assumption that something else will.
+That is the accepted trade, and STEP 1's age-gated reaper is its backstop, not its excuse: it collects such a leak only on the NEXT run of this lane and only once the leak is two hours old, so between those points the worktree is really there. Phase 1's hygiene check COUNTS worktrees and stops to ask you — it deliberately does not remove any, since a clean detached-HEAD worktree may be another session's live review — and a bare \`git worktree prune\` walks past a fresh leak entirely, because prune only reaps admin entries whose directory is already gone. Leaking a worktree is still far better than running git unsandboxed, which has no backstop at all — but it is a real cost, not a free one.
+
+SANDBOX — this is the single most common reason this lane fails, and it is NOT a CodeRabbit problem. ~/.coderabbit is outside the sandbox write allowlist, so a sandboxed CLI cannot create its log or its review store. It does not fail fast: it hangs at
+   {"type":"status","phase":"connecting","status":"connecting_to_review_service"}
+until the timebox kills it, and writes NO log file at all.
+Diagnose it by absence: if the run stalls at "connecting" and ~/.coderabbit/logs/ gained NO new file, it was sandbox-denied. A process killed mid-run still flushes a partial log — zero bytes means it never created one. A genuine cloud problem leaves a log containing 429 or queue lines.
+Therefore run STEP 2 — and only STEP 2 — with sandbox bypass (dangerouslyDisableSandbox) from the start; the observed evidence above is the justification the sandbox rules require. That step contains a single coderabbit command by design: steps 1 and 3 hold every git and working-copy operation and stay sandboxed. Never widen the bypass to cover them.
+Do NOT read a "connecting" stall as an outage, a 429, or contention with another session — a concurrent run on the same account was ruled out as the cause (an unsandboxed run succeeded while a sandboxed one hung, which merely looks like contention).
+
+RECOVERY — always try this before returning unavailable, and also whenever your own run stalls, exits non-zero, or is killed at the timebox. Run it as a SEPARATE Bash call, never appended to the steps above: STEP 2 may already have been killed at its timebox, so anything chained after it would never execute. The CLI persists every completed review to ~/.coderabbit/reviews/<a>/<b>/reviews/<id>/, where git.json carries "head", "baseCommitId" and a per-file "diff" list holding each file's full patch text, including its "index <oldblob>..<newblob>" line. Search for a record whose head is ${headSha} and whose blob OIDs equal the pinned diff exactly:
+Do the matching in Python, NOT with a shell glob. This is the shell contract stated elsewhere in this prompt, applied to the case that actually bit: under zsh a shell glob here aborts the whole command list on no-match, stranding the log fallback below in exactly the situation it exists for.
+   python3 - <<'PY'
+import glob, json, os, re, subprocess, sys
+head = "${headSha}"
+# [.][.] rather than a backslash-escaped dot: an unrecognised escape is dropped when this
+# block is assembled into the JS template literal, so the pattern would silently become
+# "index (hex)..(hex)" with two wildcards. Same class of hazard as the chr() note below.
+INDEX = re.compile('^index ([0-9a-f]+)[.][.]([0-9a-f]+)(?: ([0-7]+))?', re.M)
+# Modes are part of the identity, not decoration. A chmod +x in one commit followed by an
+# edit in the next produces a stored review of the EDIT ALONE whose path, line counts,
+# lanes and both blob OIDs are identical to the pinned range covering BOTH changes —
+# verified — so OIDs without modes accept a record that never saw the mode change. Git
+# states the modes in one of four shapes, and the trailing mode on the index line is
+# ABSENT exactly when old/new mode lines are present, so the cases do not overlap.
+OLDMODE = re.compile('^old mode ([0-7]+)', re.M)
+NEWMODE = re.compile('^new mode ([0-7]+)', re.M)
+NEWFILE = re.compile('^new file mode ([0-7]+)', re.M)
+DELFILE = re.compile('^deleted file mode ([0-7]+)', re.M)
+NOMODE = '000000'      # what --raw reports for the absent side of an add or a delete
+def storedmodes(text, mo):
+    om, nm = OLDMODE.search(text), NEWMODE.search(text)
+    if om and nm:
+        return (om.group(1), nm.group(1))
+    nf = NEWFILE.search(text)
+    if nf:
+        return (NOMODE, nf.group(1))
+    df = DELFILE.search(text)
+    if df:
+        return (df.group(1), NOMODE)
+    if mo is not None and mo.group(3):
+        return (mo.group(3), mo.group(3))   # unchanged mode, stated once on the index line
+    return None                              # the record cannot prove its modes: skip it
+# chr() rather than backslash escapes, for EVERY control character used below: this block
+# is assembled inside a JS template literal, which consumes a backslash escape before the
+# prompt is built — the agent would receive a raw control character where Python needs the
+# two-character sequence. A literal newline landing mid-string-literal is a hard
+# SyntaxError, so this is not a style preference; verify by extracting the block from the
+# ASSEMBLED prompt and running it, never by reading the source here.
+NUL, TAB, LF = chr(0), chr(9), chr(10)
+# Identity is the PINNED DIFF ITSELF, never the record's baseCommitId. MEASURED: the CLI
+# writes baseCommitId from the base it resolves locally in that working directory, NOT
+# from the --base-commit we pass. In one real store the same head carried two different
+# values — one a main tip, one a commit not on main at all — while three other valid
+# records carried the stale local "main" rather than the base Phase 1 fetched from the
+# canonical repo. Gating on equality therefore discards good reviews whenever the local
+# ref lags that base, which in the fork layout this skill supports is the common case.
+# Keep baseCommitId for statusNote; do not branch on it.
+# --numstat -z earns its place three times over: -z keeps a path containing spaces
+# intact (a plain split() shreds "with space.txt" into two members and rejects every
+# record for such a PR), the per-file counts reproduce the record's linesAdded and
+# linesRemoved exactly (verified against a real record), and comparing counts as well as
+# paths catches a same-scope review of different content that a path set alone would let
+# through. THREE dots, matching the diff Phase 1 saved: two-dot compares the base tip to
+# the head and so includes everything that landed on the base after branching — on a real
+# pair that was 13 files against the valid record's 59.
+RANGE = '${baseSha}...${headSha}'
+# --no-ext-diff --no-color on BOTH git calls. diff.external replaces the diff engine and
+# makes a patch-producing call fail outright; color.diff=always injects ANSI. Measured:
+# --numstat itself is immune to both, but the flags cost nothing and keep the two calls
+# reading identically — the --raw call below genuinely needs them.
+GITDIFF = ['git', '-C', '${repoPath}', 'diff', '--no-ext-diff', '--no-color']
+def rungit(extra):
+    o = subprocess.run(GITDIFF + extra + [RANGE], capture_output=True, text=True)
+    # FAIL CLOSED. An unreachable base (shallow clone, pruned ref, wrong repo path) exits
+    # non-zero with empty stdout; taking that as an empty result would SKIP every record
+    # and then report "no stored review matches", laundering a broken-git condition into a
+    # clean negative. A genuine PR diff is never empty either, so treat both as an error.
+    # Doing this ONCE up front also means a git failure can never later be mislabelled as
+    # a content mismatch, which would send the reader hunting a difference that is not there.
+    if o.returncode != 0 or not o.stdout.strip():
+        print('ERROR git-diff-failed rc=%d args=%s stderr=%s'
+              % (o.returncode, ' '.join(extra), o.stderr.strip()[:200]))
+        sys.exit(2)
+    return o.stdout
+def numstat(out):
+    toks = out.split(NUL)
+    if toks and toks[-1] == '':
+        toks.pop()
+    m, i = {}, 0
+    while i < len(toks):
+        # maxsplit=2, not a bare split: under -z a path is emitted raw and unquoted, so a
+        # filename containing a TAB would yield four fields and raise ValueError, exiting
+        # 1 with a traceback and no ERROR line — a shape the reader below has no rule for.
+        # Capping the split keeps such a path whole in the third field instead.
+        added, removed, path = toks[i].split(TAB, 2)
+        i += 1
+        if path == '':      # rename/copy: old and new paths follow as their own tokens
+            path = toks[i + 1]
+            i += 2          # record stores the post-rename path, so keep the new one
+        m[path] = (added, removed)
+    return m
+want = numstat(rungit(['--numstat', '-z']))
+def rawmap(out):
+    # ":<srcmode> <dstmode> <srcblob> <dstblob> <status>" NUL "<path>" NUL, with a second
+    # path token for a rename or copy. Blob OIDs are CONTENT HASHES, which is the whole
+    # point: unlike patch text they do not move with core.abbrev, diff.context,
+    # diff.noprefix, diff.algorithm, color.diff or diff.external.
+    toks = out.split(NUL)
+    if toks and toks[-1] == '':
+        toks.pop()
+    m, i = {}, 0
+    while i < len(toks):
+        meta = toks[i].split(' ')
+        i += 1
+        # meta[0] carries a leading ':' — strip it, the modes are compared literally.
+        srcmode, dstmode = meta[0][1:], meta[1]
+        src, dst, status = meta[2], meta[3], meta[4]
+        path = toks[i]
+        i += 1
+        if status[:1] in ('R', 'C'):
+            path = toks[i]
+            i += 1          # record stores the post-rename path, so keep the new one
+        # KEEP the status. Dropping it collapsed a pinned rename-plus-edit onto an
+        # edit-only record: R070 old.txt->new.txt with blobs A->B and an M new.txt with
+        # blobs A->B are byte-identical once the status and the source path are discarded,
+        # so a stored review that never saw the rename could be accepted for a pinned range
+        # that contains one. Reachable exactly where this fallback is meant to help — the
+        # same head reviewed against a different base.
+        m[path] = (srcmode, dstmode, src, dst, status)
+    return m
+wantoid = rawmap(rungit(['--raw', '--no-abbrev', '-z']))
+candidates = []
+for p in glob.glob(os.path.expanduser('~/.coderabbit/reviews/*/*/reviews/*/git.json')):
+    try:
+        d = json.load(open(p))
+    except Exception:
+        continue          # half-written or malformed record: skip, never abort the scan
+    if d.get('head') != head:
+        continue
+    entries = d.get('diff') or []
+    # Establish filePath up front so BOTH loops below can rely on it. Guarding only the
+    # comprehension and not the identity loop would leave a None to reach an argv list —
+    # a TypeError traceback with no ERROR line, the same uncovered shape the capped TAB
+    # split exists to remove.
+    if not entries or not all(e.get('filePath') for e in entries):
+        print('SKIP malformed-entries %s (an entry carries no filePath)' % p)
+        continue
+    got = {e['filePath']: (str(e.get('linesAdded')), str(e.get('linesRemoved')))
+           for e in entries}
+    # Paths and counts are a cheap PREFILTER, not identity. Two different patches collide
+    # on a numstat trivially — verified: a beta->BETA edit and a gamma->GAMMA edit in the
+    # same file both report "1 added, 1 removed". A review of this head against another
+    # base can leave exactly such a record, so counts alone would admit it.
+    if got != want:
+        print('SKIP scope-mismatch %s (%d files, want %d)' % (p, len(got), len(want)))
+        continue
+    # Matching scope is still not the same review: the CLI reviews tracked edits by
+    # default, so a dirty worktree can leave the path set identical while the patch
+    # differs. Each entry carries "lanes", a BOOLEAN MAP — {"committed": true,
+    # "uncommitted": false} — not a list, so test the VALUES: key membership is always
+    # true and would accept everything. Require the committed-only shape EXPLICITLY
+    # rather than merely rejecting a truthy "uncommitted": a record from an older CLI
+    # that omits lanes, or one carrying a non-dict, would otherwise pass as clean and
+    # contribute comments on code outside the pinned head. Absent proof of clean, skip.
+    if not all(isinstance(e.get('lanes'), dict)
+               and e['lanes'].get('committed') is True
+               and e['lanes'].get('uncommitted') is False for e in entries):
+        print('SKIP not-committed-only %s (%d entries lack an explicit committed-only lanes map)'
+              % (p, len(entries)))
+        continue
+    # EXACT identity, via the BLOB OIDs the record already carries on its "index a..b" line.
+    # Comparing the stored patch TEXT was the obvious move and is wrong: bare git diff
+    # output moves with the reader's gitconfig, so a contributor with diff.noprefix,
+    # diff.context or diff.external gets a permanent mismatch and this fallback silently
+    # never fires — the same works-on-my-machine class the sandbox-bypass decision rejected
+    # an allowlist for. Pinning flags (--no-ext-diff --no-color -U3 --src-prefix …) fixes
+    # OUR side only; if the CLI produced the record under that same config, hardening makes
+    # the mismatch worse, not better. Blob OIDs are content hashes, so they are stable on
+    # BOTH sides and are exact content identity rather than a rendering of it. Measured:
+    # identical under diff.noprefix, diff.context, diff.algorithm, diff.external and
+    # color.diff, where bare patch text differed under three of the five.
+    # The record abbreviates its OIDs and we ask git for full ones, hence startswith.
+    bad = None
+    for e in entries:
+        pair = wantoid.get(e['filePath'])
+        if pair is None:
+            bad = ('path-not-in-pinned-diff', e['filePath'])
+            break
+        wsrcmode, wdstmode, wsrc, wdst, wstatus = pair
+        # A rename or copy in the PINNED range cannot be verified from a record keyed on the
+        # post-rename path alone: the record carries no source path, so an edit-only review
+        # of that same path is indistinguishable from one that covered the rename. The docs
+        # already call renames a false-negative; fail closed so that is actually true.
+        if wstatus[:1] in ('R', 'C'):
+            bad = ('rename-unverifiable', e['filePath'])
+            break
+        text = e.get('diff') or ''
+        mo = INDEX.search(text)
+        # MODES FIRST. Blob OIDs alone accept a record that never saw a mode change: with
+        # chmod +x in one commit and an edit in the next, a stored review of the edit alone
+        # carries the same path, counts, lanes and BOTH OIDs as the pinned range covering
+        # both. Only the modes differ — pinned 100644->100755 against the record's
+        # 100755->100755. A record that states no mode at all cannot prove identity either.
+        smodes = storedmodes(text, mo)
+        if smodes is None or smodes != (wsrcmode, wdstmode):
+            bad = ('mode-mismatch', e['filePath'])
+            break
+        if mo is None:
+            # Git omits "index a..b" exactly when the BLOB IS UNCHANGED — for a mode change
+            # (chmod +x) the old/new mode lines carry the information instead, and the check
+            # above has already matched them. This repo ships executable scripts, so a
+            # chmod is routine; rejecting the record outright would permanently disable
+            # this fallback for any PR containing one. Content identity for such an entry
+            # is therefore src == dst. A missing index line with CHANGED content stays a
+            # genuine mismatch. (A 100%-similarity rename also omits the line, but never
+            # reaches here: the CLI scopes its stored patch and counts to the post-rename
+            # path, so the record's numstat differs from the pinned range's and the scope
+            # prefilter rejects it first — renames stay the documented false-negative.)
+            if wsrc != wdst:
+                bad = ('no-index-line', e['filePath'])
+                break
+            continue
+        if not wsrc.startswith(mo.group(1)) or not wdst.startswith(mo.group(2)):
+            bad = ('blob-mismatch', e['filePath'])
+            break
+    # "is not None", not truthiness: an empty string is a real value here and must not read
+    # as a pass. The two labels stay distinct so the reader is not sent hunting a content
+    # difference when the record simply lacks the line — and note a git failure cannot
+    # reach this point at all, having already exited 2 above.
+    if bad is not None:
+        print('SKIP %s %s (%s)' % (bad[0], p, bad[1]))
+        continue
+    candidates.append((os.path.getmtime(p), p))
+# Several records can pass every check at once — a re-run after a transient failure
+# produces a second record covering the same change, which is precisely the situation
+# this fallback exists for. Emit ONE MATCH so there is nothing to choose between: newest
+# by mtime wins, since a re-run supersedes the attempt it replaced.
+candidates.sort(reverse=True)
+for i, (_, p) in enumerate(candidates):
+    print('MATCH' if i == 0 else 'SKIP superseded-duplicate', p)
+PY
+This is shell-agnostic, exits 0 with empty output when nothing matches, and keeps the malformed-record guard. An empty result means no stored review matches the pinned change — that is the normal case, not an error, and the log fallback below must still run. An ERROR line with exit status 2 is NOT that case: the pinned diff could not be computed, so no verdict was reached at all — report that in statusNote rather than saying no record matched.
+Generalise that: only "exit 0 with no MATCH" means no record matched. ANY non-zero exit — the ERROR line above, or an unexpected traceback from a record shape not anticipated here — means the scan reached no verdict. Report it as such and still run the log fallback; never let a non-zero exit read as a clean negative.
+There is at most ONE MATCH line by construction, and it is a genuine CodeRabbit review of exactly the pinned change, so USE IT no matter which session, working directory or resolved base produced it — read the record's baseCommitId into statusNote for the reader, but do not treat a difference as disqualifying. A SKIP line is a review of a different change, one that cannot prove it was committed-only, or a superseded earlier run — never report any of them as this lane's result.
+Acceptance is layered, cheapest first, and only the last one is identity: same paths, then same per-file line counts, then the committed-only lanes shape, then the FILE MODES AND BLOB OIDs the record's own patch states, equal to git's for the pinned range. The first two are a prefilter — two different patches collide on a numstat trivially — so never treat a scope match alone as a result. Modes are part of identity, not decoration: with a chmod +x in one commit and an edit in the next, a stored review of the edit alone carries the same paths, counts, lanes and both blob OIDs as the pinned range covering both, and only the modes differ. Identity is deliberately NOT the stored patch text: that text moves with the reader's gitconfig, so a contributor with diff.noprefix or diff.context would get a permanent mismatch and this fallback would silently never fire. Modes and blob OIDs do not move with it.
+An entry whose patch carries no "index a..b" line is NOT automatically rejected: git omits that line precisely when the blob is unchanged, which for a record that reaches this check means an ordinary mode change (chmod +x). Such an entry is accepted when the pinned diff agrees the blob is unchanged (src == dst) and rejected as no-index-line otherwise. Rejecting them outright would have disabled this fallback for any PR that so much as marks a script executable. A 100%-similarity rename omits the line too, but a record covering one never reaches this check at all — see the rename note below, and do not read this paragraph as accepting one.
+So SKIP no-index-line is a genuine mismatch, not a false negative: it means the record omitted "index a..b" for a file whose content DID change over the pinned range, i.e. it is not a review of this change. The other SKIP labels read as: scope-mismatch = different file set or line counts; not-committed-only = the record cannot prove it excluded uncommitted work; mode-mismatch = same content but a different file mode, or a record that states no mode at all — the ordinary cause is a chmod landing in the pinned range but not in the record's; blob-mismatch = same files, different content; path-not-in-pinned-diff = the record covers a file this range does not touch; malformed-entries = an entry carries no filePath; rename-unverifiable = the pinned range renames or copies this path, which a record keyed on the post-rename path cannot corroborate; superseded-duplicate = an older run of the same change.
+Known false-negatives, all erring toward skipping, which is the safe direction: a binary file makes git print "-" for both counts where the record stores numbers; and a rename never matches, because a rename or copy in the pinned range is rejected outright as rename-unverifiable: the record is keyed on the post-rename path and carries no source path, so an edit-only review of that path cannot be told apart from one that covered the rename (measured: pinned R077 old.txt -> new.txt and stored M new.txt share modes, blobs and counts). The CLI also scopes its stored patch and counts to the post-rename path, so such a record usually fails the scope prefilter first; the status check is what makes the rejection guaranteed rather than incidental. Do NOT expect a 100%-similarity rename to be rescued by the no-index-line branch — it never reaches it. Neither case is observed in practice, but a SKIP scope-mismatch on a PR with renames or binaries, or a SKIP blob-mismatch on a file whose content you believe is right, is the likely cause. In every case the log fallback below still runs.
+The findings live in the UUID-named sibling files only. Take a sibling *.json as a comment ONLY if it parses and carries both "fileName" and "comment"; skip anything else. A real record also contains git.json, incrementalDiff.json and internalState.json, which are metadata — ingesting them as findings would invent comments that do not exist. Do not reinterpret the stored diff yourself; use the comments as written (fileName, startLine, severity, commentCategory, title, comment). Say in statusNote that the findings came from the persisted store rather than your own run, and give the record path, its baseCommitId, and the fact that the base was not used to select it.
+Only if no matching record exists: check the newest ~/.coderabbit/logs/ file for 429/queue lines and return status:"unavailable" with what you saw. CodeRabbit is best-effort and the review continues without it.`
+
+function coderabbitReviewPrompt() {
+  return `You are the CodeRabbit reviewer in a multi-reviewer cross-review.
+${header}
+MANDATORY: your findings must come from an actual CodeRabbit CLI review that COMPLETED against the pinned commits. You are a wrapper around CodeRabbit, not a substitute for it — your own direct code reading is the same model as the Claude lane and must never be counted as CodeRabbit's vote. If the CLI review did not run, did not complete, or reviewed the wrong context, return status:"unavailable" with a statusNote.
+
+${CODERABBIT_RUN}
+Do NOT post anything to GitHub.
+
+VERIFY CodeRabbit's findings before returning them (verification only — add none of your own) against the pinned tree:
+${PINNED_READS}
+Before returning a "missing path/key/field/API" finding, read the full existing file at the pinned commit to confirm it is actually absent; drop findings that fail verification and note them in statusNote.
+${NO_EXECUTION}
+${OUTPUT_RULES}`
+}
+
+function integrationPrompt() {
+  const list = changes.length ? changes.map((c) => `- ${c}`).join('\n') : '- (none extracted — return an empty findings list)'
+  return `Integration impact analysis for a cross-review. This catches issues invisible when reviewing the diff in isolation.
+${header}
+Verify ONLY these specific changed items. Say nothing for an item when nothing real is found. Do NOT expand the search beyond this list:
+${list}
+
+For each item:
+1. Search the repo for callers, consumers, and references — beyond the files in the diff.
+2. Check, in this order of likelihood for this repo:
+   - chart/templates/ and chart/values.yaml against operator/config/: the same deployment surface expressed twice, and the most common place a change lands on one side only.
+   - k8s-tests/chainsaw/: the e2e fixtures assert on exact annotation keys, status values, stage names and CR field paths, so a renamed constant breaks them without breaking the build.
+   - operator/cmd/cli/ and operator/internal/cli/: the CLI is a client of the operator's annotation, status, label and finalizer surface.
+   - operator/internal/controller/mock/: mockery output goes stale when a mocked interface changes.
+   - generated artifacts that should have moved with an operator/api/ change: zz_generated.deepcopy.go, operator/config/crd/bases/*.yaml, webhook config.
+   - agent/skyhook-agent/ and its schemas/ when the package config shape is involved.
+   - .github/workflows/, Makefile and *.mk, testdata/, and docs/ (including docs/cli.md's compatibility matrix and any docs/ page the change makes false).
+3. Distinguish "definitely breaks" (consumer depends on exact old behavior) from "might break" (depends on runtime conditions) in the impact field.
+4. Report a finding ONLY with both sides as evidence: path/line = changed side, consumerPath/consumerLine = consumer side. ONE consumer per finding — if a second consumer breaks the same way, report it as a separate finding so each is verified independently.
+
+${REPO_CONTEXT}
+
+Rules:
+- Read and search at the pinned commit, NOT the mutable working copy:
+${PINNED_READS}
+  The diff shows changes; the pinned tree shows current state.
+- Do not cite upstream charts, external APIs, or third-party docs unless you actually fetched them; unverifiable external claims go in openQuestions.
+- "No integration impact" is a valid outcome. Do not invent impacts to justify the analysis.
+${NO_EXECUTION}
+${OUTPUT_RULES}`
+}
+
+// ---------- Cross-review prompt ----------
+function findingBlock(c) {
+  return [
+    `${c.id} [${c.severity}] ${c.path}:${c.line} — ${c.summary}`,
+    `  Evidence: ${c.evidence}`,
+    `  Impact: ${c.impact}`,
+    c.consumerPath ? `  Consumer: ${c.consumerPath}:${c.consumerLine || '?'}` : null,
+    `  Sources: ${c.sources.map((s) => (s === 'integration' ? '[Integration]' : s)).join(', ')}`,
+    c.flags.length ? `  Flags: ${c.flags.join('; ')}` : null,
+  ]
+    .filter(Boolean)
+    .join('\n')
+}
+
+function crossPrompt(k, items) {
+  const list = items.map(findingBlock).join('\n\n')
+  const perReviewer =
+    k === 'codex'
+      ? `${CODEX_DISPATCH}\n${CODEX_LEAN}\nFor each candidate, have Codex read just the cited lines at the pinned commit (git -C "${repoPath}" show '${headSha}:<path>' | sed -n) before returning a verdict.${prType === 'code-change' ? '\nDuring the independent re-review apply the behavioral correctness checks: trace inputs through happy/error/edge paths; verify the scope of fallback/reset/retry logic; verify diagnostic metadata derives from real context; check multi-branch state consistency.' : ''}`
+      : `Re-read the saved diff at ${diffPath} and search/read the repo at the pinned commit (not the mutable working copy):
+${PINNED_READS}
+For "missing X" candidates, read the full existing file at the pinned commit to confirm absence.`
+  return `You are the ${k} reviewer in the cross-review round.
+${header}
+
+${`First, INDEPENDENTLY re-review the PR before reading the candidate list — cross-reference the wider repo, not just the diff${prType === 'design-doc' ? ', including existing architecture, prior design docs under docs/designs/, the docs/ pages the change touches, and codebase patterns' : ''}. Put anything you missed in Round 1 into newFindings and list every file you actually read in filesChecked. THEN evaluate every candidate below.`}
+
+${perReviewer}
+${REPO_CONTEXT}
+
+Candidate findings:
+${list}
+
+${NO_EXECUTION}
+
+Evaluation rules:
+- Return exactly one evaluation per candidate id: AGREE / DISAGREE / OPEN_QUESTION. This is the ONLY adjudication round — anything still split afterwards is reported as contested, so take a real position where you can.
+- AGREE only if you directly checked the cited file(s); put the checked path:line in evidence.
+- DISAGREE must include counter-evidence (path:line) in evidence.
+- An AGREE or DISAGREE without evidence ABORTS the whole review — the runtime returns incomplete. Use OPEN_QUESTION when you have not checked.
+- [Integration] findings are the LEAST reliable source and get your deepest scrutiny: for "missing path/key" claims verify absence yourself; for upstream/dependency assumptions fetch the source or return OPEN_QUESTION; an unverifiable integration claim defaults to OPEN_QUESTION, never AGREE.
+- Multi-source findings are NOT automatically true — multiple reviewers can converge on the same wrong surface-level claim without checking the full file. Verify the evidence yourself.`
+}
+
+// ---------- Phase: Review (barrier justified: cross-review needs the merged candidate list) ----------
+log(`Round 1: launching Claude Code, Codex, CodeRabbit + integration analysis for ${subject} (${prType})`)
+const [claudeR, codexR, rabbitR, integR] = await parallel([
+  () => agent(claudeReviewPrompt(), { label: 'review:claude', phase: 'Review', schema: FINDINGS_SCHEMA, agentType: AGENT_TYPE.claude }),
+  () => agent(codexReviewPrompt(), { label: 'review:codex', phase: 'Review', schema: FINDINGS_SCHEMA, agentType: AGENT_TYPE.codex }),
+  () => agent(coderabbitReviewPrompt(), { label: 'review:coderabbit', phase: 'Review', schema: FINDINGS_SCHEMA, agentType: AGENT_TYPE.coderabbit }),
+  // general-purpose, not Explore: Explore reads excerpts to locate code and is
+  // explicitly not a review/audit agent, which is exactly what this lane does.
+  () => agent(integrationPrompt(), { label: 'review:integration', phase: 'Review', schema: FINDINGS_SCHEMA, agentType: 'general-purpose' }),
+])
+
+const ok = (r) => (r && r.status === 'ok' ? r : null)
+const R = { claude: ok(claudeR), codex: ok(codexR), coderabbit: ok(rabbitR) }
+const integ = ok(integR)
+const statusOf = (r) => (r ? (r.status === 'ok' ? 'ok' : `unavailable${r.statusNote ? ` — ${r.statusNote}` : ''}`) : 'no result (skipped or died)')
+const reviewerStatus = {
+  claude: statusOf(claudeR),
+  codex: statusOf(codexR),
+  coderabbit: statusOf(rabbitR),
+  // An empty changeList means the lane was handed nothing to verify. Distinguish that
+  // from a lane that ran against a real list, or `ok` reads as "the change was analysed"
+  // when nothing was: intake never sees a finding, so the zero-survivor rule below is
+  // skipped too (integReturned is 0) and the run reports a clean required lane.
+  integration: changes.length === 0 && integR && integR.status === 'ok'
+    ? 'ok (empty changeList — nothing was verified)'
+    : statusOf(integR),
+}
+// Fixed vote slots — never filtered. CodeRabbit is best-effort: when it does not run,
+// its slot simply records NONE (verdictFor returns NONE for a non-source with no
+// evaluation), so there is no dynamic participant set, no quorum arithmetic, and no
+// arbitration branch to keep alive.
+// Whether the cross-review round actually ran. Declared here, not at its assignment
+// site below, because incomplete() closes over it and can return long before that line;
+// a `const` there would put every early incomplete() in the temporal dead zone.
+let crossRoundRan = false
+const participants = ['claude', 'codex', 'coderabbit']
+// CodeRabbit never takes part in the cross-review round: its CLI is a slow, blocking
+// cloud call and re-spawning the lane risks a second invocation for no new
+// signal, since the CLI reviews Git changes generically and cannot adjudicate our
+// candidate ids. Its round-1 findings still stand as its votes.
+const crossParticipants = ['claude', 'codex']
+
+log(`Round 1 done: ${participants.map((k) => `${k}=${R[k] ? 'ok' : 'unavailable'}`).join(', ')}, integration=${integ ? 'ok' : 'unavailable'}`)
+
+const openQuestions = []
+const residualRisk = []
+const positives = []
+for (const [k, r] of Object.entries({ ...R, integration: integ })) {
+  if (!r) continue
+  for (const q of r.openQuestions || []) openQuestions.push(`[${k}] ${q}`)
+  for (const q of r.residualRisk || []) residualRisk.push(`[${k}] ${q}`)
+  for (const p of r.positives || []) positives.push(`[${k}] ${p}`)
+}
+
+// Report incomplete and stop. Claude, Codex and the integration lane are required:
+// each contributes candidates the others miss, so a missing one silently narrows the
+// review this skill advertises. CodeRabbit is the only best-effort lane. There is no
+// degraded-consensus mode — a short-handed run is reported as incomplete, not as a
+// weaker result the reader has to discount.
+const incomplete = (reason) => ({
+  status: 'incomplete',
+  reason,
+  // pr is null in local mode; mode tells the caller which report shape to build.
+  pr: reviewMode === 'pr' ? pr : null,
+  mode: reviewMode,
+  branch: branch || null,
+  changeListSize: changes.length,
+  crossRoundRan,
+  headSha, prType, reviewerStatus,
+  rawFindings: [claudeR, codexR, rabbitR, integR].filter(Boolean).flatMap((r) => r.findings || []),
+  openQuestions, residualRisk, positives,
+})
+const missing = ['claude', 'codex'].filter((k) => !R[k])
+if (!integ) missing.push('integration')
+if (missing.length) {
+  log(`Stopping: required lane(s) unavailable — ${missing.join(', ')}`)
+  return incomplete(`Required lane(s) unavailable: ${missing.join(', ')}. Findings returned RAW and UNVERIFIED — no consensus was computed.`)
+}
+
+// ---------- Merge & dedupe into candidates ----------
+const candidates = []
+const byKey = new Map()
+// IDs already handed to the cross-review round for evaluation. Merging into one of these
+// is unsafe: its votes were cast on the pre-merge content, so anything appended afterwards
+// would inherit a verdict nobody gave it. Populated when the candidate list is presented.
+const presentedIds = new Set()
+// The dedup key includes a normalized summary so two distinct bugs at the same
+// path:line stay separate candidates, and the consumer coordinates so one changed
+// declaration breaking two callers stays two candidates — each gets its own
+// adversarial verification instead of the second consumer being silently dropped.
+// Keying on location ALONE was tried and reverted. It did merge the real duplicates
+// (two lanes wording one defect differently), but the evaluation schema permits exactly
+// one verdict per candidate id, so a merged pair of DISTINCT defects has no correct
+// verdict: confirming the real one also confirms the false one, and refuting the false
+// one dismisses the real one. Retaining both summaries prevented data loss but not
+// mis-adjudication, which is the worse failure. Duplicates are now surfaced as a flag
+// (see addCandidate) so reviewers can adjudicate equivalence themselves rather than
+// having it assumed from a shared line number.
+const normSummary = (s) => (s || '').toLowerCase().replace(/\s+/g, ' ').trim()
+const SEV_RANK = { critical: 3, major: 2, medium: 1, minor: 0 }
+
+function addCandidate(f, source) {
+  const key = `${f.path}:${f.line}:${normSummary(f.summary)}:${f.consumerPath || ''}:${f.consumerLine ?? ''}`
+  const existing = byKey.get(key)
+  // NEVER merge into an already-presented candidate, even on an exact key match. A finding
+  // raised DURING cross-review that merged into a presented id would be tallied with
+  // evaluations cast before it existed — two prior AGREEs would confirm a defect nobody
+  // read, and the single adversarial refuter cannot split a composite afterwards. A late
+  // finding therefore becomes its own candidate; being unpresented, it lands in `still` and
+  // stays contested for the human, which is what the cross-review round already documents.
+  if (existing && !presentedIds.has(existing.id)) {
+    if (!existing.sources.includes(source)) existing.sources.push(source)
+    // Merge the duplicate's DATA, not only its source: first-reporter ordering must
+    // not downgrade severity or discard stronger evidence/impact. Consumer coordinates
+    // need no merge — they are part of the dedupe key, so a match means they are equal.
+    if ((SEV_RANK[f.severity] ?? 0) > (SEV_RANK[existing.severity] ?? 0)) existing.severity = f.severity
+    if (f.evidence && !existing.evidence.includes(f.evidence)) existing.evidence += ` | [${source}] ${f.evidence}`
+    if (f.impact && !existing.impact.includes(f.impact)) existing.impact += ` | [${source}] ${f.impact}`
+    return existing
+  }
+  const c = { ...f, id: `F${candidates.length + 1}`, sources: [source], flags: [] }
+  // Only the first holder owns the key. When the refusal above fired, the key still maps
+  // to the presented candidate, so a second late finding at the same spot also becomes its
+  // own candidate rather than silently attaching to either.
+  if (!existing) byKey.set(key, c)
+  candidates.push(c)
+  // Same location, different wording — the case location-only keying was meant to fix.
+  // Flag it instead of merging: the flag reaches both the cross-review candidate list and
+  // the refuter prompt, so reviewers decide whether the two are one defect and evaluate
+  // them consistently. That keeps equivalence an explicit judgement rather than an
+  // assumption from a shared line number, and keeps one verdict per real defect.
+  // The hint must respect the SAME identity the key does, consumer coordinates included.
+  // One changed declaration breaking two callers is deliberately two candidates; hinting
+  // that they are possible duplicates would push reviewers to collapse a distinction the
+  // key exists to preserve. Only a genuine same-location, same-consumer pair is hinted.
+  const sameSpot = (a, b) => a.path === b.path && a.line === b.line
+    && (a.consumerPath || '') === (b.consumerPath || '')
+    && (a.consumerLine ?? null) === (b.consumerLine ?? null)
+  for (const other of candidates) {
+    if (other === c || !sameSpot(other, c)) continue
+    const where = c.consumerPath ? `${c.path}:${c.line} -> ${c.consumerPath}:${c.consumerLine}` : `${c.path}:${c.line}`
+    const pair = [[other, c], [c, other]]
+    for (const [a, b] of pair) {
+      if (!a.flags.some((s) => s.startsWith(`possible duplicate of ${b.id}`))) {
+        a.flags.push(`possible duplicate of ${b.id} (same ${where}, different wording) — decide whether they are one defect and evaluate both consistently`)
+      }
+    }
+  }
+  return c
+}
+
+// "Files checked" as an actual control: a reviewer citing a file it never listed
+// gets flagged for extra scrutiny downstream. Blank entries are dropped first —
+// f.path.endsWith('') is always true, so filesChecked: [""] would suppress the flag.
+function flagUnchecked(c, f, source, filesChecked) {
+  const checked = (filesChecked || []).map((p) => (p || '').trim()).filter(Boolean)
+  // Suffix matches must land on a path-segment boundary, otherwise
+  // internal/bar/handler.go would satisfy a finding at pkg/foo/handler.go.
+  const atBoundary = (long, short) => long === short || long.endsWith('/' + short)
+  // ONE direction only. A listed entry may be MORE specific than the cited path (an
+  // absolute path against the repo-relative one the schema asks for). The reverse
+  // direction was accepted too and is what makes this control leak: a filesChecked
+  // entry of "handler.go" satisfies a finding at any .../handler.go in the repo, so a
+  // reviewer listing basenames silently suppresses every flag. It cost the mirror case
+  // (finding path absolute, listed path relative), which the schema makes unreachable:
+  // `path` is documented repo-relative, and filesChecked is the free-form side.
+  const listed = (path) => checked.some((p) => atBoundary(p, path))
+  if (!listed(f.path)) c.flags.push(`${source} reported this file without listing it in filesChecked — scrutinize`)
+  if (f.consumerPath && !listed(f.consumerPath)) c.flags.push(`${source} cited consumer ${f.consumerPath} without listing it in filesChecked — scrutinize`)
+}
+
+// Single intake point for every candidate source. A finding whose evidence is blank
+// or whitespace-only is REJECTED here rather than merged: schema `required` only
+// guarantees the field exists, and an unevidenced duplicate would otherwise register
+// its reviewer as a source, after which evidenceFor() hands it the co-reporter's
+// citation and it silently tips the 2-of-3 tally. Rejecting at intake means an
+// unevidenced report never becomes a vote anywhere.
+// ONE coordinate rule, used for a finding's own path/line and for an integration
+// finding's consumerPath/consumerLine. The schema requires both fields but constrains
+// neither — no minLength, no minimum — so "", "   ", 0 and -1 all satisfy it and all
+// used to pass a truthiness/null check. Every previous version of this guard fixed the
+// pair it was shown and left the other, which is why this is a shared helper rather than
+// two call-site conditions: the next field pair added should reuse it, not re-derive it.
+const hasCoords = (p, l) => typeof p === 'string' && p.trim() !== '' && Number.isInteger(l) && l > 0
+
+function intake(f, source, filesChecked) {
+  const why = dropReason(f)
+  if (why === 'unlocatable') {
+    log(`Dropped unlocatable finding from ${source} — path=${JSON.stringify(f.path)} line=${JSON.stringify(f.line)} — "${f.summary}" (a real path and a 1-based line are required)`)
+    return null
+  }
+  if (why === 'unevidenced') {
+    log(`Dropped unevidenced finding from ${source} at ${f.path}:${f.line} — "${f.summary}" (evidence is required)`)
+    return null
+  }
+  const c = addCandidate(f, source)
+  flagUnchecked(c, f, source, filesChecked)
+  return c
+}
+
+// Why a finding cannot enter consensus, or null if it can. Separate from intake() so a
+// caller can report the ACTUAL reason instead of inferring one from a subtraction.
+// Coordinates first: a finding nobody can locate cannot be verified, cross-reviewed or
+// acted on, and it would still occupy a candidate slot and carry a vote. Both checks
+// cover EVERY lane — the schema is shared, so any hole in it is shared too.
+function dropReason(f) {
+  if (!hasCoords(f.path, f.line)) return 'unlocatable'
+  if (!(f.evidence || '').trim()) return 'unevidenced'
+  return null
+}
+
+// Take a whole batch and report what survived. EVERY required-lane batch goes through
+// this, because the zero-survivor rule was never specific to the integration lane: all
+// lanes share one schema, so a required reviewer whose only finding is malformed
+// contributes nothing while the run reports ok / consensusReached true — the same
+// false-clean, one lane over. Mixed batches still proceed; only a total loss stops.
+function intakeBatch(list, source, filesChecked) {
+  const findings = list || []
+  const counts = { returned: findings.length, accepted: 0, unlocatable: 0, unevidenced: 0, candidates: [] }
+  for (const f of findings) {
+    const why = dropReason(f)
+    if (why) counts[why] += 1
+    const c = intake(f, source, filesChecked)
+    if (c) { counts.accepted += 1; counts.candidates.push(c) }
+  }
+  return counts
+}
+
+// One message shape, so every lane reports the real reasons rather than a subtraction.
+function zeroSurvivors(source, c, extra = '') {
+  return `Required lane ${source} returned ${c.returned} finding(s) and none survived intake: ${c.unlocatable} lacked a usable path/line, ${c.unevidenced} lacked evidence${extra}. The lane contributed nothing usable, so no consensus was computed.`
+}
+
+for (const k of participants) {
+  // R[k] is null for a lane that did not run. Only CodeRabbit can be null here — the
+  // required lanes already returned incomplete above — but participants is a fixed
+  // slot list now, so the guard is what keeps the empty slot from being dereferenced.
+  const r = R[k]
+  if (!r) continue
+  const b = intakeBatch(r.findings, k, r.filesChecked)
+  // CodeRabbit is best-effort: a total loss there records NONE and raises the bar for the
+  // others, exactly as a lane that did not run at all. Claude and Codex are required, so
+  // a total loss there is the false-clean this guard exists to prevent.
+  if (k !== 'coderabbit' && b.returned && !b.accepted) return incomplete(zeroSurvivors(k, b))
+  // PARTIAL loss is silent otherwise: the zero-survivor rule above only fires on a total
+  // loss, so a lane returning five findings of which three were malformed reports `ok`
+  // and the report shows two. Aggregate, not per-finding — a dropped finding here failed
+  // to state a location or evidence at all, so there is nothing actionable to show a
+  // human beyond the fact that the lane's output was thinned.
+  if (b.returned && b.accepted && b.accepted < b.returned) {
+    openQuestions.push(`[${k}] ${b.returned - b.accepted} of ${b.returned} finding(s) were dropped at intake (${b.unlocatable} without a usable path/line, ${b.unevidenced} without evidence) — this lane's contribution is thinner than its status suggests`)
+  }
+}
+// An integration finding is a claim that a specific consumer breaks, so one lacking
+// consumerPath/consumerLine cannot be verified and must not enter consensus. The schema
+// cannot make those conditionally required, hence the check here.
+// Drop them INDIVIDUALLY. Failing the whole run on the first one is what this did before
+// and it is disproportionate: observed on PR 1908, the lane returned several findings —
+// one a real, evidenced stale UAT fixture — plus a stale-doc-comment finding that
+// legitimately has no consumer, and the run reported incomplete with all four lanes ok,
+// ~400k subagent tokens spent, and no report produced at all.
+// Failing closed still matters for the case that motivated it: silently dropping the
+// lane's ONLY finding once yielded consensusReached: true while a required lane had in
+// effect contributed nothing. So stop only when nothing usable survives.
+// Measure that on what SURVIVES intake(), not on what passes the coordinate check.
+// intake() independently drops a finding with blank evidence, so gating on the
+// coordinate filter alone let a coordinate-complete, whitespace-evidence finding through
+// it and then silently out of intake() — zero candidates, status ok, consensusReached
+// true. That is the same false-clean this guard exists to prevent, in a narrower form.
+// One rule covers both drop reasons: a non-empty integration result that yields no
+// accepted finding means the required lane contributed nothing.
+const integUsable = [], integDropped = []
+for (const f of integ.findings || []) {
+  // Presence is not usability, and the CONSUMER side needs the same rule as the finding's
+  // own coordinates — same schema, same absent constraints, same false-clean if it slips.
+  // hasCoords is shared with intake() precisely so the two cannot drift apart again.
+  // The finding's own path/line are checked in intake(), so a finding reaching consensus
+  // has both ends locatable.
+  if (!hasCoords(f.consumerPath, f.consumerLine)) integDropped.push(f)
+  else integUsable.push(f)
+}
+if (integDropped.length) {
+  // Never silent: an unreported drop is how a thinned lane passes for a clean one.
+  log(`Integration lane: dropped ${integDropped.length} finding(s) lacking consumerPath/consumerLine — ${integDropped.map((f) => `${f.path}:${f.line}`).join(', ')}`)
+  // log() reaches the run journal only. The Phase 4 report is built from the RETURN
+  // VALUE, so a drop that exists only in the journal still lets a thinned required lane
+  // read as a clean one in the report — the exact failure the comment above disclaims.
+  // These carry a path, a line and a summary, so they are actionable for a human.
+  for (const f of integDropped) {
+    openQuestions.push(`[integration] ${f.path}:${f.line} — ${f.summary} (dropped: no consumerPath/consumerLine, so the claimed consumer breakage could not be verified)`)
+  }
+}
+// Same batch rule as every other required lane; the only extra is the consumer-side
+// filter above, whose count is reported separately. Do NOT infer a reason by subtracting
+// counts: own-coordinate and evidence failures are distinct and were being reported as
+// one, which sent the reader after the wrong defect.
+const integBatch = intakeBatch(integUsable, 'integration', integ.filesChecked)
+const integReturned = (integ.findings || []).length
+if (integReturned && !integBatch.accepted) {
+  return incomplete(zeroSurvivors('integration', { ...integBatch, returned: integReturned },
+    `, and ${integDropped.length} lacked a usable consumerPath/consumerLine. An integration finding is a claim that a specific consumer breaks and cannot be verified without both ends located and evidence`))
+}
+log(`Merged: ${candidates.length} unique candidate finding(s)`)
+
+// ---------- Consensus (round 1 reports, then one cross-review round) ----------
+const evals = { claude: {}, codex: {}, coderabbit: {} } // reviewer -> id -> latest evaluation
+const resolution = {} // id -> 'confirmed' | 'dismissed' | 'open'
+// Ids that reached `contested` because they were raised DURING cross-review and so were
+// never presented for evaluation — as opposed to being presented, evaluated, and left
+// split. Both land in the same bucket, and a reader cannot otherwise tell "the reviewers
+// disagreed" from "nobody has looked at this yet", which are different asks: one needs a
+// tie broken, the other needs someone to read it. Observed on a real run: 8 of 8
+// contested findings were late, each carrying a single AGREE from its reporter and NONE
+// elsewhere — zero actual disagreements, reported as eight contested.
+// Annotation only: membership, resolution values and consensusReached are unchanged, so
+// nothing that already consumes this result can regress.
+const lateIds = new Set()
+const dismissReason = {}
+
+// Latest cross-review evaluation wins over original-reporter status, so a reporter
+// who later submits DISAGREE is counted correctly rather than locked into AGREE.
+const verdictFor = (k, c) => {
+  if (evals[k][c.id]) return evals[k][c.id].verdict
+  if (c.sources.includes(k)) return 'AGREE'
+  return 'NONE'
+}
+// Trimmed so whitespace-only strings count as absent — a single space is not a citation.
+const evidenceFor = (k, c) => {
+  const raw = evals[k][c.id] ? (evals[k][c.id].evidence || '') : c.sources.includes(k) ? (c.evidence || '') : ''
+  return raw.trim()
+}
+
+// Single consensus rule (mirrors SKILL.md), symmetric in both directions: two evidenced
+// AGREEs confirm, two evidenced DISAGREEs dismiss, anything else is contested.
+// Integration analysis is never a reviewer slot. Evidence is required for AGREE and
+// DISAGREE, so a reviewer cannot move a finding without actually checking code.
+function tally(c) {
+  const agrees = participants.filter((k) => verdictFor(k, c) === 'AGREE' && evidenceFor(k, c))
+  const disagrees = participants.filter((k) => verdictFor(k, c) === 'DISAGREE' && evidenceFor(k, c))
+  if (agrees.length >= 2) return 'confirmed'
+  if (disagrees.length >= 2) return 'dismissed'
+  // No single-vote dismissal. A lone evidenced DISAGREE — reachable when CodeRabbit is
+  // unavailable and the reporter softens to OPEN_QUESTION — must not bury a finding
+  // that only one of three slots ever judged. It stays contested for the human.
+  return 'contested'
+}
+
+// ONE cross-review round. A third "final positions" round re-asked the same
+// reviewers the same question with the positions shown; it rarely moved a verdict
+// and cost a full extra fan-out. Anything still split after this round is reported
+// as contested for the human to settle.
+let pending = candidates.map((c) => c.id)
+
+// The cross-review block does TWO jobs: it adjudicates candidates, and it makes Claude
+// and Codex independently re-review the change before seeing the candidate list. Guarding
+// it on pending.length skips both, so a run where every lane found nothing reports
+// consensusReached: true off a SINGLE pass per lane, with the anti-anchoring pass never
+// run and nothing in the output saying so. That is the same false-clean this script
+// guards against everywhere else, in the case where a missed defect is most likely.
+// Record it rather than forcing the round: running it unconditionally costs two full
+// agent invocations on every clean change, and the honest report is what was missing.
+crossRoundRan = pending.length > 0
+if (!crossRoundRan) log('Cross-review SKIPPED: no round-1 candidates, so the independent re-review did not run — this result rests on one pass per lane')
+if (pending.length) {
+  const items = candidates.filter((c) => pending.includes(c.id))
+  log(`Cross-review: ${items.length} candidate(s)`)
+  const results = await parallel(
+    crossParticipants.map((k) => () =>
+      agent(crossPrompt(k, items), {
+        label: `cross:${k}`,
+        phase: 'Cross-review',
+        schema: EVAL_SCHEMA,
+        agentType: AGENT_TYPE[k],
+      })),
+  )
+  // Strict completeness: each required lane must return EXACTLY one evaluation per
+  // candidate it was shown — no missing ids, no duplicates, no ids we never presented.
+  // Without this, dropping the old crossChecked gate would let a candidate nobody
+  // actually evaluated ride its initial source votes straight to "confirmed".
+  const presented = new Set(items.map((c) => c.id))
+  // Mirror into the module-level set addCandidate consults, so a late finding cannot be
+  // merged into an id whose evaluations predate it.
+  for (const id of presented) presentedIds.add(id)
+  for (let i = 0; i < crossParticipants.length; i++) {
+    const k = crossParticipants[i]
+    const res = ok(results[i])
+    if (!res) return incomplete(`Required lane ${k} did not complete the cross-review round. No consensus was computed.`)
+    const seen = new Set()
+    for (const e of res.evaluations || []) {
+      if (!presented.has(e.id)) return incomplete(`Cross-review lane ${k} returned an evaluation for unknown candidate ${e.id}.`)
+      if (seen.has(e.id)) return incomplete(`Cross-review lane ${k} returned duplicate evaluations for candidate ${e.id}.`)
+      seen.add(e.id)
+    }
+    if (seen.size !== presented.size) {
+      const gaps = [...presented].filter((id) => !seen.has(id))
+      return incomplete(`Cross-review lane ${k} evaluated ${seen.size} of ${presented.size} candidates (missing: ${gaps.join(', ')}).`)
+    }
+  }
+  let bad = null
+  crossParticipants.forEach((k, i) => {
+    const res = ok(results[i])
+    for (const e of res.evaluations || []) {
+      // Dropping an unevidenced AGREE/DISAGREE is not enough: with no stored evaluation
+      // the reviewer falls back to its round-1 source vote, so the discarded verdict
+      // still decides the tally. Under the strict contract it is fatal.
+      if ((e.verdict === 'AGREE' || e.verdict === 'DISAGREE') && !(e.evidence || '').trim()) {
+        bad = bad || `Cross-review lane ${k} returned ${e.verdict} on ${e.id} with no evidence.`
+        continue
+      }
+      evals[k][e.id] = e
+    }
+    // newFindings go through the same intake gate as round 1 — an unevidenced or
+    // unlocatable late finding must not enter the tally either. But NOT the
+    // zero-survivor rule, which does not transfer to this round. That rule tests
+    // "the lane contributed nothing", and round 1 can assert that because findings
+    // are the lane's whole output. Here the lane's output is its evaluations, and
+    // the completeness gate above already returned incomplete unless this lane
+    // evaluated EVERY presented candidate — so by this line it has provably
+    // contributed. newFindings are strictly supplementary and volunteered.
+    // Failing the run on them would discard a complete set of adjudications plus
+    // the verification round over one imprecise extra finding: the same
+    // disproportionate total-loss observed on PR 1908, reintroduced one round over.
+    // So drop malformed late findings individually — intake() logs each with its
+    // reason, so this is never silent — exactly as the integration lane does.
+    const nb = intakeBatch(res.newFindings, k, res.filesChecked)
+    for (const c of nb.candidates) if (!pending.includes(c.id)) pending.push(c.id)
+  })
+  if (bad) return incomplete(bad)
+  const still = []
+  for (const id of pending) {
+    const c = candidates.find((x) => x.id === id)
+    // Findings raised DURING cross-review were never presented to anyone, so nobody
+    // evaluated them. Their reporters' source votes alone must not confirm them — two
+    // lanes independently raising the same late finding would otherwise reach two
+    // AGREEs with zero cross-checks, contradicting the one-evaluation-per-candidate
+    // contract. They stay contested for the human; we do not add another round.
+    if (!presented.has(id)) { still.push(id); lateIds.add(id); continue }
+    const t = tally(c)
+    if (t === 'confirmed' || t === 'dismissed') {
+      resolution[id] = t
+      if (t === 'dismissed') {
+        dismissReason[id] =
+          participants
+            .filter((k) => verdictFor(k, c) === 'DISAGREE')
+            .map((k) => `${k}: ${(evals[k][id] && (evals[k][id].reason || evals[k][id].evidence)) || 'disagreed'}`)
+            .join(' | ') || 'no reviewer support'
+      }
+    } else {
+      still.push(id)
+    }
+  }
+  pending = still
+  const counts = Object.values(resolution)
+  const lateCount = pending.filter((id) => lateIds.has(id)).length
+  log(`Tally: confirmed=${counts.filter((v) => v === 'confirmed').length}, dismissed=${counts.filter((v) => v === 'dismissed').length}, contested=${pending.length} (${pending.length - lateCount} evaluated-but-split, ${lateCount} raised late)`)
+}
+
+// Still unresolved after the cross-review round: no valid vote at all -> open question;
+// otherwise contested and reported for the human to settle.
+const contestedIds = []
+for (const id of pending) {
+  const c = candidates.find((x) => x.id === id)
+  const votes = participants.filter((k) => ['AGREE', 'DISAGREE'].includes(verdictFor(k, c)) && evidenceFor(k, c)).length
+  if (votes === 0) {
+    resolution[id] = 'open'
+    const oq = participants
+      .filter((k) => verdictFor(k, c) === 'OPEN_QUESTION')
+      .map((k) => `${k}: ${(evals[k][c.id] && evals[k][c.id].reason) || 'open question'}`)
+    openQuestions.push(
+      oq.length
+        ? `[unadjudicated] ${c.path}:${c.line} — ${c.summary} (explicit OPEN_QUESTION — ${oq.join(' | ')})`
+        : `[unadjudicated] ${c.path}:${c.line} — ${c.summary} (no reviewer took a position)`,
+    )
+  } else {
+    contestedIds.push(id)
+  }
+}
+
+// ---------- Phase: Verify (adversarial refuter per confirmed finding, fresh context each) ----------
+const confirmedIds = candidates.filter((c) => resolution[c.id] === 'confirmed').map((c) => c.id)
+log(`Verification: adversarially re-checking ${confirmedIds.length} confirmed finding(s)`)
+
+function refutePrompt(c) {
+  return `Adversarial verification of a code-review finding that reached reviewer consensus. Your job is to try to REFUTE it — default to skepticism.
+${header}
+Finding ${c.id} [${c.severity}] ${c.path}:${c.line} — ${c.summary}
+Evidence claimed: ${c.evidence}
+Impact claimed: ${c.impact}
+${c.consumerPath ? `Claimed broken consumer: ${c.consumerPath}:${c.consumerLine || '?'} — trace its actual dependency on the changed code` : ''}${c.flags.length ? `\nFlags: ${c.flags.join('; ')}` : ''}
+
+Method:
+- Read the FULL cited file(s) at the pinned commit — not just the diff, not the working copy:
+${PINNED_READS}
+  The diff shows what changed; the full file shows current state.
+- For "missing X" claims, confirm X is actually absent from the existing file.
+- For consumer-breakage claims, trace the actual dependency from consumer to changed code.
+- For claims about upstream/external systems, fetch the cited source; if you cannot, return UNVERIFIABLE.
+${REPO_CONTEXT}
+
+${NO_EXECUTION}
+
+Return CONFIRMED only if you independently reproduced the evidence. REFUTED requires counter-evidence. Both REQUIRE a path:line citation in the evidence field — a verdict without one is discarded and the finding falls back to an open question.`
+}
+
+const verifierResults = await parallel(
+  confirmedIds.map((id) => () => {
+    const c = candidates.find((x) => x.id === id)
+    // agentType stated explicitly, as every other lane does. The refuter runs the same
+    // pinned reads and searches as the reviewers, so it needs the same agent; leaving it
+    // to the default workflow subagent made the one lane whose whole job is independent
+    // verification the only lane whose capabilities were implicit.
+    return agent(refutePrompt(c), { label: `verify:${id}`, phase: 'Verify', schema: REFUTE_SCHEMA, agentType: 'general-purpose' })
+  }),
+)
+confirmedIds.forEach((id, i) => {
+  const v = verifierResults[i]
+  const c = candidates.find((x) => x.id === id)
+  // No result, or a CONFIRMED/REFUTED with no citation, means the finding was never
+  // actually checked. Fall back to open — "survived adversarial verification" must be
+  // literally true, and an unchecked assertion must not dismiss a consensus either.
+  const unchecked = !v || ((v.verdict === 'CONFIRMED' || v.verdict === 'REFUTED') && !(v.evidence || '').trim())
+  if (unchecked) {
+    resolution[id] = 'open'
+    openQuestions.push(`[verification] ${c.path}:${c.line} — ${c.summary}: ${v ? `verifier returned ${v.verdict} without evidence` : 'verifier returned no result (agent timeout or failure)'} — treated as UNVERIFIABLE`)
+    return
+  }
+  if (v.verdict === 'REFUTED') {
+    resolution[id] = 'dismissed'
+    dismissReason[id] = `failed adversarial verification: ${v.reason} (${v.evidence})`
+  } else if (v.verdict === 'UNVERIFIABLE') {
+    resolution[id] = 'open'
+    openQuestions.push(`[verification] ${c.path}:${c.line} — ${c.summary}: ${v.reason}`)
+  } else {
+    c.verifiedEvidence = v.evidence
+  }
+})
+
+// Confirmed integration findings identifying broken consumers escalate to at least medium.
+for (const c of candidates) {
+  if (resolution[c.id] === 'confirmed' && c.sources.includes('integration') && c.severity === 'minor') c.severity = 'medium'
+}
+
+// ---------- Result ----------
+const emit = (c) => ({
+  id: c.id,
+  severity: c.severity,
+  path: c.path,
+  line: c.line,
+  summary: c.summary,
+  evidence: c.evidence,
+  impact: c.impact,
+  consumerPath: c.consumerPath || null,
+  consumerLine: c.consumerLine || null,
+  sources: c.sources,
+  flags: c.flags,
+  // Every surviving vote is evidenced: intake drops unevidenced findings and an
+  // unevidenced cross-review verdict returns incomplete, so no "uncounted" state
+  // can reach this point.
+  votes: Object.fromEntries(participants.map((k) => [k, verdictFor(k, c)])),
+  verifiedEvidence: c.verifiedEvidence || null,
+})
+
+const confirmed = candidates.filter((c) => resolution[c.id] === 'confirmed').map(emit)
+const contested = candidates
+  .filter((c) => contestedIds.includes(c.id))
+  .map((c) => ({
+    ...emit(c),
+    // Why this is unsettled, which the positions alone do not say.
+    adjudication: lateIds.has(c.id) ? 'raised-late' : 'evaluated',
+    why: lateIds.has(c.id)
+      ? 'raised during the cross-review round, after candidates were presented — never cross-evaluated, so the only position is its reporter\'s'
+      : 'presented and evaluated, but the reviewers did not reach 2-of-3',
+    positions: Object.fromEntries(
+      participants.map((k) => [
+        k,
+        {
+          verdict: verdictFor(k, c),
+          reason: (evals[k][c.id] && evals[k][c.id].reason) || (c.sources.includes(k) ? 'original reporter' : 'no position'),
+          evidence: evidenceFor(k, c) || null,
+        },
+      ]),
+    ),
+  }))
+const dismissed = candidates
+  .filter((c) => resolution[c.id] === 'dismissed')
+  .map((c) => ({ ...emit(c), why: dismissReason[c.id] || 'no consensus' }))
+// Findings resolved to 'open' — reached consensus but did not survive verification
+// (UNVERIFIABLE, verifier died, or verifier gave a verdict with no citation), or drew
+// no valid vote at all. They MUST be emitted: previously they appeared in none of the
+// three arrays, so a candidate could vanish into a text open question while
+// consensusReached still reported true.
+const unresolved = candidates
+  .filter((c) => resolution[c.id] === 'open')
+  .map((c) => ({ ...emit(c), why: 'reached consensus but did not survive verification, or drew no valid vote — see openQuestions' }))
+
+const contestedLate = contested.filter((c) => c.adjudication === 'raised-late').length
+log(`Done: ${confirmed.length} confirmed, ${contested.length} contested (${contested.length - contestedLate} evaluated-but-split, ${contestedLate} raised late), ${unresolved.length} unresolved, ${dismissed.length} dismissed, ${openQuestions.length} open questions`)
+
+return {
+  status: 'ok',
+  pr: reviewMode === 'pr' ? pr : null,
+  mode: reviewMode,
+  branch: branch || null,
+  changeListSize: changes.length,
+  // False when round 1 produced no candidates: the adjudication AND the independent
+  // re-review were both skipped, so the report must not imply two passes.
+  crossRoundRan,
+  headSha,
+  prType,
+  // Consensus means every candidate reached a final disposition. An unresolved
+  // finding is an unanswered question, so it blocks the claim just as a contested
+  // one does.
+  consensusReached: contested.length === 0 && unresolved.length === 0,
+  reviewerStatus,
+  confirmed,
+  contested,
+  unresolved,
+  dismissed,
+  openQuestions,
+  residualRisk,
+  positives,
+}


### PR DESCRIPTION
## What

Adds `.claude/skills/nodewright-cross-review/`, a repo-local skill that reviews a change with three independent reviewers (Claude Code, Codex, CodeRabbit) plus a targeted integration impact analysis, cross-reviews them to a 2-of-3 consensus, and sends every confirmed finding to a fresh adversarial refuter before reporting it.

Two files, both new, nothing else touched:

- `SKILL.md` (764 lines) is the phase-by-phase procedure: pre-flight, mode resolution, pinned setup, classification, the `Workflow` call, CI status, report, output.
- `scripts/workflow.mjs` (1281 lines) is the orchestration and the single source of truth for the consensus mechanics.

## Why this shape

Ported from the `aicr-cross-review` skill in `NVIDIA/aicr`, which is where the consensus mechanics and the CLI operational notes were worked out. That provenance is stated in `SKILL.md` rather than left implicit: claims marked "measured" were measured there, against the same CLIs on the same machine, and have **not** been re-measured against this repo. Reviewers should read them as inherited rather than as evidence gathered here.

The parts written for this repository:

- **A repository-context block handed to all five prompt sites.** It names the three components; tells reviewers the partial Skyhook to NodeWright rename is expected, so a mixed vocabulary is never reported as a defect; makes Status/State/Stage confusion an explicit finding class; lists the vendored and generated trees not to review, including the hand-written `zz.migration.*.go` exception; and supplies the pathspec that keeps repo-wide greps out of `operator/vendor` and `agent/vendor`. Most of that block removes work rather than adding it, which is why it is affordable even in the deliberately context-starved Codex lane.
- **A `code-change` focus covering the operator invariants this codebase actually depends on**: level-triggered, idempotent, no reconciler-owned state, status subresource, finalizer cleanup, no sleep or poll inside reconcile. Plus the cross-surface contracts that break silently: `operator/config/` to `chart/`, `make manifests generate` drift, stale mockery output, the CLI annotation contract, and docs landing in the same PR.
- **`design-doc`, `config-change` and `documentation-only` focuses** aimed at `docs/designs/`, `docs/plans/`, `chart/` and `operator/config/`.
- **An integration lane** that searches this repo's real consumer surfaces first: chart templates against `operator/config/`, chainsaw fixtures (which assert on exact annotation keys, statuses and stage names), the CLI, mocks, agent schemas.

## Self-review mode

The skill runs without an argument: it resolves the PR for the current branch, and falls back to reviewing the branch's committed work against its merge-base when there is no PR yet. Both modes share one code path because both pin a commit, so there is one consensus path to keep correct rather than two. Uncommitted work is never reviewed in either mode, since every lane reads a commit-pinned diff and a dirty tree would hand each lane a different view of the code.

## Safety properties

- **Never executes the reviewed commit's code.** No builds, tests, generators, `make` targets or repository scripts. Suspected `make manifests generate` drift is reported as a finding against the diff, not settled by running the generator.
- **Never posts to a PR** unless explicitly asked. The Claude lane deliberately does not delegate to `/code-review`, whose final step posts its result back to the PR, and `disallowed-tools: Skill` closes the path by which the CodeRabbit skill could auto-trigger and post.
- **Reads instructions from the base ref**, not the working copy, so a fork PR cannot rewrite the instructions its own review runs under.
- **Refuses to review itself.** Phase 0 stops when a changed path is under `.claude/skills/nodewright-cross-review/`, since the scripts that would execute are the ones under review. This PR is therefore deliberately **not** self-reviewed; it wants ordinary human review, and the first real exercise should be an unrelated PR.

## New pattern, called out per the working rules

This is the **first `.claude/skills/` directory in the repo**, so it introduces a convention rather than following one. The layout (`<skill-name>/SKILL.md` plus `scripts/`) matches the Claude Code skill convention and the sibling `aicr` repo. It sits under `.claude/` alongside the existing `CLAUDE.md`, which is already the agent-configuration root here.

Two consequences worth knowing:

- `.claude/skills/` is on the local sandbox write deny-list, so *editing* the skill needs a sandbox bypass even though *running* it does not. That is a property of the local sandbox profile, not of the skill, and it is documented in `SKILL.md`.
- Neither `.md` nor `.mjs` is in the `license_files` globs in `operator/Makefile`, so the license-header gate does not cover these files. `workflow.mjs` carries the Apache-2.0 header anyway; `SKILL.md` does not, matching how other Markdown in the repo is treated.

## Testing

Not behavior-changing for the operator, CLI, agent or chart, so no `docs/` update applies and no test suite covers it. What was verified:

- `workflow.mjs` parses. It cannot be checked directly because the Workflow runtime permits top-level `return`, so it was validated by wrapping the source in an async function and running `node --check`.
- Every repository reference resolves to `NVIDIA/nodewright`. The remaining `skyhook` strings were each checked against `.claude/CLAUDE.md` and are all still-true: `agent/skyhook-agent/`, `/skyhook-package/config.json`, the legacy read-only `skyhook.nvidia.com` CRD group, and the namespace.

The end-to-end run is the obvious gap. It is genuinely expensive (four parallel agents, with the Codex lane budgeted up to about eighteen minutes) and, per the self-review guard above, cannot be exercised against this PR. Reviewers should treat the consensus mechanics as inherited-and-unexercised-here rather than as verified in this repo.
