### PR TITLE
chore: set rebase strategy for all Dependabot ecosystems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,7 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    rebase-strategy: "rebase"
     labels: ["dependencies", "component/operator"]
     commit-message:
       prefix: "chore"
@@ -47,6 +48,7 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    rebase-strategy: "rebase"
     labels: ["dependencies", "component/agent"]
     commit-message:
       prefix: "chore"
@@ -68,6 +70,7 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    rebase-strategy: "rebase"
     labels: ["dependencies", "component/agent"]
     commit-message:
       prefix: "chore"
@@ -79,6 +82,7 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    rebase-strategy: "rebase"
     labels: ["dependencies", "component/ci"]
     commit-message:
       prefix: "chore"
@@ -91,6 +95,7 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    rebase-strategy: "rebase"
     labels: ["dependencies", "component/ci"]
     commit-message:
       prefix: "chore"


### PR DESCRIPTION
Set `rebase-strategy: "rebase"` on all five Dependabot ecosystems (gomod /operator, gomod /agent/go, pip, github-actions, docker).

Without this, Dependabot updates branches with a merge commit whose message (`Merge branch 'main' into ...`) does not match the Conventional Commits branch ruleset, blocking the "Update branch" button on its PRs.

With rebase, Dependabot replays its own commit on top of main — no new commit message is introduced and the existing one already matches the pattern.

Mirrors [NVIDIA/cluster-api-provider-launchlayer#15](https://github.com/NVIDIA/cluster-api-provider-launchlayer/pull/15).