### PR TITLE
chore: standardize license header tooling

### DIFF
--- a/.github/workflows/agent-go-ci.yaml
+++ b/.github/workflows/agent-go-ci.yaml
@@ -71,6 +71,9 @@ jobs:
         with:
           go-version-file: agent/go/go.mod
           cache-dependency-path: agent/go/go.sum
+      - name: Check license headers
+        working-directory: agent/go
+        run: make license-header-check
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:

--- a/.github/workflows/lint-ci.yaml
+++ b/.github/workflows/lint-ci.yaml
@@ -50,6 +50,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+      - name: Set up Go for license tooling
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
+        with:
+          go-version-file: operator/go.mod
+          cache: false
+      - name: Check license headers
+        run: make license-header-check
       - name: actionlint (workflow files)
         if: always()
         run: |

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,12 @@ test: ## Run tests for operator and agent.
 
 ##@ Formatting
 
+LICENSE_HOLDER ?= NVIDIA CORPORATION & AFFILIATES
+LICENSE_TEMPLATE ?= scripts/license-header.tmpl
+ADDLICENSE ?= $(CURDIR)/operator/bin/addlicense
+license_files = git ls-files -- '*.go' '*.py' '*.sh' '*.yaml' '*.yml' 'Dockerfile' '*.Dockerfile' \
+	| grep -vE '^(operator|agent|chart)/'
+
 .PHONY: fmt
 fmt: ## Run formatters for operator and agent.
 	$(MAKE) -C operator fmt
@@ -52,7 +58,22 @@ fmt: ## Run formatters for operator and agent.
 
 .PHONY: license-fmt
 license-fmt: ## Run license header formatting for all code.
-	python3 scripts/format_license.py --root-dir . --license-file LICENSE
+	$(MAKE) -C operator license-fmt
+	$(license_files) | xargs $(ADDLICENSE) -c "$(LICENSE_HOLDER)" -f $(LICENSE_TEMPLATE)
+	$(MAKE) -C agent license-fmt
+
+.PHONY: license-header-check
+license-header-check: ## Check license headers for all code.
+	$(MAKE) -C operator license-header-check
+	$(license_files) | xargs $(ADDLICENSE) -check -c "$(LICENSE_HOLDER)" -f $(LICENSE_TEMPLATE)
+	@wrong=$$($(license_files) | while read -r f; do \
+		grep -qE '^.{1,2} Code generated .* DO NOT EDIT\.$$' "$$f" && continue; \
+		head -20 "$$f" | grep -q 'SPDX-License-Identifier: Apache-2.0' || echo "  $$f"; \
+	done); \
+	if [ -n "$$wrong" ]; then \
+		echo "ERROR: header present but not Apache-2.0:"; echo "$$wrong"; exit 1; \
+	fi
+	$(MAKE) -C agent license-header-check
 
 ##@ Licenses
 

--- a/agent/Makefile
+++ b/agent/Makefile
@@ -40,12 +40,35 @@ test: venv ## Test using hatch, prints coverage and outputs a report to coverage
 	$(VENV)coverage report --show-missing --data-file=skyhook-agent/.coverage
 	$(VENV)coverage xml --data-file=skyhook-agent/.coverage
 
+## The agent target owns both the legacy Python sources and the Go rewrite.
+## Enumerating tracked files avoids rewriting vendored dependencies or local virtualenvs.
+LICENSE_HOLDER ?= NVIDIA CORPORATION & AFFILIATES
+LICENSE_TEMPLATE ?= ../scripts/license-header.tmpl
+ADDLICENSE ?= $(CURDIR)/go/bin/addlicense
+license_files = git ls-files -- '*.go' '*.py' '*.sh' '*.yaml' '*.yml' 'Dockerfile' '*.Dockerfile' \
+	| grep -vE '^vendor/'
+
+.PHONY: addlicense
+addlicense:
+	$(MAKE) -C go addlicense
+
 .PHONY: license-fmt
-license-fmt: ## Run add license header to code.
-	python3 ../scripts/format_license.py --root-dir . --license-file ../LICENSE
+license-fmt: addlicense ## Add the Apache-2.0 header to tracked agent source files.
+	$(license_files) | xargs $(ADDLICENSE) -c "$(LICENSE_HOLDER)" -f $(LICENSE_TEMPLATE)
+
+.PHONY: license-header-check
+license-header-check: addlicense ## Fail if a tracked agent source file is missing an Apache-2.0 header.
+	$(license_files) | xargs $(ADDLICENSE) -check -c "$(LICENSE_HOLDER)" -f $(LICENSE_TEMPLATE)
+	@wrong=$$($(license_files) | while read -r f; do \
+		grep -qE '^.{1,2} Code generated .* DO NOT EDIT\.$$' "$$f" && continue; \
+		head -20 "$$f" | grep -q 'SPDX-License-Identifier: Apache-2.0' || echo "  $$f"; \
+	done); \
+	if [ -n "$$wrong" ]; then \
+		echo "ERROR: header present but not Apache-2.0:"; echo "$$wrong"; exit 1; \
+	fi
 
 .PHONY: fmt
-fmt: license-fmt ## Run go fmt against code.
+fmt: license-fmt ## Format agent source files.
 	@echo "formattted"
 
 ##@ Build

--- a/agent/go/Makefile
+++ b/agent/go/Makefile
@@ -35,9 +35,29 @@ help: ## Display this help.
 	@awk 'BEGIN {FS = ":.*##"; printf "\n\033[1;31mUsage:\033[0m\n  make \033[3;1;36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1;31m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
 ##@ Development
+
+## addlicense takes explicit paths, so enumerate tracked sources from agent/go rather
+## than letting it walk outside this component or rewrite untracked local files.
+LICENSE_HOLDER ?= NVIDIA CORPORATION & AFFILIATES
+LICENSE_TEMPLATE ?= ../../scripts/license-header.tmpl
+license_files = git ls-files -- '*.go' '*.py' '*.sh' '*.yaml' '*.yml' 'Dockerfile' '*.Dockerfile'
+
 .PHONY: license-fmt
-license-fmt: ## Run license header formatting for changed files.
-	python3 ../../scripts/format_license.py --root-dir . --license-file ../../LICENSE
+license-fmt: addlicense ## Add the Apache-2.0 header to any agent Go source file missing one.
+	$(license_files) | xargs $(ADDLICENSE) -c "$(LICENSE_HOLDER)" -f $(LICENSE_TEMPLATE)
+
+## addlicense -check accepts any license marker, so verify the required SPDX
+## identifier separately while continuing to exempt generated source files.
+.PHONY: license-header-check
+license-header-check: addlicense ## Fail if any agent Go source file is missing an Apache-2.0 header.
+	$(license_files) | xargs $(ADDLICENSE) -check -c "$(LICENSE_HOLDER)" -f $(LICENSE_TEMPLATE)
+	@wrong=$$($(license_files) | while read -r f; do \
+		grep -qE '^.{1,2} Code generated .* DO NOT EDIT\.$$' "$$f" && continue; \
+		head -20 "$$f" | grep -q 'SPDX-License-Identifier: Apache-2.0' || echo "  $$f"; \
+	done); \
+	if [ -n "$$wrong" ]; then \
+		echo "ERROR: header present but not Apache-2.0:"; echo "$$wrong"; exit 1; \
+	fi
 
 .PHONY: fmt
 fmt: license-fmt ## Format go files and update license headers.
@@ -83,7 +103,7 @@ merge-coverage: reporting ## Merge test coverage profiles.
 	fi
 
 .PHONY: lint
-lint: golangci-lint ## Run golangci-lint.
+lint: golangci-lint license-header-check ## Run golangci-lint.
 	$(GOLANGCI_LINT) run ./...
 
 .PHONY: lint-fix

--- a/agent/go/deps.mk
+++ b/agent/go/deps.mk
@@ -20,6 +20,7 @@
 
 GOLANGCI_LINT_VERSION ?= v2.12.2
 GINKGO_VERSION ?= v2.32.0
+ADDLICENSE_VERSION ?= v1.2.0
 
 ## Location to install dependencies to
 LOCALBIN ?= $(shell pwd)/bin
@@ -28,9 +29,10 @@ $(LOCALBIN):
 
 GOLANGCI_LINT = $(LOCALBIN)/golangci-lint
 GINKGO = $(LOCALBIN)/ginkgo
+ADDLICENSE = $(LOCALBIN)/addlicense
 
 .PHONY: install-deps
-install-deps: golangci-lint ginkgo ## Install all dependencies.
+install-deps: golangci-lint ginkgo addlicense ## Install all dependencies.
 
 .PHONY: golangci-lint
 golangci-lint: $(LOCALBIN) ## Download golangci-lint locally if necessary.
@@ -44,3 +46,7 @@ ginkgo: $(LOCALBIN) ## Download ginkgo locally if necessary.
 	@test -x $(GINKGO) \
 		&& [ "$$($(GINKGO) version)" = "Ginkgo Version $(patsubst v%,%,$(GINKGO_VERSION))" ] \
 		|| GOBIN=$(LOCALBIN) go install github.com/onsi/ginkgo/v2/ginkgo@$(GINKGO_VERSION)
+
+.PHONY: addlicense
+addlicense: $(LOCALBIN) ## Download addlicense locally if necessary.
+	test -s $(ADDLICENSE) || GOBIN=$(LOCALBIN) go install github.com/google/addlicense@$(ADDLICENSE_VERSION)

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -148,25 +148,24 @@ vulncheck: govulncheck ## Run govulncheck against code; fails on any reachable v
 vulncheck-all: govulncheck ## Run govulncheck in verbose mode, including module-level vulns not reachable from this code.
 	GOFLAGS="$(GOFLAGS)" $(GOVULNCHECK) -mode source -show verbose ./...
 
-## addlicense takes explicit paths, so enumerate tracked sources from git rather than
-## letting it walk the tree: an untracked local git worktree under .claude/ or a stray
-## venv would otherwise be rewritten. vendor/ and chart/ carry upstream headers.
+## addlicense takes explicit paths, so enumerate only tracked operator sources and
+## leave repository-wide formatting to the root Makefile. vendor/ carries upstream headers.
 LICENSE_HOLDER ?= NVIDIA CORPORATION & AFFILIATES
-LICENSE_TEMPLATE ?= scripts/license-header.tmpl
+LICENSE_TEMPLATE ?= ../scripts/license-header.tmpl
 license_files = git ls-files -- '*.go' '*.py' '*.sh' '*.yaml' '*.yml' 'Dockerfile' '*.Dockerfile' \
-	| grep -vE '^(operator|agent)/vendor/|^chart/'
+	| grep -vE '^vendor/'
 
 .PHONY: license-fmt
 license-fmt: addlicense ## Add the Apache-2.0 header to any source file missing one.
-	cd .. && $(license_files) | xargs $(ADDLICENSE) -c "$(LICENSE_HOLDER)" -f $(LICENSE_TEMPLATE)
+	$(license_files) | xargs $(ADDLICENSE) -c "$(LICENSE_HOLDER)" -f $(LICENSE_TEMPLATE)
 
 ## addlicense -check only asserts that *some* license marker is present, so an MIT or
 ## malformed header would pass. The old format_license.py replaced a wrong header
 ## outright; assert the SPDX identifier explicitly to keep that guarantee.
 .PHONY: license-header-check
 license-header-check: addlicense ## Fail if any tracked source file is missing an Apache-2.0 header.
-	cd .. && $(license_files) | xargs $(ADDLICENSE) -check -c "$(LICENSE_HOLDER)" -f $(LICENSE_TEMPLATE)
-	@cd .. && wrong=$$($(license_files) | while read -r f; do \
+	$(license_files) | xargs $(ADDLICENSE) -check -c "$(LICENSE_HOLDER)" -f $(LICENSE_TEMPLATE)
+	@wrong=$$($(license_files) | while read -r f; do \
 		grep -qE '^.{1,2} Code generated .* DO NOT EDIT\.$$' "$$f" && continue; \
 		head -20 "$$f" | grep -q 'SPDX-License-Identifier: Apache-2.0' || echo "  $$f"; \
 	done); \


### PR DESCRIPTION
## Description

Standardizes Apache-2.0 source-header formatting and validation with google/addlicense while preserving component ownership.

- Pins addlicense v1.2.0 for the Go agent tooling.
- Keeps the operator format/check targets scoped to tracked operator sources.
- Makes the agent format/check targets cover tracked agent sources, including the Go rewrite, while excluding vendored dependencies.
- Makes the root format/check targets own root-level sources and delegate to both component targets.
- Runs the repo-wide header check from the unfiltered Lint CI workflow and keeps the focused Agent Go CI check.
- Removes the remaining Makefile references to the deleted `format_license.py` implementation.

Third-party dependency license allowlisting is intentionally out of scope and will be handled in a separate PR.

Part of #219

## Validation

- `make license-fmt`
- `make license-header-check`
- `make unit-tests` (`agent/go`)
- `make vet` (`agent/go`)
- `make lint` (`agent/go`)
- `make build` (`agent/go`)
- `yamllint -c ci/yamllint.yaml .github/workflows/lint-ci.yaml .github/workflows/agent-go-ci.yaml`
- Verified wrong headers fail only their owning component check and the aggregate root check.

## Checklist

- [X] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/skyhook/blob/main/CONTRIBUTING.md).
- [X] My commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
